### PR TITLE
Release OpenROADM 15.0 models

### DIFF
--- a/model/Common/org-openroadm-alarm.yang
+++ b/model/Common/org-openroadm-alarm.yang
@@ -8,11 +8,11 @@ module org-openroadm-alarm {
   }
   import org-openroadm-resource {
     prefix org-openroadm-resource;
-    revision-date 2023-05-26;
+    revision-date 2024-03-29;
   }
   import org-openroadm-probable-cause {
     prefix org-openroadm-probable-cause;
-    revision-date 2023-03-31;
+    revision-date 2024-03-29;
   }
 
   organization
@@ -48,6 +48,10 @@ module org-openroadm-alarm {
      ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
      POSSIBILITY OF SUCH DAMAGE.";
 
+  revision 2024-03-29 {
+    description
+      "Version 15.0";
+  }
   revision 2023-05-26 {
     description
       "Version 13.1";

--- a/model/Common/org-openroadm-common-link-types.yang
+++ b/model/Common/org-openroadm-common-link-types.yang
@@ -35,6 +35,10 @@ module org-openroadm-common-link-types {
       ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
       POSSIBILITY OF SUCH DAMAGE";
 
+  revision 2024-03-29 {
+    description
+      "Version 15.0";
+  }
   revision 2019-11-29 {
     description
       "Version 6.1.0";
@@ -89,6 +93,27 @@ module org-openroadm-common-link-types {
     }
     description
       "Optical Control Mode: identifies specific algorithm related to power management and general optical control.";
+    reference
+      "openroadm.org: Open ROADM MSA Specification.";
+  }
+
+  typedef act-optical-control-mode {
+    type enumeration {
+      enum power {
+        value 1;
+      }
+      enum gainLoss {
+        value 2;
+      }
+      enum off {
+        value 3;
+      }
+      enum unknown {
+        value 4;
+      }
+    }
+    description
+      "Actual Optical Control Mode: identifies specific algorithm related to power management and general optical control.";
     reference
       "openroadm.org: Open ROADM MSA Specification.";
   }

--- a/model/Common/org-openroadm-common-types.yang
+++ b/model/Common/org-openroadm-common-types.yang
@@ -35,6 +35,10 @@ module org-openroadm-common-types {
       ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
       POSSIBILITY OF SUCH DAMAGE";
 
+  revision 2024-03-29 {
+    description
+      "Version 15.0";
+  }
   revision 2023-12-08 {
     description
       "Version 14.1";
@@ -360,6 +364,11 @@ module org-openroadm-common-types {
         value 30;
         description
           "value for 14.1";
+      }
+      enum 15.0 {
+        value 31;
+        description
+          "value for 15.0";
       }
     }
     description

--- a/model/Common/org-openroadm-common-types.yang
+++ b/model/Common/org-openroadm-common-types.yang
@@ -208,6 +208,9 @@ module org-openroadm-common-types {
       enum In-progress {
         value 3;
       }
+      enum Partial {
+        value 4;
+      }
     }
     description
       "status of RPC ";

--- a/model/Common/org-openroadm-manifest-file.yang
+++ b/model/Common/org-openroadm-manifest-file.yang
@@ -10,7 +10,7 @@ module org-openroadm-manifest-file {
 
   import org-openroadm-common-types {
     prefix org-openroadm-common-types;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
 
   organization
@@ -60,6 +60,10 @@ module org-openroadm-manifest-file {
      Section 4.e of the Trust Legal Provisions and are provided without warranty as
      described in the Simplified BSD License.";
 
+  revision 2024-03-29 {
+    description
+      "Version 15.0";
+  }
   revision 2023-12-08 {
     description
       "Version 14.1";

--- a/model/Common/org-openroadm-pm.yang
+++ b/model/Common/org-openroadm-pm.yang
@@ -324,7 +324,11 @@ module org-openroadm-pm {
          could be initiated while the file transfer of the previous file is still in progress.
 
          The file content should be written in xml format based on the historical-pm-list
-         yang definition and the file should be gzip compressed.";
+         yang definition and the file should be gzip compressed.
+
+         If no data is to be returned, the file content should contain only an empty XML tag:
+         <historical-pm-list/>
+         This file would then be gzip compressed.";
     }
     uses org-openroadm-common-types:rpc-response-status;
   }

--- a/model/Common/org-openroadm-pm.yang
+++ b/model/Common/org-openroadm-pm.yang
@@ -8,7 +8,7 @@ module org-openroadm-pm {
   }
   import org-openroadm-common-types {
     prefix org-openroadm-common-types;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
   import org-openroadm-common-alarm-pm-types {
     prefix org-openroadm-common-alarm-pm-types;
@@ -60,6 +60,10 @@ module org-openroadm-pm {
       ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
       POSSIBILITY OF SUCH DAMAGE";
 
+  revision 2024-03-29 {
+    description
+      "Version 15.0";
+  }
   revision 2023-12-08 {
     description
       "Version 14.1";

--- a/model/Common/org-openroadm-pm.yang
+++ b/model/Common/org-openroadm-pm.yang
@@ -16,7 +16,7 @@ module org-openroadm-pm {
   }
   import org-openroadm-resource {
     prefix org-openroadm-resource;
-    revision-date 2023-05-26;
+    revision-date 2024-03-29;
   }
   import org-openroadm-resource-types {
     prefix org-openroadm-resource-types;

--- a/model/Common/org-openroadm-port-types.yang
+++ b/model/Common/org-openroadm-port-types.yang
@@ -4,7 +4,7 @@ module org-openroadm-port-types {
 
   import org-openroadm-common-link-types {
     prefix org-openroadm-common-link-types;
-    revision-date 2019-11-29;
+    revision-date 2024-03-29;
   }
 
   organization
@@ -40,6 +40,10 @@ module org-openroadm-port-types {
      ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
      POSSIBILITY OF SUCH DAMAGE.";
 
+  revision 2024-03-29 {
+    description
+      "Version 15.0";
+  }
   revision 2023-05-26 {
     description
       "Version 13.1";

--- a/model/Common/org-openroadm-probable-cause.yang
+++ b/model/Common/org-openroadm-probable-cause.yang
@@ -40,6 +40,10 @@ module org-openroadm-probable-cause {
       ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
       POSSIBILITY OF SUCH DAMAGE";
 
+  revision 2024-03-29 {
+    description
+      "Version 15.0";
+  }
   revision 2023-03-31 {
     description
       "Version 13.0";
@@ -1219,6 +1223,11 @@ module org-openroadm-probable-cause {
       value 340;
       description
         "Laser has been manually disabled";
+    }
+    enum rebalancingInProgress {
+      value 341;
+      description
+        "Optical channel rebalancing in progress";
     }
   }
     description

--- a/model/Common/org-openroadm-resource-types.yang
+++ b/model/Common/org-openroadm-resource-types.yang
@@ -188,6 +188,16 @@ module org-openroadm-resource-types {
         description
           "circuit-pack-pg";
       }
+      enum slot {
+        value 21;
+        description
+          "shelf slot";
+      }
+      enum cp-slot {
+        value 22;
+        description
+          "circuit pack cp-slot";
+      }
     }
   }
 
@@ -409,6 +419,26 @@ module org-openroadm-resource-types {
       mandatory true;
       description
         "number of the xponder";
+    }
+  }
+
+  grouping slot-name {
+    leaf slot-name {
+      type string;
+      mandatory true;
+      description
+        "Slot-name identifier for a shelf slot. Unique within the context of a shelf.
+         Same as leafref value in model, if applicable.";
+    }
+  }
+
+  grouping cp-slot-name {
+    leaf slot-name {
+      type string;
+      mandatory true;
+      description
+        "Slot-name identifier for a circuit-pack cp-slot. Unique within the context of a circut-pack.
+         Same as leafref value in model, if applicable.";
     }
   }
 }

--- a/model/Common/org-openroadm-resource.yang
+++ b/model/Common/org-openroadm-resource.yang
@@ -20,7 +20,7 @@ module org-openroadm-resource {
   }
   import org-openroadm-common-link-types {
     prefix org-openroadm-common-link-types;
-    revision-date 2019-11-29;
+    revision-date 2024-03-29;
   }
 
   organization
@@ -56,6 +56,10 @@ module org-openroadm-resource {
       ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
       POSSIBILITY OF SUCH DAMAGE";
 
+  revision 2024-03-29 {
+    description
+      "Version 15.0";
+  }
   revision 2023-05-26 {
     description
       "Version 13.1";

--- a/model/Common/org-openroadm-resource.yang
+++ b/model/Common/org-openroadm-resource.yang
@@ -557,6 +557,18 @@ module org-openroadm-resource {
         case temp-service {
           uses org-openroadm-resource-types:temp-service-name;
         }
+        case slot {
+          container slot {
+            uses org-openroadm-resource-types:shelf-name;
+            uses org-openroadm-resource-types:slot-name;
+          }
+        }
+        case cp-slot {
+          container cp-slot {
+            uses org-openroadm-resource-types:circuit-pack-name;
+            uses org-openroadm-resource-types:cp-slot-name;
+          }
+        }
       }
     }
     container resourceType {

--- a/model/Common/org-openroadm-tca.yang
+++ b/model/Common/org-openroadm-tca.yang
@@ -29,7 +29,7 @@ module org-openroadm-tca {
   }
   import org-openroadm-common-types {
     prefix org-openroadm-common-types;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
   import org-openroadm-interfaces {
     prefix org-openroadm-interfaces;
@@ -69,6 +69,10 @@ module org-openroadm-tca {
       ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
       POSSIBILITY OF SUCH DAMAGE";
 
+  revision 2024-03-29 {
+    description
+      "Version 15.0";
+  }
   revision 2023-12-08 {
     description
       "Version 14.1";

--- a/model/Common/tree-view-common.txt
+++ b/model/Common/tree-view-common.txt
@@ -47,7 +47,15 @@ module: org-openroadm-alarm
         |  |     |  +--ro versioned-service-name    string
         |  |     |  +--ro version-number            uint64
         |  |     +--:(temp-service)
-        |  |        +--ro common-id                 string
+        |  |     |  +--ro common-id                 string
+        |  |     +--:(slot)
+        |  |     |  +--ro slot
+        |  |     |     +--ro shelf-name    string
+        |  |     |     +--ro slot-name     string
+        |  |     +--:(cp-slot)
+        |  |        +--ro cp-slot
+        |  |           +--ro circuit-pack-name    string
+        |  |           +--ro slot-name            string
         |  +--ro resourceType
         |     +--ro type         resource-type-enum
         |     +--ro extension?   string
@@ -111,7 +119,15 @@ module: org-openroadm-alarm
        |  |     |  +--ro versioned-service-name    string
        |  |     |  +--ro version-number            uint64
        |  |     +--:(temp-service)
-       |  |        +--ro common-id                 string
+       |  |     |  +--ro common-id                 string
+       |  |     +--:(slot)
+       |  |     |  +--ro slot
+       |  |     |     +--ro shelf-name    string
+       |  |     |     +--ro slot-name     string
+       |  |     +--:(cp-slot)
+       |  |        +--ro cp-slot
+       |  |           +--ro circuit-pack-name    string
+       |  |           +--ro slot-name            string
        |  +--ro resourceType
        |     +--ro type         resource-type-enum
        |     +--ro extension?   string
@@ -363,7 +379,15 @@ module: org-openroadm-pm
     |  |  |     |  +---w versioned-service-name    string
     |  |  |     |  +---w version-number            uint64
     |  |  |     +--:(temp-service)
-    |  |  |        +---w common-id                 string
+    |  |  |     |  +---w common-id                 string
+    |  |  |     +--:(slot)
+    |  |  |     |  +---w slot
+    |  |  |     |     +---w shelf-name    string
+    |  |  |     |     +---w slot-name     string
+    |  |  |     +--:(cp-slot)
+    |  |  |        +---w cp-slot
+    |  |  |           +---w circuit-pack-name    string
+    |  |  |           +---w slot-name            string
     |  |  +---w resourceType
     |  |  |  +---w type         resource-type-enum
     |  |  |  +---w extension?   string

--- a/model/Device/org-openroadm-database.yang
+++ b/model/Device/org-openroadm-database.yang
@@ -4,7 +4,7 @@ module org-openroadm-database {
 
   import org-openroadm-common-types {
     prefix org-openroadm-common-types;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
 
   organization
@@ -40,6 +40,10 @@ module org-openroadm-database {
      ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
      POSSIBILITY OF SUCH DAMAGE.";
 
+  revision 2024-03-29 {
+    description
+      "Version 15.0";
+  }
   revision 2023-12-08 {
     description
       "Version 14.1";

--- a/model/Device/org-openroadm-de-operations.yang
+++ b/model/Device/org-openroadm-de-operations.yang
@@ -4,7 +4,7 @@ module org-openroadm-de-operations {
 
   import org-openroadm-resource {
     prefix org-openroadm-resource;
-    revision-date 2023-05-26;
+    revision-date 2024-03-29;
   }
   import org-openroadm-common-types {
     prefix org-openroadm-common-types;

--- a/model/Device/org-openroadm-de-operations.yang
+++ b/model/Device/org-openroadm-de-operations.yang
@@ -8,7 +8,7 @@ module org-openroadm-de-operations {
   }
   import org-openroadm-common-types {
     prefix org-openroadm-common-types;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
 
   organization
@@ -44,6 +44,10 @@ module org-openroadm-de-operations {
      ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
      POSSIBILITY OF SUCH DAMAGE.";
 
+  revision 2024-03-29 {
+    description
+      "Version 15.0";
+  }
   revision 2023-12-08 {
     description
       "Version 14.1";

--- a/model/Device/org-openroadm-device.yang
+++ b/model/Device/org-openroadm-device.yang
@@ -2564,7 +2564,14 @@ module org-openroadm-device {
               "allows identifying ports associated with logical amp :
                TX for OSC circuit-pack IN RX for OSC circuit-pack OUT";
           }
-          uses port-name;
+          uses port-name {
+            refine "circuit-pack-name" {
+              mandatory true;
+            }
+            refine "port-name" {
+              mandatory true;
+            }
+          }
         }
         list otdr-port {
           key "otdr-direction";

--- a/model/Device/org-openroadm-device.yang
+++ b/model/Device/org-openroadm-device.yang
@@ -1174,6 +1174,18 @@ module org-openroadm-device {
         }
       }
     }
+    container osc-port {
+      description
+        "osc port associated with degree.";
+      uses port-name {
+        refine "circuit-pack-name" {
+          mandatory true;
+        }
+        refine "port-name" {
+          mandatory true;
+        }
+      }
+    }
     container otdr-port {
       description
         "otdr port associated with degree.";

--- a/model/Device/org-openroadm-device.yang
+++ b/model/Device/org-openroadm-device.yang
@@ -16,7 +16,7 @@ module org-openroadm-device {
   }
   import org-openroadm-common-types {
     prefix org-openroadm-common-types;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
   import org-openroadm-common-alarm-pm-types {
     prefix org-openroadm-common-alarm-pm-types;
@@ -72,7 +72,7 @@ module org-openroadm-device {
   }
   import org-openroadm-swdl {
     prefix org-openroadm-swdl;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
   import org-openroadm-equipment-states-types {
     prefix org-openroadm-equipment-states-types;
@@ -145,6 +145,10 @@ module org-openroadm-device {
      Section 4.e of the Trust Legal Provisions and are provided without warranty as
      described in the Simplified BSD License.";
 
+  revision 2024-03-29 {
+    description
+      "Version 15.0";
+  }
   revision 2023-12-08 {
     description
       "Version 14.1";

--- a/model/Device/org-openroadm-device.yang
+++ b/model/Device/org-openroadm-device.yang
@@ -36,7 +36,7 @@ module org-openroadm-device {
   }
   import org-openroadm-common-link-types {
     prefix org-openroadm-common-link-types;
-    revision-date 2019-11-29;
+    revision-date 2024-03-29;
   }
   import org-openroadm-common-node-types {
     prefix org-openroadm-common-node-types;
@@ -64,7 +64,7 @@ module org-openroadm-device {
   }
   import org-openroadm-port-types {
     prefix org-openroadm-port-types;
-    revision-date 2023-05-26;
+    revision-date 2024-03-29;
   }
   import org-openroadm-interfaces {
     prefix org-openroadm-interfaces;
@@ -1074,6 +1074,17 @@ module org-openroadm-device {
       default "off";
       description
         "Whether connection is currently in power or gain/loss mode";
+      reference
+        "openroadm.org: Open ROADM MSA Specification.";
+    }
+    leaf actual-control-mode {
+      type org-openroadm-common-link-types:act-optical-control-mode;
+      config false;
+      mandatory true;
+      description
+        "The actual control mode for the roadm-connection.
+         The actual control mode can be different from the provisioned opticalControlMode
+         when a rebalancing RPC is in progress (adjust-optical-power RPC).";
       reference
         "openroadm.org: Open ROADM MSA Specification.";
     }

--- a/model/Device/org-openroadm-device.yang
+++ b/model/Device/org-openroadm-device.yang
@@ -359,6 +359,13 @@ module org-openroadm-device {
         "Common Language Location Identifier.";
     }
     uses org-openroadm-physical-types:node-info;
+    leaf oamp-interface-name {
+      type string;
+      config false;
+      description
+        "Assign the Ethernet interface name linked to the OAMP management port,
+         typically utilized for provisioning the primary IP address of the device.";
+    }
     leaf macAddress {
       type ietf-yang-types:mac-address;
       config false;

--- a/model/Device/org-openroadm-device.yang
+++ b/model/Device/org-openroadm-device.yang
@@ -1177,14 +1177,7 @@ module org-openroadm-device {
     container osc-port {
       description
         "osc port associated with degree.";
-      uses port-name {
-        refine "circuit-pack-name" {
-          mandatory true;
-        }
-        refine "port-name" {
-          mandatory true;
-        }
-      }
+      uses port-name;
     }
     container otdr-port {
       description
@@ -2571,14 +2564,7 @@ module org-openroadm-device {
               "allows identifying ports associated with logical amp :
                TX for OSC circuit-pack IN RX for OSC circuit-pack OUT";
           }
-          uses port-name {
-            refine "circuit-pack-name" {
-              mandatory true;
-            }
-            refine "port-name" {
-              mandatory true;
-            }
-          }
+          uses port-name;
         }
         list otdr-port {
           key "otdr-direction";

--- a/model/Device/org-openroadm-dhcp.yang
+++ b/model/Device/org-openroadm-dhcp.yang
@@ -4,7 +4,7 @@ module org-openroadm-dhcp {
 
   import org-openroadm-device {
     prefix org-openroadm-device;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
   import ietf-inet-types {
     prefix ietf-inet-types;
@@ -45,6 +45,10 @@ module org-openroadm-dhcp {
      ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
      POSSIBILITY OF SUCH DAMAGE.";
 
+  revision 2024-03-29 {
+    description
+      "Version 15.0";
+  }
   revision 2023-12-08 {
     description
       "Version 14.1";

--- a/model/Device/org-openroadm-ethernet-interfaces.yang
+++ b/model/Device/org-openroadm-ethernet-interfaces.yang
@@ -5,7 +5,7 @@ module org-openroadm-ethernet-interfaces {
 
   import org-openroadm-device {
     prefix org-openroadm-device;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
   import org-openroadm-interfaces {
     prefix openROADM-if;
@@ -13,11 +13,11 @@ module org-openroadm-ethernet-interfaces {
   }
   import org-openroadm-common-types {
     prefix org-openroadm-common-types;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
   import org-openroadm-maintenance-testsignal {
     prefix org-openroadm-maint-testsignal;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
   import org-openroadm-maintenance-loopback {
     prefix org-openroadm-maint-loopback;
@@ -71,6 +71,10 @@ module org-openroadm-ethernet-interfaces {
      Section 4.e of the Trust Legal Provisions and are provided without warranty as
      described in the Simplified BSD License.";
 
+  revision 2024-03-29 {
+    description
+      "Version 15.0";
+  }
   revision 2023-12-08 {
     description
       "Version 14.1";

--- a/model/Device/org-openroadm-fcc-interfaces.yang
+++ b/model/Device/org-openroadm-fcc-interfaces.yang
@@ -4,7 +4,7 @@ module org-openroadm-fcc-interfaces {
 
   import org-openroadm-device {
     prefix org-openroadm-device;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
   import org-openroadm-interfaces {
     prefix openROADM-if;
@@ -58,6 +58,10 @@ module org-openroadm-fcc-interfaces {
      Section 4.e of the Trust Legal Provisions and are provided without warranty as
      described in the Simplified BSD License.";
 
+  revision 2024-03-29 {
+    description
+      "Version 15.0";
+  }
   revision 2023-12-08 {
     description
       "Version 14.1";

--- a/model/Device/org-openroadm-file-transfer.yang
+++ b/model/Device/org-openroadm-file-transfer.yang
@@ -8,7 +8,7 @@ module org-openroadm-file-transfer {
   }
   import org-openroadm-common-types {
     prefix org-openroadm-common-types;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
   import ietf-yang-types {
     prefix ietf-yang-types;
@@ -48,6 +48,10 @@ module org-openroadm-file-transfer {
      ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
      POSSIBILITY OF SUCH DAMAGE.";
 
+  revision 2024-03-29 {
+    description
+      "Version 15.0";
+  }
   revision 2023-12-08 {
     description
       "Version 14.1";

--- a/model/Device/org-openroadm-fwdl.yang
+++ b/model/Device/org-openroadm-fwdl.yang
@@ -4,7 +4,7 @@ module org-openroadm-fwdl {
 
   import org-openroadm-common-types {
     prefix org-openroadm-common-types;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
 
   organization
@@ -40,6 +40,10 @@ module org-openroadm-fwdl {
      ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
      POSSIBILITY OF SUCH DAMAGE.";
 
+  revision 2024-03-29 {
+    description
+      "Version 15.0";
+  }
   revision 2023-12-08 {
     description
       "Version 14.1";

--- a/model/Device/org-openroadm-gcc-interfaces.yang
+++ b/model/Device/org-openroadm-gcc-interfaces.yang
@@ -4,7 +4,7 @@ module org-openroadm-gcc-interfaces {
 
   import org-openroadm-device {
     prefix org-openroadm-device;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
   import org-openroadm-interfaces {
     prefix openROADM-if;
@@ -58,6 +58,10 @@ module org-openroadm-gcc-interfaces {
      Section 4.e of the Trust Legal Provisions and are provided without warranty as
      described in the Simplified BSD License.";
 
+  revision 2024-03-29 {
+    description
+      "Version 15.0";
+  }
   revision 2023-12-08 {
     description
       "Version 14.1";

--- a/model/Device/org-openroadm-gnmi.yang
+++ b/model/Device/org-openroadm-gnmi.yang
@@ -5,11 +5,11 @@ module org-openroadm-gnmi {
 
   import org-openroadm-device {
     prefix org-openroadm-device;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
   import org-openroadm-security {
     prefix org-openroadm-security;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
   import ietf-inet-types {
     prefix inet;
@@ -49,6 +49,10 @@ module org-openroadm-gnmi {
      ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
      POSSIBILITY OF SUCH DAMAGE.";
 
+  revision 2024-03-29 {
+    description
+      "Version 15.0";
+  }
   revision 2023-12-08 {
     description
       "Version 14.1";

--- a/model/Device/org-openroadm-ip.yang
+++ b/model/Device/org-openroadm-ip.yang
@@ -4,7 +4,7 @@ module org-openroadm-ip {
 
   import org-openroadm-device {
     prefix org-openroadm-device;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
   import ietf-inet-types {
     prefix inet;
@@ -39,6 +39,10 @@ module org-openroadm-ip {
      Section 4.c of the IETF Trust's Legal Provisions Relating
      to IETF Documents (http://trustee.ietf.org/license-info).";
 
+  revision 2024-03-29 {
+    description
+      "Version 15.0";
+  }
   revision 2023-12-08 {
     description
       "Version 14.1";

--- a/model/Device/org-openroadm-ipv4-unicast-routing.yang
+++ b/model/Device/org-openroadm-ipv4-unicast-routing.yang
@@ -4,7 +4,7 @@ module org-openroadm-ipv4-unicast-routing {
 
   import org-openroadm-routing {
     prefix org-openroadm-routing;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
   import ietf-inet-types {
     prefix inet;
@@ -12,7 +12,7 @@ module org-openroadm-ipv4-unicast-routing {
   }
   import org-openroadm-device {
     prefix org-openroadm-device;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
 
   organization
@@ -39,6 +39,10 @@ module org-openroadm-ipv4-unicast-routing {
      Section 4.c of the IETF Trust's Legal Provisions Relating
      to IETF Documents (http://trustee.ietf.org/license-info).";
 
+  revision 2024-03-29 {
+    description
+      "Version 15.0";
+  }
   revision 2023-12-08 {
     description
       "Version 14.1";

--- a/model/Device/org-openroadm-ipv6-unicast-routing.yang
+++ b/model/Device/org-openroadm-ipv6-unicast-routing.yang
@@ -4,7 +4,7 @@ module org-openroadm-ipv6-unicast-routing {
 
   import org-openroadm-routing {
     prefix org-openroadm-routing;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
   import ietf-inet-types {
     prefix inet;
@@ -12,7 +12,7 @@ module org-openroadm-ipv6-unicast-routing {
   }
   import org-openroadm-device {
     prefix org-openroadm-device;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
 
   organization
@@ -39,6 +39,10 @@ module org-openroadm-ipv6-unicast-routing {
      Section 4.c of the IETF Trust's Legal Provisions Relating
      to IETF Documents (http://trustee.ietf.org/license-info).";
 
+  revision 2024-03-29 {
+    description
+      "Version 15.0";
+  }
   revision 2023-12-08 {
     description
       "Version 14.1";

--- a/model/Device/org-openroadm-lldp.yang
+++ b/model/Device/org-openroadm-lldp.yang
@@ -8,7 +8,7 @@ module org-openroadm-lldp {
   }
   import org-openroadm-device {
     prefix org-openroadm-device;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
   import iana-afn-safi {
     prefix ianaaf;
@@ -56,6 +56,10 @@ module org-openroadm-lldp {
      ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
      POSSIBILITY OF SUCH DAMAGE.";
 
+  revision 2024-03-29 {
+    description
+      "Version 15.0";
+  }
   revision 2023-12-08 {
     description
       "Version 14.1";

--- a/model/Device/org-openroadm-lldp.yang
+++ b/model/Device/org-openroadm-lldp.yang
@@ -10,9 +10,9 @@ module org-openroadm-lldp {
     prefix org-openroadm-device;
     revision-date 2024-03-29;
   }
-  import iana-afn-safi {
-    prefix ianaaf;
-    revision-date 2013-07-04;
+  import iana-routing-types {
+    prefix iana-rt-types;
+    revision-date 2022-08-19;
   }
   import org-openroadm-resource-types {
     prefix org-openroadm-resource-types;
@@ -186,7 +186,7 @@ module org-openroadm-lldp {
         "remote neighbour system name";
     }
     leaf remoteMgmtAddressSubType {
-      type ianaaf:address-family;
+      type iana-rt-types:address-family;
       description
         "remote neighbour Management Address Subtype Enumeration";
     }

--- a/model/Device/org-openroadm-maintenance-testsignal.yang
+++ b/model/Device/org-openroadm-maintenance-testsignal.yang
@@ -5,7 +5,7 @@ module org-openroadm-maintenance-testsignal {
 
   import org-openroadm-common-types {
     prefix org-openroadm-common-types;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
 
   organization
@@ -41,6 +41,10 @@ module org-openroadm-maintenance-testsignal {
      ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
      POSSIBILITY OF SUCH DAMAGE.";
 
+  revision 2024-03-29 {
+    description
+      "Version 15.0";
+  }
   revision 2023-12-08 {
     description
       "Version 14.1";

--- a/model/Device/org-openroadm-media-channel-interfaces.yang
+++ b/model/Device/org-openroadm-media-channel-interfaces.yang
@@ -4,7 +4,7 @@ module org-openroadm-media-channel-interfaces {
 
   import org-openroadm-device {
     prefix org-openroadm-device;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
   import org-openroadm-interfaces {
     prefix openROADM-if;
@@ -62,6 +62,10 @@ module org-openroadm-media-channel-interfaces {
      Section 4.e of the Trust Legal Provisions and are provided without warranty as
      described in the Simplified BSD License.";
 
+  revision 2024-03-29 {
+    description
+      "Version 15.0";
+  }
   revision 2023-12-08 {
     description
       "Version 14.1";

--- a/model/Device/org-openroadm-native-data.yang
+++ b/model/Device/org-openroadm-native-data.yang
@@ -12,7 +12,7 @@ module org-openroadm-native-data {
   contact
     "OpenROADM.org";
   description
-    "YANG definitions of operations.
+    "YANG definitions to retrieve vendor native data.
 
      Copyright of the Members of the Open ROADM MSA Agreement dated (c) 2016,
      All other rights reserved.

--- a/model/Device/org-openroadm-native-data.yang
+++ b/model/Device/org-openroadm-native-data.yang
@@ -1,0 +1,84 @@
+module org-openroadm-native-data {
+  namespace "http://org/openroadm/native/data";
+  prefix org-openroadm-native-data;
+
+  import org-openroadm-common-types {
+    prefix org-openroadm-common-types;
+    revision-date 2024-03-29;
+  }
+
+  organization
+    "Open ROADM MSA";
+  contact
+    "OpenROADM.org";
+  description
+    "YANG definitions of operations.
+
+     Copyright of the Members of the Open ROADM MSA Agreement dated (c) 2016,
+     All other rights reserved.
+
+     Redistribution and use in source and binary forms, with or without modification,
+     are permitted provided that the following conditions are met:
+
+     * Redistributions of source code must retain the above copyright notice, this
+       list of conditions and the following disclaimer.
+     * Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation and/or
+       other materials provided with the distribution.
+     * Neither the Members of the Open ROADM MSA Agreement nor the names of its
+       contributors may be used to endorse or promote products derived from this software
+       without specific prior written permission.
+
+     THIS SOFTWARE IS PROVIDED BY THE MEMBERS OF THE OPEN ROADM MSA  AGREEMENT ''AS IS''
+     AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+     WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+     IN NO EVENT THE MEMBERS OF THE OPEN ROADM MSA  AGREEMENT BE LIABLE FOR ANY DIRECT,
+     INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+     NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE, DATA,
+     OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+     WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+     ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+     POSSIBILITY OF SUCH DAMAGE.";
+
+  revision 2024-03-29 {
+    description
+      "Version 15.0";
+  }
+
+  rpc get-native-data {
+    description
+      "Retrieve data from the vendor’s native data model.";
+    input {
+      leaf get-request {
+         type string;
+         description
+           "Input command to retrieve data from the vendor’s native data model.
+            This attribute is generic and does not specify the
+            format or details of the get-request input.
+
+            The vendor determines the valid get-request inputs that are supported by the product.
+            The vendor is free to choose any management interface language
+            (NETCONF, CLI, TL1, SNMP, etc.), format and semantics for the get-request.
+            It is expected that the vendor would provide documentation on the valid
+            get-request values through an outside mechanism.";
+      }
+    }
+    output {
+      uses org-openroadm-common-types:rpc-response-status;
+      leaf get-response {
+         type string;
+         description
+            "Output response containing the vendor’s native data model information.
+             This attribute is generic and does not specify the
+             format or details of the get-response output.
+
+             The vendor determines the valid get-response outputs that are
+             supported by the product based on the input to the RPC.
+             The vendor is free to choose any management interface
+             language (NETCONF, CLI, TL1, SNMP, etc.), format and
+             semantics for the get-response. It is expected that the vendor
+             would provide documentation on the get-response data through an outside mechanism.";
+      }
+    }
+  }
+}

--- a/model/Device/org-openroadm-network-media-channel-interfaces.yang
+++ b/model/Device/org-openroadm-network-media-channel-interfaces.yang
@@ -4,7 +4,7 @@ module org-openroadm-network-media-channel-interfaces {
 
   import org-openroadm-device {
     prefix org-openroadm-device;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
   import org-openroadm-interfaces {
     prefix openROADM-if;
@@ -62,6 +62,10 @@ module org-openroadm-network-media-channel-interfaces {
      Section 4.e of the Trust Legal Provisions and are provided without warranty as
      described in the Simplified BSD License.";
 
+  revision 2024-03-29 {
+    description
+      "Version 15.0";
+  }
   revision 2023-12-08 {
     description
       "Version 14.1";

--- a/model/Device/org-openroadm-optical-channel-interfaces.yang
+++ b/model/Device/org-openroadm-optical-channel-interfaces.yang
@@ -12,7 +12,7 @@ module org-openroadm-optical-channel-interfaces {
   }
   import org-openroadm-common-link-types {
     prefix org-openroadm-common-link-types;
-    revision-date 2019-11-29;
+    revision-date 2024-03-29;
   }
   import org-openroadm-common-optical-channel-types {
     prefix org-openroadm-common-optical-channel-types;

--- a/model/Device/org-openroadm-optical-channel-interfaces.yang
+++ b/model/Device/org-openroadm-optical-channel-interfaces.yang
@@ -4,7 +4,7 @@ module org-openroadm-optical-channel-interfaces {
 
   import org-openroadm-device {
     prefix org-openroadm-device;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
   import org-openroadm-interfaces {
     prefix openROADM-if;
@@ -24,7 +24,7 @@ module org-openroadm-optical-channel-interfaces {
   }
   import org-openroadm-common-types {
     prefix org-openroadm-common-types;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
 
   organization
@@ -74,6 +74,10 @@ module org-openroadm-optical-channel-interfaces {
      Section 4.e of the Trust Legal Provisions and are provided without warranty as
      described in the Simplified BSD License.";
 
+  revision 2024-03-29 {
+    description
+      "Version 15.0";
+  }
   revision 2023-12-08 {
     description
       "Version 14.1";

--- a/model/Device/org-openroadm-optical-rebalancing.yang
+++ b/model/Device/org-openroadm-optical-rebalancing.yang
@@ -1,0 +1,189 @@
+module org-openroadm-optical-rebalancing {
+  namespace "http://org/openroadm/optical/rebalancing";
+  prefix org-openroadm-optical-rebalancing;
+
+  import org-openroadm-device {
+    prefix org-openroadm-device;
+    revision-date 2024-03-29;
+  }
+  import org-openroadm-common-types {
+    prefix org-openroadm-common-types;
+    revision-date 2024-03-29;
+  }
+  import org-openroadm-common-link-types {
+    prefix org-openroadm-common-link-types;
+    revision-date 2024-03-29;
+  }
+  organization
+    "Open ROADM MSA";
+  contact
+    "OpenROADM.org";
+  description
+    "YANG definitions of power rebalancing operations.
+
+     Copyright of the Members of the Open ROADM MSA Agreement dated (c) 2016,
+     All other rights reserved.
+
+     Redistribution and use in source and binary forms, with or without modification,
+     are permitted provided that the following conditions are met:
+
+     * Redistributions of source code must retain the above copyright notice, this
+       list of conditions and the following disclaimer.
+     * Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation and/or
+       other materials provided with the distribution.
+     * Neither the Members of the Open ROADM MSA Agreement nor the names of its
+       contributors may be used to endorse or promote products derived from this software
+       without specific prior written permission.
+
+     THIS SOFTWARE IS PROVIDED BY THE MEMBERS OF THE OPEN ROADM MSA  AGREEMENT ''AS IS''
+     AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+     WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+     IN NO EVENT THE MEMBERS OF THE OPEN ROADM MSA  AGREEMENT BE LIABLE FOR ANY DIRECT,
+     INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+     NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;  LOSS OF USE, DATA,
+     OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+     WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+     ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+     POSSIBILITY OF SUCH DAMAGE.
+
+     Also contains code components extracted from IETF netconf.  These code components
+     are copyrighted and licensed as follows:
+
+     Copyright (c) 2016 IETF Trust and the persons identified as the document authors.
+     All rights reserved.
+
+     This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating
+     to IETF Documents (http://trustee.ietf.org/license-info) in effect on the date of
+     publication of this document. Please review these documents carefully, as they
+     describe your rights and restrictions with respect to this document. Code Components
+     extracted from this document must include Simplified BSD License text as described in
+     Section 4.e of the Trust Legal Provisions and are provided without warranty as
+     described in the Simplified BSD License.";
+
+  revision 2024-03-29 {
+    description
+      "Version 15.0";
+  }
+
+  grouping failed-connections {
+    description
+      "List of failed connections and the reasons for failure.";
+    list failed-connection {
+      description
+      "Failed connection and the reason for the failure.";
+      key connection-name;
+      leaf connection-name {
+        type string;
+        description
+          "Name of the roadm-connection.";
+      }
+      leaf failure-reason {
+        type string;
+        mandatory true;
+        description
+          "Reason for the rebalancing failure for the roadm-connection.";
+      }
+      leaf reversion-failed {
+        type boolean;
+        mandatory true;
+        description
+          "If rebalancing fails, it is expected that the roadm-connection be reverted back to its
+           previous gainLoss setting. If it was not possible to reset the service back to the
+           previous setting, this flag is set to true.";
+      }
+    }
+  }
+
+  rpc adjust-optical-power {
+    description
+      "This command will instruct the device to rebalance a set of roadm-connections.
+       The device initiates the power rebalancing for the specified connections that are
+       in the gainLoss mode. Connections that are in the off or power mode are skipped without error.
+
+       The device validates that the optical signal is good before beginning the rebalancing
+       procedure for that connection (e.g., no RX LOS, POS or POR). The device puts the
+       connections into an operational power mode without changing the provisioned opticalControlMode.
+       After a 12s soak time, the device validates that the optical signal is good at the RX and TX
+       ports and within the target-power-threshold of the target-output-power setting. If all conditions
+       are met, the device puts the connection back to gainLoss mode with the new internal settings.
+
+       If any issues are detected during or at the end of the rebalancing operation, then the device
+       reverts the connection back to the previous gainLoss setting.
+
+       The device raises the rebalancingInProgress condition while the operation is in effect and clears
+       the condition at the end of the rebalancing procedure. An adjust-optical-power-result notification
+       is sent at the end of the rebalancing procedure that provides the status and results of the procedure.
+       Connections that failed the rebalancing validations are reported in this notification along with the
+       reason for failure.";
+    input {
+      choice adjust-scope {
+        case roadm-connections {
+          leaf-list connection-name {
+            type leafref {
+              path "/org-openroadm-device:org-openroadm-device/org-openroadm-device:roadm-connections/org-openroadm-device:connection-name";
+            }
+            description
+              "Explicit list of roadm-connections to rebalance";
+          }
+        }
+        case ingress-oms {
+          leaf ingress-oms {
+            type leafref {
+              path "/org-openroadm-device:org-openroadm-device/org-openroadm-device:interface/org-openroadm-device:name";
+            }
+            mandatory true;
+            description
+              "Rebalance all roadm-connections that have their src-if on the ingress-oms";
+          }
+        }
+        case egress-oms {
+          leaf egress-oms {
+            type leafref {
+              path "/org-openroadm-device:org-openroadm-device/org-openroadm-device:interface/org-openroadm-device:name";
+            }
+            mandatory true;
+            description
+              "Rebalance all roadm-connections that have their dst-if on the egress-oms";
+          }
+        }
+      }
+      leaf target-power-threshold {
+        type org-openroadm-common-link-types:ratio-dB;
+        default 1;
+        units dB;
+        description
+          "The transmit target power threshold for rebalancing.
+           If the difference between the actual transmit power and the provisioned target-output-power
+           is less than or equal to the target-power-threshold, then the rebalancing is successful
+           for that roadm-connection.
+           default = 1 dB";
+      }
+    }
+    output {
+      uses org-openroadm-common-types:rpc-response-status;
+    }
+  }
+
+  notification adjust-optical-power-result {
+    description
+      "An asynchronous notification of the result of the adjust-optical-power RPC.
+
+       For the response status, skipped connections are not used to determine the Successful,
+       Failed or Partial.
+
+       A service is successful if the power is rebalanced to the target-output-power within the
+       target-power-threshold. Otherwise, it is failed.
+
+       Successful will be returned if all non-skipped services were successfully rebalanced.
+       Failed will be returned if all non-skipped services were not successfully rebalanced.
+       If some non-skipped services were successful others were failed, then Partial will be returned.";
+    uses org-openroadm-common-types:extended-rpc-response-status;
+    container failed-connections {
+      description
+        "List of failed connections and the reasons for the failure.";
+      uses failed-connections;
+    }
+  }
+
+}

--- a/model/Device/org-openroadm-optical-transport-interfaces.yang
+++ b/model/Device/org-openroadm-optical-transport-interfaces.yang
@@ -4,7 +4,7 @@ module org-openroadm-optical-transport-interfaces {
 
   import org-openroadm-device {
     prefix org-openroadm-device;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
   import org-openroadm-interfaces {
     prefix openROADM-if;
@@ -63,6 +63,10 @@ module org-openroadm-optical-transport-interfaces {
      Section 4.e of the Trust Legal Provisions and are provided without warranty as
      described in the Simplified BSD License.";
 
+  revision 2024-03-29 {
+    description
+      "Version 15.0";
+  }
   revision 2023-12-08 {
     description
       "Version 14.1";

--- a/model/Device/org-openroadm-optical-transport-interfaces.yang
+++ b/model/Device/org-openroadm-optical-transport-interfaces.yang
@@ -12,7 +12,7 @@ module org-openroadm-optical-transport-interfaces {
   }
   import org-openroadm-common-link-types {
     prefix org-openroadm-common-link-types;
-    revision-date 2019-11-29;
+    revision-date 2024-03-29;
   }
 
   organization

--- a/model/Device/org-openroadm-optical-tributary-signal-interfaces.yang
+++ b/model/Device/org-openroadm-optical-tributary-signal-interfaces.yang
@@ -12,7 +12,7 @@ module org-openroadm-optical-tributary-signal-interfaces {
   }
   import org-openroadm-common-types {
     prefix org-openroadm-common-types;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
   import org-openroadm-optical-operational-interfaces {
     prefix org-openroadm-optical-operational-interfaces;
@@ -20,7 +20,7 @@ module org-openroadm-optical-tributary-signal-interfaces {
   }
   import org-openroadm-device {
     prefix org-openroadm-device;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
   import org-openroadm-interfaces {
     prefix openROADM-if;
@@ -78,6 +78,10 @@ module org-openroadm-optical-tributary-signal-interfaces {
      Section 4.e of the Trust Legal Provisions and are provided without warranty as
      described in the Simplified BSD License.";
 
+  revision 2024-03-29 {
+    description
+      "Version 15.0";
+  }
   revision 2023-12-08 {
     description
       "Version 14.1";

--- a/model/Device/org-openroadm-optical-tributary-signal-interfaces.yang
+++ b/model/Device/org-openroadm-optical-tributary-signal-interfaces.yang
@@ -4,7 +4,7 @@ module org-openroadm-optical-tributary-signal-interfaces {
 
   import org-openroadm-common-link-types {
     prefix org-openroadm-common-link-types;
-    revision-date 2019-11-29;
+    revision-date 2024-03-29;
   }
   import org-openroadm-common-optical-channel-types {
     prefix org-openroadm-common-optical-channel-types;

--- a/model/Device/org-openroadm-ospf.yang
+++ b/model/Device/org-openroadm-ospf.yang
@@ -12,11 +12,11 @@ module org-openroadm-ospf {
   }
   import org-openroadm-device {
     prefix org-openroadm-device;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
   import org-openroadm-routing {
     prefix org-openroadm-routing;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
   import org-openroadm-key-chain {
     prefix org-openroadm-key-chain;
@@ -47,6 +47,10 @@ module org-openroadm-ospf {
      Section 4.c of the IETF Trust's Legal Provisions Relating
      to IETF Documents (http://trustee.ietf.org/license-info).";
 
+  revision 2024-03-29 {
+    description
+      "Version 15.0";
+  }
   revision 2023-12-08 {
     description
       "Version 14.1";

--- a/model/Device/org-openroadm-otn-odu-interfaces.yang
+++ b/model/Device/org-openroadm-otn-odu-interfaces.yang
@@ -5,7 +5,7 @@ module org-openroadm-otn-odu-interfaces {
 
   import org-openroadm-device {
     prefix org-openroadm-device;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
   import org-openroadm-interfaces {
     prefix openROADM-if;
@@ -13,7 +13,7 @@ module org-openroadm-otn-odu-interfaces {
   }
   import org-openroadm-maintenance-testsignal {
     prefix org-openroadm-maint-testsignal;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
   import org-openroadm-otn-common {
     prefix org-openroadm-otn-common;
@@ -75,6 +75,10 @@ module org-openroadm-otn-odu-interfaces {
      Section 4.e of the Trust Legal Provisions and are provided without warranty as
      described in the Simplified BSD License.";
 
+  revision 2024-03-29 {
+    description
+      "Version 15.0";
+  }
   revision 2023-12-08 {
     description
       "Version 14.1";

--- a/model/Device/org-openroadm-otn-otu-interfaces.yang
+++ b/model/Device/org-openroadm-otn-otu-interfaces.yang
@@ -4,7 +4,7 @@ module org-openroadm-otn-otu-interfaces {
 
   import org-openroadm-device {
     prefix org-openroadm-device;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
   import org-openroadm-interfaces {
     prefix openROADM-if;
@@ -28,7 +28,7 @@ module org-openroadm-otn-otu-interfaces {
   }
   import org-openroadm-common-types {
     prefix org-openroadm-common-types;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
 
   organization
@@ -78,6 +78,10 @@ module org-openroadm-otn-otu-interfaces {
      Section 4.e of the Trust Legal Provisions and are provided without warranty as
      described in the Simplified BSD License.";
 
+  revision 2024-03-29 {
+    description
+      "Version 15.0";
+  }
   revision 2023-12-08 {
     description
       "Version 14.1";

--- a/model/Device/org-openroadm-otsi-group-interfaces.yang
+++ b/model/Device/org-openroadm-otsi-group-interfaces.yang
@@ -5,7 +5,7 @@ module org-openroadm-otsi-group-interfaces {
 
   import org-openroadm-device {
     prefix org-openroadm-device;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
   import org-openroadm-interfaces {
     prefix openROADM-if;
@@ -22,7 +22,7 @@ module org-openroadm-otsi-group-interfaces {
 
   import org-openroadm-maintenance-testsignal {
     prefix org-openroadm-maint-testsignal;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
   import org-openroadm-maintenance-loopback {
     prefix org-openroadm-maint-loopback;
@@ -76,6 +76,10 @@ module org-openroadm-otsi-group-interfaces {
      Section 4.e of the Trust Legal Provisions and are provided without warranty as
      described in the Simplified BSD License.";
 
+  revision 2024-03-29 {
+    description
+      "Version 15.0";
+  }
   revision 2023-12-08 {
     description
       "Version 14.1";

--- a/model/Device/org-openroadm-pluggable-optics-holder-capability.yang
+++ b/model/Device/org-openroadm-pluggable-optics-holder-capability.yang
@@ -4,11 +4,11 @@ module org-openroadm-pluggable-optics-holder-capability {
 
   import org-openroadm-device {
     prefix org-openroadm-device;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
   import org-openroadm-port-capability {
     prefix org-openroadm-port-capability;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
   import org-openroadm-port-types {
     prefix org-openroadm-port-types;
@@ -62,6 +62,10 @@ module org-openroadm-pluggable-optics-holder-capability {
      Section 4.e of the Trust Legal Provisions and are provided without warranty as
      described in the Simplified BSD License.";
 
+  revision 2024-03-29 {
+    description
+      "Version 15.0";
+  }
   revision 2023-12-08 {
     description
       "Version 14.1";

--- a/model/Device/org-openroadm-pluggable-optics-holder-capability.yang
+++ b/model/Device/org-openroadm-pluggable-optics-holder-capability.yang
@@ -12,7 +12,7 @@ module org-openroadm-pluggable-optics-holder-capability {
   }
   import org-openroadm-port-types {
     prefix org-openroadm-port-types;
-    revision-date 2023-05-26;
+    revision-date 2024-03-29;
   }
 
   organization

--- a/model/Device/org-openroadm-port-capability.yang
+++ b/model/Device/org-openroadm-port-capability.yang
@@ -4,7 +4,7 @@ module org-openroadm-port-capability {
 
   import org-openroadm-device {
     prefix org-openroadm-device;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
   import org-openroadm-port-types {
     prefix org-openroadm-port-types;
@@ -58,6 +58,10 @@ module org-openroadm-port-capability {
      Section 4.e of the Trust Legal Provisions and are provided without warranty as
      described in the Simplified BSD License.";
 
+  revision 2024-03-29 {
+    description
+      "Version 15.0";
+  }
   revision 2023-12-08 {
     description
       "Version 14.1";

--- a/model/Device/org-openroadm-port-capability.yang
+++ b/model/Device/org-openroadm-port-capability.yang
@@ -8,7 +8,7 @@ module org-openroadm-port-capability {
   }
   import org-openroadm-port-types {
     prefix org-openroadm-port-types;
-    revision-date 2023-05-26;
+    revision-date 2024-03-29;
   }
 
   organization

--- a/model/Device/org-openroadm-port-capability.yang
+++ b/model/Device/org-openroadm-port-capability.yang
@@ -210,7 +210,14 @@ module org-openroadm-port-capability {
       }
       config false;
       description
-        "Optical operation capabilities handled through specific operation modes leaf list";
+    "Optical operational modes supported.
+
+       The optical-operational-mode is configured on the OCH and OTSI interfaces.
+       When an Open ROADM standard optical operational mode is advertised, this indicates
+       that the mode is supported and can be provisioned using the provision-mode = explicit 
+       or profile.
+       When a bookended optical operational mode is advertised, this indicates that the mode
+       is supported and can be provisioned using the provisioned-mode = profile.";
     }
   }
 

--- a/model/Device/org-openroadm-prot-equipment-aps.yang
+++ b/model/Device/org-openroadm-prot-equipment-aps.yang
@@ -4,11 +4,11 @@ module org-openroadm-prot-equipment-aps {
 
   import org-openroadm-device {
     prefix org-openroadm-device;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
   import org-openroadm-common-types {
     prefix org-openroadm-common-types;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
 
   organization
@@ -58,6 +58,10 @@ module org-openroadm-prot-equipment-aps {
      Section 4.e of the Trust Legal Provisions and are provided without warranty as
      described in the Simplified BSD License.";
 
+  revision 2024-03-29 {
+    description
+      "Version 15.0";
+  }
   revision 2023-12-08 {
     description
       "Version 14.1";

--- a/model/Device/org-openroadm-prot-otn-linear-aps.yang
+++ b/model/Device/org-openroadm-prot-otn-linear-aps.yang
@@ -4,11 +4,11 @@ module org-openroadm-prot-otn-linear-aps {
 
   import org-openroadm-device {
     prefix org-openroadm-device;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
   import org-openroadm-common-types {
     prefix org-openroadm-common-types;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
 
   organization
@@ -58,6 +58,10 @@ module org-openroadm-prot-otn-linear-aps {
      Section 4.e of the Trust Legal Provisions and are provided without warranty as
      described in the Simplified BSD License.";
 
+  revision 2024-03-29 {
+    description
+      "Version 15.0";
+  }
   revision 2023-12-08 {
     description
       "Version 14.1";

--- a/model/Device/org-openroadm-routing.yang
+++ b/model/Device/org-openroadm-routing.yang
@@ -8,7 +8,7 @@ module org-openroadm-routing {
   }
   import org-openroadm-device {
     prefix org-openroadm-device;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
 
   organization
@@ -35,6 +35,10 @@ module org-openroadm-routing {
      Section 4.c of the IETF Trust's Legal Provisions Relating
      to IETF Documents (http://trustee.ietf.org/license-info).";
 
+  revision 2024-03-29 {
+    description
+      "Version 15.0";
+  }
   revision 2023-12-08 {
     description
       "Version 14.1";

--- a/model/Device/org-openroadm-rstp.yang
+++ b/model/Device/org-openroadm-rstp.yang
@@ -4,7 +4,7 @@ module org-openroadm-rstp {
 
   import org-openroadm-device {
     prefix org-openroadm-device;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
   import org-openroadm-resource-types {
     prefix org-openroadm-resource-types;
@@ -45,6 +45,10 @@ module org-openroadm-rstp {
      ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
      POSSIBILITY OF SUCH DAMAGE.";
 
+  revision 2024-03-29 {
+    description
+      "Version 15.0";
+  }
   revision 2023-12-08 {
     description
       "Version 14.1";

--- a/model/Device/org-openroadm-security.yang
+++ b/model/Device/org-openroadm-security.yang
@@ -5,11 +5,11 @@ module org-openroadm-security {
 
   import org-openroadm-device {
     prefix org-openroadm-device;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
   import org-openroadm-common-types {
     prefix org-openroadm-common-types;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
 
   organization
@@ -45,6 +45,10 @@ module org-openroadm-security {
      ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
      POSSIBILITY OF SUCH DAMAGE.";
 
+  revision 2024-03-29 {
+    description
+      "Version 15.0";
+  }
   revision 2023-12-08 {
     description
       "Version 14.1";

--- a/model/Device/org-openroadm-swdl.yang
+++ b/model/Device/org-openroadm-swdl.yang
@@ -8,7 +8,7 @@ module org-openroadm-swdl {
   }
   import org-openroadm-common-types {
     prefix org-openroadm-common-types;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
 
   organization
@@ -44,6 +44,10 @@ module org-openroadm-swdl {
      ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
      POSSIBILITY OF SUCH DAMAGE.";
 
+  revision 2024-03-29 {
+    description
+      "Version 15.0";
+  }
   revision 2023-12-08 {
     description
       "Version 14.1";

--- a/model/Device/tree-view-device.txt
+++ b/model/Device/tree-view-device.txt
@@ -1035,8 +1035,8 @@ module: org-openroadm-device
      |  |  +--rw port-name                           -> /org-openroadm-device/circuit-packs[circuit-pack-name=current()/../circuit-pack-name]/ports/port-name
      |  +--rw osc-port* [port-direction]
      |  |  +--rw port-direction       org-openroadm-common-alarm-pm-types:direction
-     |  |  +--rw circuit-pack-name?   -> /org-openroadm-device/circuit-packs/circuit-pack-name
-     |  |  +--rw port-name?           -> /org-openroadm-device/circuit-packs[circuit-pack-name=current()/../circuit-pack-name]/ports/port-name
+     |  |  +--rw circuit-pack-name    -> /org-openroadm-device/circuit-packs/circuit-pack-name
+     |  |  +--rw port-name            -> /org-openroadm-device/circuit-packs[circuit-pack-name=current()/../circuit-pack-name]/ports/port-name
      |  +--rw otdr-port* [otdr-direction]
      |     +--rw otdr-direction       string
      |     +--rw circuit-pack-name    -> /org-openroadm-device/circuit-packs/circuit-pack-name

--- a/model/Device/tree-view-device.txt
+++ b/model/Device/tree-view-device.txt
@@ -897,7 +897,7 @@ module: org-openroadm-device
      |  |     +--ro org-openroadm-lldp:if-name* [ifName]
      |  |        +--ro org-openroadm-lldp:ifName                      string
      |  |        +--ro org-openroadm-lldp:remoteSysName?              string
-     |  |        +--ro org-openroadm-lldp:remoteMgmtAddressSubType?   ianaaf:address-family
+     |  |        +--ro org-openroadm-lldp:remoteMgmtAddressSubType?   iana-rt-types:address-family
      |  |        +--ro org-openroadm-lldp:remoteMgmtAddress?          inet:ip-address
      |  |        +--ro org-openroadm-lldp:remotePortIdSubType?        enumeration
      |  |        +--ro org-openroadm-lldp:remotePortId?               string
@@ -1976,7 +1976,7 @@ module: org-openroadm-lldp
        +--ro resource?            string
        +--ro nbr-info
        |  +--ro remoteSysName?              string
-       |  +--ro remoteMgmtAddressSubType?   ianaaf:address-family
+       |  +--ro remoteMgmtAddressSubType?   iana-rt-types:address-family
        |  +--ro remoteMgmtAddress?          inet:ip-address
        |  +--ro remotePortIdSubType?        enumeration
        |  +--ro remotePortId?               string

--- a/model/Device/tree-view-device.txt
+++ b/model/Device/tree-view-device.txt
@@ -508,47 +508,6 @@ module: org-openroadm-device
      |  +--rw supporting-interface-list*                                -> /org-openroadm-device/interface/name
      |  +--rw common-functions
      |  |  +--ro org-openroadm-prot-otn-linear-aps:protection-profile-name*   -> /org-openroadm-device:org-openroadm-device/protection-profiles/org-openroadm-prot-otn-linear-aps:protection-profile/profile-name
-     |  +--rw org-openroadm-eth-interfaces:ethernet
-     |  |  +--rw org-openroadm-eth-interfaces:speed?                          uint32
-     |  |  +--rw org-openroadm-eth-interfaces:eth-function?                   eth-function-type
-     |  |  +--rw org-openroadm-eth-interfaces:fec?                            identityref
-     |  |  +--rw org-openroadm-eth-interfaces:egress-consequent-action?       enumeration
-     |  |  +--rw org-openroadm-eth-interfaces:duplex?                         enumeration
-     |  |  +--rw org-openroadm-eth-interfaces:auto-negotiation?               enumeration
-     |  |  +--rw org-openroadm-eth-interfaces:enable-laser?                   enumeration
-     |  |  +--ro org-openroadm-eth-interfaces:laser-status?                   enumeration
-     |  |  +--ro org-openroadm-eth-interfaces:curr-speed?                     string
-     |  |  +--ro org-openroadm-eth-interfaces:curr-duplex?                    string
-     |  |  +--ro org-openroadm-eth-interfaces:max-frame-size?                 uint32
-     |  |  +--rw org-openroadm-eth-interfaces:subrate-eth-sla!
-     |  |  |  +--rw org-openroadm-eth-interfaces:committed-info-rate     uint32
-     |  |  |  +--rw org-openroadm-eth-interfaces:committed-burst-size    uint16
-     |  |  +--ro org-openroadm-eth-interfaces:no-oam-function?                empty
-     |  |  +--ro org-openroadm-eth-interfaces:no-maint-testsignal-function?   empty
-     |  |  +--rw org-openroadm-eth-interfaces:parent-flexo-allocation!
-     |  |  |  +--rw org-openroadm-eth-interfaces:trib-port-number    uint16
-     |  |  |  +--rw org-openroadm-eth-interfaces:iid*                uint16
-     |  |  +--rw org-openroadm-eth-interfaces:maint-testsignal
-     |  |  |  +---x org-openroadm-eth-interfaces:clear-diagnostics
-     |  |  |  |  +---w org-openroadm-eth-interfaces:input
-     |  |  |  |  |  +---w org-openroadm-eth-interfaces:type?   testsig-type
-     |  |  |  |  +--ro org-openroadm-eth-interfaces:output
-     |  |  |  |     +--ro org-openroadm-eth-interfaces:status            org-openroadm-common-types:rpc-status
-     |  |  |  |     +--ro org-openroadm-eth-interfaces:status-message?   string
-     |  |  |  +--rw org-openroadm-eth-interfaces:enabled?             boolean
-     |  |  |  +--rw org-openroadm-eth-interfaces:testPattern          enumeration
-     |  |  |  +--rw org-openroadm-eth-interfaces:type?                testsig-type
-     |  |  |  +--ro org-openroadm-eth-interfaces:inSync?              boolean
-     |  |  |  +--ro org-openroadm-eth-interfaces:seconds              uint32
-     |  |  |  +--ro org-openroadm-eth-interfaces:bitErrors?           uint32
-     |  |  |  +--ro org-openroadm-eth-interfaces:bitErrorRate?        decimal64
-     |  |  +--rw org-openroadm-eth-interfaces:maint-loopback
-     |  |     +--rw org-openroadm-eth-interfaces:enabled?   boolean
-     |  |     +--rw org-openroadm-eth-interfaces:type?      enumeration
-     |  +--rw org-openroadm-fcc-interfaces:fcc
-     |  |  +--rw org-openroadm-fcc-interfaces:fcc-channel-type?   enumeration
-     |  +--rw org-openroadm-gcc-interfaces:gcc
-     |  |  +--rw org-openroadm-gcc-interfaces:gcc-channel-type?   enumeration
      |  +--rw org-openroadm-ip:ipv4!
      |  |  +--rw org-openroadm-ip:enabled?             boolean
      |  |  +--rw org-openroadm-ip:forwarding?          boolean
@@ -604,59 +563,6 @@ module: org-openroadm-device
      |  |  |  +--ro org-openroadm-ip:prefix-length    uint8
      |  |  +--ro org-openroadm-ip:origin?       ip-address-origin
      |  |  +--ro org-openroadm-ip:status?       ipv6-address-status
-     |  +--rw org-openroadm-media-channel-interfaces:mc-ttp
-     |  |  +--rw org-openroadm-media-channel-interfaces:min-freq?      org-openroadm-common-optical-channel-types:frequency-THz
-     |  |  +--rw org-openroadm-media-channel-interfaces:max-freq?      org-openroadm-common-optical-channel-types:frequency-THz
-     |  |  +--ro org-openroadm-media-channel-interfaces:center-freq?   org-openroadm-common-optical-channel-types:frequency-THz
-     |  |  +--ro org-openroadm-media-channel-interfaces:slot-width?    org-openroadm-common-optical-channel-types:frequency-GHz
-     |  +--rw org-openroadm-network-media-channel-interfaces:nmc-ctp
-     |  |  +--rw org-openroadm-network-media-channel-interfaces:frequency?                org-openroadm-common-optical-channel-types:frequency-THz
-     |  |  +--rw org-openroadm-network-media-channel-interfaces:width?                    org-openroadm-common-optical-channel-types:frequency-GHz
-     |  |  +--rw org-openroadm-network-media-channel-interfaces:full-bandwidth-at-3dB?    org-openroadm-common-optical-channel-types:frequency-GHz
-     |  |  +--rw org-openroadm-network-media-channel-interfaces:full-bandwidth-at-10dB?   org-openroadm-common-optical-channel-types:frequency-GHz
-     |  +--rw org-openroadm-optical-channel-interfaces:och
-     |  |  +--rw org-openroadm-optical-channel-interfaces:provision-mode?             org-openroadm-common-optical-channel-types:provision-mode-type
-     |  |  +--rw org-openroadm-optical-channel-interfaces:rate?                       identityref
-     |  |  +--rw org-openroadm-optical-channel-interfaces:frequency?                  org-openroadm-common-optical-channel-types:frequency-THz
-     |  |  +--ro org-openroadm-optical-channel-interfaces:width?                      org-openroadm-common-optical-channel-types:frequency-GHz
-     |  |  +--ro org-openroadm-optical-channel-interfaces:full-bandwidth-at-3dB?      org-openroadm-common-optical-channel-types:frequency-GHz
-     |  |  +--ro org-openroadm-optical-channel-interfaces:full-bandwidth-at-10dB?     org-openroadm-common-optical-channel-types:frequency-GHz
-     |  |  +--rw org-openroadm-optical-channel-interfaces:enable-laser?               enumeration
-     |  |  +--ro org-openroadm-optical-channel-interfaces:laser-status?               enumeration
-     |  |  +--rw org-openroadm-optical-channel-interfaces:modulation-format?          org-openroadm-common-optical-channel-types:modulation-format
-     |  |  +--rw org-openroadm-optical-channel-interfaces:transmit-power?             org-openroadm-common-link-types:power-dBm
-     |  |  +--rw org-openroadm-optical-channel-interfaces:optical-operational-mode?   string
-     |  |  +--ro org-openroadm-optical-channel-interfaces:operational-mode-params
-     |  |     +--ro org-openroadm-optical-channel-interfaces:spectral-width?   org-openroadm-common-optical-channel-types:frequency-GHz
-     |  +--rw org-openroadm-optical-transport-interfaces:ots
-     |  |  +--rw org-openroadm-optical-transport-interfaces:fiber-type?                       enumeration
-     |  |  +--rw org-openroadm-optical-transport-interfaces:span-loss-receive?                org-openroadm-common-link-types:ratio-dB
-     |  |  +--rw org-openroadm-optical-transport-interfaces:span-loss-transmit?               org-openroadm-common-link-types:ratio-dB
-     |  |  +--rw org-openroadm-optical-transport-interfaces:ingress-span-loss-aging-margin?   org-openroadm-common-link-types:ratio-dB
-     |  |  +--rw org-openroadm-optical-transport-interfaces:eol-max-load-pIn?                 org-openroadm-common-link-types:power-dBm
-     |  +--rw org-openroadm-optical-tributary-signal-interfaces:otsi
-     |  |  +--rw org-openroadm-optical-tributary-signal-interfaces:provision-mode?             org-openroadm-common-optical-channel-types:provision-mode-type
-     |  |  +--rw org-openroadm-optical-tributary-signal-interfaces:otsi-rate?                  identityref
-     |  |  +--rw org-openroadm-optical-tributary-signal-interfaces:otsi-member-id?             uint16
-     |  |  +--rw org-openroadm-optical-tributary-signal-interfaces:frequency?                  org-openroadm-common-optical-channel-types:frequency-THz
-     |  |  +--ro org-openroadm-optical-tributary-signal-interfaces:width?                      org-openroadm-common-optical-channel-types:frequency-GHz
-     |  |  +--ro org-openroadm-optical-tributary-signal-interfaces:full-bandwidth-at-3dB?      org-openroadm-common-optical-channel-types:frequency-GHz
-     |  |  +--ro org-openroadm-optical-tributary-signal-interfaces:full-bandwidth-at-10dB?     org-openroadm-common-optical-channel-types:frequency-GHz
-     |  |  +--rw org-openroadm-optical-tributary-signal-interfaces:enable-laser?               enumeration
-     |  |  +--ro org-openroadm-optical-tributary-signal-interfaces:laser-status?               enumeration
-     |  |  +--rw org-openroadm-optical-tributary-signal-interfaces:modulation-format?          org-openroadm-common-optical-channel-types:modulation-format
-     |  |  +--rw org-openroadm-optical-tributary-signal-interfaces:transmit-power?             org-openroadm-common-link-types:power-dBm
-     |  |  +--rw org-openroadm-optical-tributary-signal-interfaces:fec?                        identityref
-     |  |  +--rw org-openroadm-optical-tributary-signal-interfaces:optical-operational-mode?   string
-     |  |  +--ro org-openroadm-optical-tributary-signal-interfaces:operational-mode-params
-     |  |  |  +--ro org-openroadm-optical-tributary-signal-interfaces:spectral-width?   org-openroadm-common-optical-channel-types:frequency-GHz
-     |  |  +--ro org-openroadm-optical-tributary-signal-interfaces:supported-group-if?         -> /org-openroadm-device:org-openroadm-device/interface/name
-     |  |  +--rw org-openroadm-optical-tributary-signal-interfaces:flexo!
-     |  |     +--rw org-openroadm-optical-tributary-signal-interfaces:foic-type?             identityref
-     |  |     +--rw org-openroadm-optical-tributary-signal-interfaces:iid*                   uint8
-     |  |     +--ro org-openroadm-optical-tributary-signal-interfaces:accepted-group-id*     uint32
-     |  |     +--ro org-openroadm-optical-tributary-signal-interfaces:accepted-iid*          uint8
-     |  |     +--ro org-openroadm-optical-tributary-signal-interfaces:accepted-payload-id*   org-openroadm-otn-common-types:flexo-payload-type-def
      |  +--rw org-openroadm-otn-odu-interfaces:odu!
      |  |  +--rw org-openroadm-otn-odu-interfaces:rate?                                  identityref
      |  |  +--rw org-openroadm-otn-odu-interfaces:oducn-n-rate?                          uint16
@@ -754,6 +660,43 @@ module: org-openroadm-device
      |  |     +--ro org-openroadm-otn-odu-interfaces:seconds              uint32
      |  |     +--ro org-openroadm-otn-odu-interfaces:bitErrors?           uint32
      |  |     +--ro org-openroadm-otn-odu-interfaces:bitErrorRate?        decimal64
+     |  +--rw org-openroadm-eth-interfaces:ethernet
+     |  |  +--rw org-openroadm-eth-interfaces:speed?                          uint32
+     |  |  +--rw org-openroadm-eth-interfaces:eth-function?                   eth-function-type
+     |  |  +--rw org-openroadm-eth-interfaces:fec?                            identityref
+     |  |  +--rw org-openroadm-eth-interfaces:egress-consequent-action?       enumeration
+     |  |  +--rw org-openroadm-eth-interfaces:duplex?                         enumeration
+     |  |  +--rw org-openroadm-eth-interfaces:auto-negotiation?               enumeration
+     |  |  +--rw org-openroadm-eth-interfaces:enable-laser?                   enumeration
+     |  |  +--ro org-openroadm-eth-interfaces:laser-status?                   enumeration
+     |  |  +--ro org-openroadm-eth-interfaces:curr-speed?                     string
+     |  |  +--ro org-openroadm-eth-interfaces:curr-duplex?                    string
+     |  |  +--ro org-openroadm-eth-interfaces:max-frame-size?                 uint32
+     |  |  +--rw org-openroadm-eth-interfaces:subrate-eth-sla!
+     |  |  |  +--rw org-openroadm-eth-interfaces:committed-info-rate     uint32
+     |  |  |  +--rw org-openroadm-eth-interfaces:committed-burst-size    uint16
+     |  |  +--ro org-openroadm-eth-interfaces:no-oam-function?                empty
+     |  |  +--ro org-openroadm-eth-interfaces:no-maint-testsignal-function?   empty
+     |  |  +--rw org-openroadm-eth-interfaces:parent-flexo-allocation!
+     |  |  |  +--rw org-openroadm-eth-interfaces:trib-port-number    uint16
+     |  |  |  +--rw org-openroadm-eth-interfaces:iid*                uint16
+     |  |  +--rw org-openroadm-eth-interfaces:maint-testsignal
+     |  |  |  +---x org-openroadm-eth-interfaces:clear-diagnostics
+     |  |  |  |  +---w org-openroadm-eth-interfaces:input
+     |  |  |  |  |  +---w org-openroadm-eth-interfaces:type?   testsig-type
+     |  |  |  |  +--ro org-openroadm-eth-interfaces:output
+     |  |  |  |     +--ro org-openroadm-eth-interfaces:status            org-openroadm-common-types:rpc-status
+     |  |  |  |     +--ro org-openroadm-eth-interfaces:status-message?   string
+     |  |  |  +--rw org-openroadm-eth-interfaces:enabled?             boolean
+     |  |  |  +--rw org-openroadm-eth-interfaces:testPattern          enumeration
+     |  |  |  +--rw org-openroadm-eth-interfaces:type?                testsig-type
+     |  |  |  +--ro org-openroadm-eth-interfaces:inSync?              boolean
+     |  |  |  +--ro org-openroadm-eth-interfaces:seconds              uint32
+     |  |  |  +--ro org-openroadm-eth-interfaces:bitErrors?           uint32
+     |  |  |  +--ro org-openroadm-eth-interfaces:bitErrorRate?        decimal64
+     |  |  +--rw org-openroadm-eth-interfaces:maint-loopback
+     |  |     +--rw org-openroadm-eth-interfaces:enabled?   boolean
+     |  |     +--rw org-openroadm-eth-interfaces:type?      enumeration
      |  +--rw org-openroadm-otn-otu-interfaces:otu
      |  |  +--rw org-openroadm-otn-otu-interfaces:rate?                      identityref
      |  |  +--rw org-openroadm-otn-otu-interfaces:otu4-member-id?            uint16
@@ -780,56 +723,101 @@ module: org-openroadm-device
      |  |  +--rw org-openroadm-otn-otu-interfaces:parent-flexo-allocation!
      |  |     +--rw org-openroadm-otn-otu-interfaces:trib-port-number    uint8
      |  |     +--rw org-openroadm-otn-otu-interfaces:iid*                uint8
+     |  +--rw org-openroadm-optical-transport-interfaces:ots
+     |  |  +--rw org-openroadm-optical-transport-interfaces:fiber-type?                       enumeration
+     |  |  +--rw org-openroadm-optical-transport-interfaces:span-loss-receive?                org-openroadm-common-link-types:ratio-dB
+     |  |  +--rw org-openroadm-optical-transport-interfaces:span-loss-transmit?               org-openroadm-common-link-types:ratio-dB
+     |  |  +--rw org-openroadm-optical-transport-interfaces:ingress-span-loss-aging-margin?   org-openroadm-common-link-types:ratio-dB
+     |  |  +--rw org-openroadm-optical-transport-interfaces:eol-max-load-pIn?                 org-openroadm-common-link-types:power-dBm
+     |  +--rw org-openroadm-gcc-interfaces:gcc
+     |  |  +--rw org-openroadm-gcc-interfaces:gcc-channel-type?   enumeration
+     |  +--rw org-openroadm-optical-tributary-signal-interfaces:otsi
+     |  |  +--rw org-openroadm-optical-tributary-signal-interfaces:provision-mode?             org-openroadm-common-optical-channel-types:provision-mode-type
+     |  |  +--rw org-openroadm-optical-tributary-signal-interfaces:otsi-rate?                  identityref
+     |  |  +--rw org-openroadm-optical-tributary-signal-interfaces:otsi-member-id?             uint16
+     |  |  +--rw org-openroadm-optical-tributary-signal-interfaces:frequency?                  org-openroadm-common-optical-channel-types:frequency-THz
+     |  |  +--ro org-openroadm-optical-tributary-signal-interfaces:width?                      org-openroadm-common-optical-channel-types:frequency-GHz
+     |  |  +--ro org-openroadm-optical-tributary-signal-interfaces:full-bandwidth-at-3dB?      org-openroadm-common-optical-channel-types:frequency-GHz
+     |  |  +--ro org-openroadm-optical-tributary-signal-interfaces:full-bandwidth-at-10dB?     org-openroadm-common-optical-channel-types:frequency-GHz
+     |  |  +--rw org-openroadm-optical-tributary-signal-interfaces:enable-laser?               enumeration
+     |  |  +--ro org-openroadm-optical-tributary-signal-interfaces:laser-status?               enumeration
+     |  |  +--rw org-openroadm-optical-tributary-signal-interfaces:modulation-format?          org-openroadm-common-optical-channel-types:modulation-format
+     |  |  +--rw org-openroadm-optical-tributary-signal-interfaces:transmit-power?             org-openroadm-common-link-types:power-dBm
+     |  |  +--rw org-openroadm-optical-tributary-signal-interfaces:fec?                        identityref
+     |  |  +--rw org-openroadm-optical-tributary-signal-interfaces:optical-operational-mode?   string
+     |  |  +--ro org-openroadm-optical-tributary-signal-interfaces:operational-mode-params
+     |  |  |  +--ro org-openroadm-optical-tributary-signal-interfaces:spectral-width?   org-openroadm-common-optical-channel-types:frequency-GHz
+     |  |  +--ro org-openroadm-optical-tributary-signal-interfaces:supported-group-if?         -> /org-openroadm-device:org-openroadm-device/interface/name
+     |  |  +--rw org-openroadm-optical-tributary-signal-interfaces:flexo!
+     |  |     +--rw org-openroadm-optical-tributary-signal-interfaces:foic-type?             identityref
+     |  |     +--rw org-openroadm-optical-tributary-signal-interfaces:iid*                   uint8
+     |  |     +--ro org-openroadm-optical-tributary-signal-interfaces:accepted-group-id*     uint32
+     |  |     +--ro org-openroadm-optical-tributary-signal-interfaces:accepted-iid*          uint8
+     |  |     +--ro org-openroadm-optical-tributary-signal-interfaces:accepted-payload-id*   org-openroadm-otn-common-types:flexo-payload-type-def
+     |  +--rw org-openroadm-fcc-interfaces:fcc
+     |  |  +--rw org-openroadm-fcc-interfaces:fcc-channel-type?   enumeration
+     |  +--rw org-openroadm-optical-channel-interfaces:och
+     |  |  +--rw org-openroadm-optical-channel-interfaces:provision-mode?             org-openroadm-common-optical-channel-types:provision-mode-type
+     |  |  +--rw org-openroadm-optical-channel-interfaces:rate?                       identityref
+     |  |  +--rw org-openroadm-optical-channel-interfaces:frequency?                  org-openroadm-common-optical-channel-types:frequency-THz
+     |  |  +--ro org-openroadm-optical-channel-interfaces:width?                      org-openroadm-common-optical-channel-types:frequency-GHz
+     |  |  +--ro org-openroadm-optical-channel-interfaces:full-bandwidth-at-3dB?      org-openroadm-common-optical-channel-types:frequency-GHz
+     |  |  +--ro org-openroadm-optical-channel-interfaces:full-bandwidth-at-10dB?     org-openroadm-common-optical-channel-types:frequency-GHz
+     |  |  +--rw org-openroadm-optical-channel-interfaces:enable-laser?               enumeration
+     |  |  +--ro org-openroadm-optical-channel-interfaces:laser-status?               enumeration
+     |  |  +--rw org-openroadm-optical-channel-interfaces:modulation-format?          org-openroadm-common-optical-channel-types:modulation-format
+     |  |  +--rw org-openroadm-optical-channel-interfaces:transmit-power?             org-openroadm-common-link-types:power-dBm
+     |  |  +--rw org-openroadm-optical-channel-interfaces:optical-operational-mode?   string
+     |  |  +--ro org-openroadm-optical-channel-interfaces:operational-mode-params
+     |  |     +--ro org-openroadm-optical-channel-interfaces:spectral-width?   org-openroadm-common-optical-channel-types:frequency-GHz
      |  +--rw org-openroadm-otsi-group-interfaces:otsi-group
-     |     +--rw org-openroadm-otsi-group-interfaces:group-rate?              identityref
-     |     +--rw org-openroadm-otsi-group-interfaces:group-id?                uint32
-     |     +--rw org-openroadm-otsi-group-interfaces:flexo-group-container!
-     |     |  +--rw org-openroadm-otsi-group-interfaces:payload-id?   org-openroadm-otn-common-types:flexo-payload-type-def
-     |     |  +--ro org-openroadm-otsi-group-interfaces:tx-msi* [index]
-     |     |  |  +--ro org-openroadm-otsi-group-interfaces:index          uint16
-     |     |  |  +--ro org-openroadm-otsi-group-interfaces:instance-id?   uint16
-     |     |  |  +--ro org-openroadm-otsi-group-interfaces:occupation?    boolean
-     |     |  |  +--ro org-openroadm-otsi-group-interfaces:trib-port?     uint16
-     |     |  +--ro org-openroadm-otsi-group-interfaces:rx-msi* [index]
-     |     |  |  +--ro org-openroadm-otsi-group-interfaces:index          uint16
-     |     |  |  +--ro org-openroadm-otsi-group-interfaces:instance-id?   uint16
-     |     |  |  +--ro org-openroadm-otsi-group-interfaces:occupation?    boolean
-     |     |  |  +--ro org-openroadm-otsi-group-interfaces:trib-port?     uint16
-     |     |  +--ro org-openroadm-otsi-group-interfaces:exp-msi* [index]
-     |     |     +--ro org-openroadm-otsi-group-interfaces:index          uint16
-     |     |     +--ro org-openroadm-otsi-group-interfaces:instance-id?   uint16
-     |     |     +--ro org-openroadm-otsi-group-interfaces:occupation?    boolean
-     |     |     +--ro org-openroadm-otsi-group-interfaces:trib-port?     uint16
-     |     +--rw org-openroadm-otsi-group-interfaces:maint-testsignal
-     |     |  +---x org-openroadm-otsi-group-interfaces:clear-diagnostics
-     |     |  |  +---w org-openroadm-otsi-group-interfaces:input
-     |     |  |  |  +---w org-openroadm-otsi-group-interfaces:type?   testsig-type
-     |     |  |  +--ro org-openroadm-otsi-group-interfaces:output
-     |     |  |     +--ro org-openroadm-otsi-group-interfaces:status            org-openroadm-common-types:rpc-status
-     |     |  |     +--ro org-openroadm-otsi-group-interfaces:status-message?   string
-     |     |  +--rw org-openroadm-otsi-group-interfaces:enabled?             boolean
-     |     |  +--rw org-openroadm-otsi-group-interfaces:testPattern          enumeration
-     |     |  +--rw org-openroadm-otsi-group-interfaces:type?                testsig-type
-     |     |  +--ro org-openroadm-otsi-group-interfaces:inSync?              boolean
-     |     |  +--ro org-openroadm-otsi-group-interfaces:seconds              uint32
-     |     |  +--ro org-openroadm-otsi-group-interfaces:bitErrors?           uint32
-     |     |  +--ro org-openroadm-otsi-group-interfaces:bitErrorRate?        decimal64
-     |     +--rw org-openroadm-otsi-group-interfaces:maint-loopback
-     |        +--rw org-openroadm-otsi-group-interfaces:enabled?   boolean
-     |        +--rw org-openroadm-otsi-group-interfaces:type?      enumeration
+     |  |  +--rw org-openroadm-otsi-group-interfaces:group-rate?              identityref
+     |  |  +--rw org-openroadm-otsi-group-interfaces:group-id?                uint32
+     |  |  +--rw org-openroadm-otsi-group-interfaces:flexo-group-container!
+     |  |  |  +--rw org-openroadm-otsi-group-interfaces:payload-id?   org-openroadm-otn-common-types:flexo-payload-type-def
+     |  |  |  +--ro org-openroadm-otsi-group-interfaces:tx-msi* [index]
+     |  |  |  |  +--ro org-openroadm-otsi-group-interfaces:index          uint16
+     |  |  |  |  +--ro org-openroadm-otsi-group-interfaces:instance-id?   uint16
+     |  |  |  |  +--ro org-openroadm-otsi-group-interfaces:occupation?    boolean
+     |  |  |  |  +--ro org-openroadm-otsi-group-interfaces:trib-port?     uint16
+     |  |  |  +--ro org-openroadm-otsi-group-interfaces:rx-msi* [index]
+     |  |  |  |  +--ro org-openroadm-otsi-group-interfaces:index          uint16
+     |  |  |  |  +--ro org-openroadm-otsi-group-interfaces:instance-id?   uint16
+     |  |  |  |  +--ro org-openroadm-otsi-group-interfaces:occupation?    boolean
+     |  |  |  |  +--ro org-openroadm-otsi-group-interfaces:trib-port?     uint16
+     |  |  |  +--ro org-openroadm-otsi-group-interfaces:exp-msi* [index]
+     |  |  |     +--ro org-openroadm-otsi-group-interfaces:index          uint16
+     |  |  |     +--ro org-openroadm-otsi-group-interfaces:instance-id?   uint16
+     |  |  |     +--ro org-openroadm-otsi-group-interfaces:occupation?    boolean
+     |  |  |     +--ro org-openroadm-otsi-group-interfaces:trib-port?     uint16
+     |  |  +--rw org-openroadm-otsi-group-interfaces:maint-testsignal
+     |  |  |  +---x org-openroadm-otsi-group-interfaces:clear-diagnostics
+     |  |  |  |  +---w org-openroadm-otsi-group-interfaces:input
+     |  |  |  |  |  +---w org-openroadm-otsi-group-interfaces:type?   testsig-type
+     |  |  |  |  +--ro org-openroadm-otsi-group-interfaces:output
+     |  |  |  |     +--ro org-openroadm-otsi-group-interfaces:status            org-openroadm-common-types:rpc-status
+     |  |  |  |     +--ro org-openroadm-otsi-group-interfaces:status-message?   string
+     |  |  |  +--rw org-openroadm-otsi-group-interfaces:enabled?             boolean
+     |  |  |  +--rw org-openroadm-otsi-group-interfaces:testPattern          enumeration
+     |  |  |  +--rw org-openroadm-otsi-group-interfaces:type?                testsig-type
+     |  |  |  +--ro org-openroadm-otsi-group-interfaces:inSync?              boolean
+     |  |  |  +--ro org-openroadm-otsi-group-interfaces:seconds              uint32
+     |  |  |  +--ro org-openroadm-otsi-group-interfaces:bitErrors?           uint32
+     |  |  |  +--ro org-openroadm-otsi-group-interfaces:bitErrorRate?        decimal64
+     |  |  +--rw org-openroadm-otsi-group-interfaces:maint-loopback
+     |  |     +--rw org-openroadm-otsi-group-interfaces:enabled?   boolean
+     |  |     +--rw org-openroadm-otsi-group-interfaces:type?      enumeration
+     |  +--rw org-openroadm-media-channel-interfaces:mc-ttp
+     |  |  +--rw org-openroadm-media-channel-interfaces:min-freq?      org-openroadm-common-optical-channel-types:frequency-THz
+     |  |  +--rw org-openroadm-media-channel-interfaces:max-freq?      org-openroadm-common-optical-channel-types:frequency-THz
+     |  |  +--ro org-openroadm-media-channel-interfaces:center-freq?   org-openroadm-common-optical-channel-types:frequency-THz
+     |  |  +--ro org-openroadm-media-channel-interfaces:slot-width?    org-openroadm-common-optical-channel-types:frequency-GHz
+     |  +--rw org-openroadm-network-media-channel-interfaces:nmc-ctp
+     |     +--rw org-openroadm-network-media-channel-interfaces:frequency?                org-openroadm-common-optical-channel-types:frequency-THz
+     |     +--rw org-openroadm-network-media-channel-interfaces:width?                    org-openroadm-common-optical-channel-types:frequency-GHz
+     |     +--rw org-openroadm-network-media-channel-interfaces:full-bandwidth-at-3dB?    org-openroadm-common-optical-channel-types:frequency-GHz
+     |     +--rw org-openroadm-network-media-channel-interfaces:full-bandwidth-at-10dB?   org-openroadm-common-optical-channel-types:frequency-GHz
      +--rw protection-grps
-     |  +--rw org-openroadm-prot-equipment-aps:circuit-pack-pg* [name]
-     |  |  +--rw org-openroadm-prot-equipment-aps:name                 string
-     |  |  +--rw org-openroadm-prot-equipment-aps:prot-architecture    prot-architecture-type
-     |  |  +--ro org-openroadm-prot-equipment-aps:service-state        pg-service-state-type
-     |  |  +--ro org-openroadm-prot-equipment-aps:redundancy-state     pg-redundancy-state-type
-     |  |  +--ro org-openroadm-prot-equipment-aps:lockout-state?       pg-lockout-state-type
-     |  |  +--rw org-openroadm-prot-equipment-aps:cp-pg-descriptor* [name]
-     |  |     +--rw org-openroadm-prot-equipment-aps:name               string
-     |  |     +--rw org-openroadm-prot-equipment-aps:pg-circuit-pack    -> /org-openroadm-device:org-openroadm-device/circuit-packs/circuit-pack-name
-     |  |     +--ro org-openroadm-prot-equipment-aps:member-state       pg-member-state-type
-     |  |     +--ro org-openroadm-prot-equipment-aps:switch-request     pg-member-switch-request-type
-     |  |     +--ro org-openroadm-prot-equipment-aps:member-active      boolean
      |  +--rw org-openroadm-prot-otn-linear-aps:odu-sncp-pg* [name]
      |  |  +--rw org-openroadm-prot-otn-linear-aps:name                   string
      |  |  +--rw org-openroadm-prot-otn-linear-aps:level                  protection-level-type
@@ -848,18 +836,30 @@ module: org-openroadm-device
      |  |  +--ro org-openroadm-prot-otn-linear-aps:active-if?             -> /org-openroadm-device:org-openroadm-device/interface/name
      |  |  +--ro org-openroadm-prot-otn-linear-aps:request-state?         request-state-type
      |  +--rw org-openroadm-prot-otn-linear-aps:client-sncp-pg* [name]
-     |     +--rw org-openroadm-prot-otn-linear-aps:name                   string
-     |     +--rw org-openroadm-prot-otn-linear-aps:switching-direction?   switching-direction-type
-     |     +--rw org-openroadm-prot-otn-linear-aps:revertive?             boolean
-     |     +--rw org-openroadm-prot-otn-linear-aps:sd-enable?             boolean
-     |     +--rw org-openroadm-prot-otn-linear-aps:wait-to-restore?       uint8
-     |     +--rw org-openroadm-prot-otn-linear-aps:holdoff-timer
-     |     |  +--rw org-openroadm-prot-otn-linear-aps:holdoff?              uint8
-     |     |  +--rw org-openroadm-prot-otn-linear-aps:holdoff-multiplier?   uint8
-     |     +--rw org-openroadm-prot-otn-linear-aps:working-if             -> /org-openroadm-device:org-openroadm-device/interface/name
-     |     +--rw org-openroadm-prot-otn-linear-aps:pg-interfaces*         -> /org-openroadm-device:org-openroadm-device/interface/name
-     |     +--ro org-openroadm-prot-otn-linear-aps:active-if?             -> /org-openroadm-device:org-openroadm-device/interface/name
-     |     +--ro org-openroadm-prot-otn-linear-aps:request-state?         request-state-type
+     |  |  +--rw org-openroadm-prot-otn-linear-aps:name                   string
+     |  |  +--rw org-openroadm-prot-otn-linear-aps:switching-direction?   switching-direction-type
+     |  |  +--rw org-openroadm-prot-otn-linear-aps:revertive?             boolean
+     |  |  +--rw org-openroadm-prot-otn-linear-aps:sd-enable?             boolean
+     |  |  +--rw org-openroadm-prot-otn-linear-aps:wait-to-restore?       uint8
+     |  |  +--rw org-openroadm-prot-otn-linear-aps:holdoff-timer
+     |  |  |  +--rw org-openroadm-prot-otn-linear-aps:holdoff?              uint8
+     |  |  |  +--rw org-openroadm-prot-otn-linear-aps:holdoff-multiplier?   uint8
+     |  |  +--rw org-openroadm-prot-otn-linear-aps:working-if             -> /org-openroadm-device:org-openroadm-device/interface/name
+     |  |  +--rw org-openroadm-prot-otn-linear-aps:pg-interfaces*         -> /org-openroadm-device:org-openroadm-device/interface/name
+     |  |  +--ro org-openroadm-prot-otn-linear-aps:active-if?             -> /org-openroadm-device:org-openroadm-device/interface/name
+     |  |  +--ro org-openroadm-prot-otn-linear-aps:request-state?         request-state-type
+     |  +--rw org-openroadm-prot-equipment-aps:circuit-pack-pg* [name]
+     |     +--rw org-openroadm-prot-equipment-aps:name                 string
+     |     +--rw org-openroadm-prot-equipment-aps:prot-architecture    prot-architecture-type
+     |     +--ro org-openroadm-prot-equipment-aps:service-state        pg-service-state-type
+     |     +--ro org-openroadm-prot-equipment-aps:redundancy-state     pg-redundancy-state-type
+     |     +--ro org-openroadm-prot-equipment-aps:lockout-state?       pg-lockout-state-type
+     |     +--rw org-openroadm-prot-equipment-aps:cp-pg-descriptor* [name]
+     |        +--rw org-openroadm-prot-equipment-aps:name               string
+     |        +--rw org-openroadm-prot-equipment-aps:pg-circuit-pack    -> /org-openroadm-device:org-openroadm-device/circuit-packs/circuit-pack-name
+     |        +--ro org-openroadm-prot-equipment-aps:member-state       pg-member-state-type
+     |        +--ro org-openroadm-prot-equipment-aps:switch-request     pg-member-switch-request-type
+     |        +--ro org-openroadm-prot-equipment-aps:member-active      boolean
      +--ro protection-profiles
      |  +--ro org-openroadm-prot-otn-linear-aps:protection-profile* [profile-name]
      |     +--ro org-openroadm-prot-otn-linear-aps:profile-name            string
@@ -871,6 +871,48 @@ module: org-openroadm-device
      |     +--ro org-openroadm-prot-otn-linear-aps:pg-capabilities-list*   pg-capabilities-type
      +--rw protocols
      |  +--rw lifecycle-state?                      org-openroadm-common-state-types:lifecycle-state
+     |  +--rw org-openroadm-gnmi:gnmi
+     |  |  +--rw org-openroadm-gnmi:enabled?          boolean
+     |  |  +--rw org-openroadm-gnmi:certificate-id?   -> /org-openroadm-device:org-openroadm-device/org-openroadm-security:security/certificate/certificate-id
+     |  |  +--rw org-openroadm-gnmi:port?             inet:port-number
+     |  +--rw org-openroadm-rstp:rstp
+     |  |  +--ro org-openroadm-rstp:max-bridge-instances?   uint32
+     |  |  +--rw org-openroadm-rstp:rstp-bridge-instance* [bridge-name]
+     |  |     +--rw org-openroadm-rstp:bridge-name    string
+     |  |     +--rw org-openroadm-rstp:rstp-config
+     |  |     |  +--rw org-openroadm-rstp:bridge-priority?          uint32
+     |  |     |  +--rw org-openroadm-rstp:shutdown?                 empty
+     |  |     |  +--rw org-openroadm-rstp:hold-time?                uint32
+     |  |     |  +--rw org-openroadm-rstp:hello-time?               uint32
+     |  |     |  +--rw org-openroadm-rstp:max-age?                  uint32
+     |  |     |  +--rw org-openroadm-rstp:forward-delay?            uint32
+     |  |     |  +--rw org-openroadm-rstp:transmit-hold-count?      uint32
+     |  |     |  +--rw org-openroadm-rstp:rstp-bridge-port-table* [ifname]
+     |  |     |     +--rw org-openroadm-rstp:ifname      -> /org-openroadm-device:org-openroadm-device/interface/name
+     |  |     |     +--rw org-openroadm-rstp:cost?       uint32
+     |  |     |     +--rw org-openroadm-rstp:priority?   uint32
+     |  |     +--ro org-openroadm-rstp:rstp-state
+     |  |        +--ro org-openroadm-rstp:rstp-bridge-attr
+     |  |        |  +--ro org-openroadm-rstp:root-bridge-port?         uint32
+     |  |        |  +--ro org-openroadm-rstp:root-path-cost?           uint32
+     |  |        |  +--ro org-openroadm-rstp:root-bridge-priority?     uint32
+     |  |        |  +--ro org-openroadm-rstp:root-bridge-id?           bridge-id-type
+     |  |        |  +--ro org-openroadm-rstp:root-hold-time?           uint32
+     |  |        |  +--ro org-openroadm-rstp:root-hello-time?          uint32
+     |  |        |  +--ro org-openroadm-rstp:root-max-age?             uint32
+     |  |        |  +--ro org-openroadm-rstp:root-forward-delay?       uint32
+     |  |        |  +--ro org-openroadm-rstp:bridge-id?                bridge-id-type
+     |  |        |  +--ro org-openroadm-rstp:topo-change-count?        uint32
+     |  |        |  +--ro org-openroadm-rstp:time-since-topo-change?   uint32
+     |  |        +--ro org-openroadm-rstp:rstp-bridge-port-attr
+     |  |           +--ro org-openroadm-rstp:rstp-bridge-port-table* [ifname]
+     |  |              +--ro org-openroadm-rstp:ifname                    string
+     |  |              +--ro org-openroadm-rstp:bridge-port-state?        enumeration
+     |  |              +--ro org-openroadm-rstp:bridge-port-role?         enumeration
+     |  |              +--ro org-openroadm-rstp:bridge-port-id?           uint32
+     |  |              +--ro org-openroadm-rstp:oper-edge-bridge-port?    empty
+     |  |              +--ro org-openroadm-rstp:designated-bridge-port?   uint32
+     |  |              +--ro org-openroadm-rstp:designated-bridgeid?      bridge-id-type
      |  +--rw org-openroadm-dhcp:ipv4-dhcp-relay
      |  |  +--rw org-openroadm-dhcp:ipv4-server-group* [server-group-name]
      |  |     +--rw org-openroadm-dhcp:server-group-name    string
@@ -881,66 +923,24 @@ module: org-openroadm-device
      |  |     +--rw org-openroadm-dhcp:server-group-name    string
      |  |     +--rw org-openroadm-dhcp:interface-name*      -> /org-openroadm-device:org-openroadm-device/interface/name
      |  |     +--rw org-openroadm-dhcp:server-address*      ietf-inet-types:ipv6-address
-     |  +--rw org-openroadm-gnmi:gnmi
-     |  |  +--rw org-openroadm-gnmi:enabled?          boolean
-     |  |  +--rw org-openroadm-gnmi:certificate-id?   -> /org-openroadm-device:org-openroadm-device/org-openroadm-security:security/certificate/certificate-id
-     |  |  +--rw org-openroadm-gnmi:port?             inet:port-number
      |  +--rw org-openroadm-lldp:lldp
-     |  |  +--rw org-openroadm-lldp:global-config
-     |  |  |  +--rw org-openroadm-lldp:adminStatus?           enumeration
-     |  |  |  +--rw org-openroadm-lldp:msgTxInterval?         uint16
-     |  |  |  +--rw org-openroadm-lldp:msgTxHoldMultiplier?   uint8
-     |  |  +--rw org-openroadm-lldp:port-config* [ifName]
-     |  |  |  +--rw org-openroadm-lldp:ifName         -> /org-openroadm-device:org-openroadm-device/interface/name
-     |  |  |  +--rw org-openroadm-lldp:adminStatus?   enumeration
-     |  |  +--ro org-openroadm-lldp:nbr-list
-     |  |     +--ro org-openroadm-lldp:if-name* [ifName]
-     |  |        +--ro org-openroadm-lldp:ifName                      string
-     |  |        +--ro org-openroadm-lldp:remoteSysName?              string
-     |  |        +--ro org-openroadm-lldp:remoteMgmtAddressSubType?   ianaaf:address-family
-     |  |        +--ro org-openroadm-lldp:remoteMgmtAddress?          inet:ip-address
-     |  |        +--ro org-openroadm-lldp:remotePortIdSubType?        enumeration
-     |  |        +--ro org-openroadm-lldp:remotePortId?               string
-     |  |        +--ro org-openroadm-lldp:remoteChassisIdSubType?     enumeration
-     |  |        +--ro org-openroadm-lldp:remoteChassisId?            string
-     |  +--rw org-openroadm-rstp:rstp
-     |     +--ro org-openroadm-rstp:max-bridge-instances?   uint32
-     |     +--rw org-openroadm-rstp:rstp-bridge-instance* [bridge-name]
-     |        +--rw org-openroadm-rstp:bridge-name    string
-     |        +--rw org-openroadm-rstp:rstp-config
-     |        |  +--rw org-openroadm-rstp:bridge-priority?          uint32
-     |        |  +--rw org-openroadm-rstp:shutdown?                 empty
-     |        |  +--rw org-openroadm-rstp:hold-time?                uint32
-     |        |  +--rw org-openroadm-rstp:hello-time?               uint32
-     |        |  +--rw org-openroadm-rstp:max-age?                  uint32
-     |        |  +--rw org-openroadm-rstp:forward-delay?            uint32
-     |        |  +--rw org-openroadm-rstp:transmit-hold-count?      uint32
-     |        |  +--rw org-openroadm-rstp:rstp-bridge-port-table* [ifname]
-     |        |     +--rw org-openroadm-rstp:ifname      -> /org-openroadm-device:org-openroadm-device/interface/name
-     |        |     +--rw org-openroadm-rstp:cost?       uint32
-     |        |     +--rw org-openroadm-rstp:priority?   uint32
-     |        +--ro org-openroadm-rstp:rstp-state
-     |           +--ro org-openroadm-rstp:rstp-bridge-attr
-     |           |  +--ro org-openroadm-rstp:root-bridge-port?         uint32
-     |           |  +--ro org-openroadm-rstp:root-path-cost?           uint32
-     |           |  +--ro org-openroadm-rstp:root-bridge-priority?     uint32
-     |           |  +--ro org-openroadm-rstp:root-bridge-id?           bridge-id-type
-     |           |  +--ro org-openroadm-rstp:root-hold-time?           uint32
-     |           |  +--ro org-openroadm-rstp:root-hello-time?          uint32
-     |           |  +--ro org-openroadm-rstp:root-max-age?             uint32
-     |           |  +--ro org-openroadm-rstp:root-forward-delay?       uint32
-     |           |  +--ro org-openroadm-rstp:bridge-id?                bridge-id-type
-     |           |  +--ro org-openroadm-rstp:topo-change-count?        uint32
-     |           |  +--ro org-openroadm-rstp:time-since-topo-change?   uint32
-     |           +--ro org-openroadm-rstp:rstp-bridge-port-attr
-     |              +--ro org-openroadm-rstp:rstp-bridge-port-table* [ifname]
-     |                 +--ro org-openroadm-rstp:ifname                    string
-     |                 +--ro org-openroadm-rstp:bridge-port-state?        enumeration
-     |                 +--ro org-openroadm-rstp:bridge-port-role?         enumeration
-     |                 +--ro org-openroadm-rstp:bridge-port-id?           uint32
-     |                 +--ro org-openroadm-rstp:oper-edge-bridge-port?    empty
-     |                 +--ro org-openroadm-rstp:designated-bridge-port?   uint32
-     |                 +--ro org-openroadm-rstp:designated-bridgeid?      bridge-id-type
+     |     +--rw org-openroadm-lldp:global-config
+     |     |  +--rw org-openroadm-lldp:adminStatus?           enumeration
+     |     |  +--rw org-openroadm-lldp:msgTxInterval?         uint16
+     |     |  +--rw org-openroadm-lldp:msgTxHoldMultiplier?   uint8
+     |     +--rw org-openroadm-lldp:port-config* [ifName]
+     |     |  +--rw org-openroadm-lldp:ifName         -> /org-openroadm-device:org-openroadm-device/interface/name
+     |     |  +--rw org-openroadm-lldp:adminStatus?   enumeration
+     |     +--ro org-openroadm-lldp:nbr-list
+     |        +--ro org-openroadm-lldp:if-name* [ifName]
+     |           +--ro org-openroadm-lldp:ifName                      string
+     |           +--ro org-openroadm-lldp:remoteSysName?              string
+     |           +--ro org-openroadm-lldp:remoteMgmtAddressSubType?   ianaaf:address-family
+     |           +--ro org-openroadm-lldp:remoteMgmtAddress?          inet:ip-address
+     |           +--ro org-openroadm-lldp:remotePortIdSubType?        enumeration
+     |           +--ro org-openroadm-lldp:remotePortId?               string
+     |           +--ro org-openroadm-lldp:remoteChassisIdSubType?     enumeration
+     |           +--ro org-openroadm-lldp:remoteChassisId?            string
      +--ro internal-link* [internal-link-name]
      |  +--ro internal-link-name    string
      |  +--ro source
@@ -980,6 +980,9 @@ module: org-openroadm-device
      |  |  +--rw circuit-pack-name    -> /org-openroadm-device/circuit-packs/circuit-pack-name
      |  +--rw connection-ports* [index]
      |  |  +--rw index                uint32
+     |  |  +--rw circuit-pack-name    -> /org-openroadm-device/circuit-packs/circuit-pack-name
+     |  |  +--rw port-name            -> /org-openroadm-device/circuit-packs[circuit-pack-name=current()/../circuit-pack-name]/ports/port-name
+     |  +--rw osc-port
      |  |  +--rw circuit-pack-name    -> /org-openroadm-device/circuit-packs/circuit-pack-name
      |  |  +--rw port-name            -> /org-openroadm-device/circuit-packs[circuit-pack-name=current()/../circuit-pack-name]/ports/port-name
      |  +--rw otdr-port

--- a/model/Device/tree-view-device.txt
+++ b/model/Device/tree-view-device.txt
@@ -1067,6 +1067,7 @@ module: org-openroadm-device
      +--rw roadm-connections* [connection-name]
      |  +--rw connection-name        string
      |  +--rw opticalControlMode?    org-openroadm-common-link-types:optical-control-mode
+     |  +--ro actual-control-mode    org-openroadm-common-link-types:act-optical-control-mode
      |  +--rw target-output-power?   org-openroadm-common-link-types:power-dBm
      |  +--rw source
      |  |  +--rw src-if    -> /org-openroadm-device/interface/name
@@ -1994,6 +1995,33 @@ module: org-openroadm-native-data
           +--ro status            rpc-status
           +--ro status-message?   string
           +--ro get-response?     string
+
+module: org-openroadm-optical-rebalancing
+
+  rpcs:
+    +---x adjust-optical-power
+       +---w input
+       |  +---w (adjust-scope)?
+       |  |  +--:(roadm-connections)
+       |  |  |  +---w connection-name*    -> /org-openroadm-device:org-openroadm-device/roadm-connections/connection-name
+       |  |  +--:(ingress-oms)
+       |  |  |  +---w ingress-oms         -> /org-openroadm-device:org-openroadm-device/interface/name
+       |  |  +--:(egress-oms)
+       |  |     +---w egress-oms          -> /org-openroadm-device:org-openroadm-device/interface/name
+       |  +---w target-power-threshold?   org-openroadm-common-link-types:ratio-dB
+       +--ro output
+          +--ro status            rpc-status
+          +--ro status-message?   string
+
+  notifications:
+    +---n adjust-optical-power-result
+       +--ro status                extended-rpc-status
+       +--ro status-message?       string
+       +--ro failed-connections
+          +--ro failed-connection* [connection-name]
+             +--ro connection-name     string
+             +--ro failure-reason      string
+             +--ro reversion-failed    boolean
 
 module: org-openroadm-ospf
 

--- a/model/Device/tree-view-device.txt
+++ b/model/Device/tree-view-device.txt
@@ -184,7 +184,15 @@ module: org-openroadm-de-operations
        |  |     |  +---w versioned-service-name    string
        |  |     |  +---w version-number            uint64
        |  |     +--:(temp-service)
-       |  |        +---w common-id                 string
+       |  |     |  +---w common-id                 string
+       |  |     +--:(slot)
+       |  |     |  +---w slot
+       |  |     |     +---w shelf-name    string
+       |  |     |     +---w slot-name     string
+       |  |     +--:(cp-slot)
+       |  |        +---w cp-slot
+       |  |           +---w circuit-pack-name    string
+       |  |           +---w slot-name            string
        |  +---w resourceType
        |  |  +---w type         resource-type-enum
        |  |  +---w extension?   string
@@ -239,7 +247,15 @@ module: org-openroadm-de-operations
        |     |  +--ro versioned-service-name    string
        |     |  +--ro version-number            uint64
        |     +--:(temp-service)
-       |        +--ro common-id                 string
+       |     |  +--ro common-id                 string
+       |     +--:(slot)
+       |     |  +--ro slot
+       |     |     +--ro shelf-name    string
+       |     |     +--ro slot-name     string
+       |     +--:(cp-slot)
+       |        +--ro cp-slot
+       |           +--ro circuit-pack-name    string
+       |           +--ro slot-name            string
        +--ro resourceType
           +--ro type         resource-type-enum
           +--ro extension?   string

--- a/model/Device/tree-view-device.txt
+++ b/model/Device/tree-view-device.txt
@@ -255,6 +255,7 @@ module: org-openroadm-device
      |  +--ro vendor                              string
      |  +--ro model                               string
      |  +--ro serial-id                           string
+     |  +--ro oamp-interface-name?                string
      |  +--ro macAddress?                         ietf-yang-types:mac-address
      |  +--ro softwareVersion?                    string
      |  +--ro software-build?                     string

--- a/model/Device/tree-view-device.txt
+++ b/model/Device/tree-view-device.txt
@@ -1965,6 +1965,17 @@ module: org-openroadm-lldp
        |  +--ro remoteChassisId?            string
        +--ro event-time?          yang:date-and-time
 
+module: org-openroadm-native-data
+
+  rpcs:
+    +---x get-native-data
+       +---w input
+       |  +---w get-request?   string
+       +--ro output
+          +--ro status            rpc-status
+          +--ro status-message?   string
+          +--ro get-response?     string
+
 module: org-openroadm-ospf
 
   notifications:

--- a/model/Device/tree-view-device.txt
+++ b/model/Device/tree-view-device.txt
@@ -508,6 +508,47 @@ module: org-openroadm-device
      |  +--rw supporting-interface-list*                                -> /org-openroadm-device/interface/name
      |  +--rw common-functions
      |  |  +--ro org-openroadm-prot-otn-linear-aps:protection-profile-name*   -> /org-openroadm-device:org-openroadm-device/protection-profiles/org-openroadm-prot-otn-linear-aps:protection-profile/profile-name
+     |  +--rw org-openroadm-eth-interfaces:ethernet
+     |  |  +--rw org-openroadm-eth-interfaces:speed?                          uint32
+     |  |  +--rw org-openroadm-eth-interfaces:eth-function?                   eth-function-type
+     |  |  +--rw org-openroadm-eth-interfaces:fec?                            identityref
+     |  |  +--rw org-openroadm-eth-interfaces:egress-consequent-action?       enumeration
+     |  |  +--rw org-openroadm-eth-interfaces:duplex?                         enumeration
+     |  |  +--rw org-openroadm-eth-interfaces:auto-negotiation?               enumeration
+     |  |  +--rw org-openroadm-eth-interfaces:enable-laser?                   enumeration
+     |  |  +--ro org-openroadm-eth-interfaces:laser-status?                   enumeration
+     |  |  +--ro org-openroadm-eth-interfaces:curr-speed?                     string
+     |  |  +--ro org-openroadm-eth-interfaces:curr-duplex?                    string
+     |  |  +--ro org-openroadm-eth-interfaces:max-frame-size?                 uint32
+     |  |  +--rw org-openroadm-eth-interfaces:subrate-eth-sla!
+     |  |  |  +--rw org-openroadm-eth-interfaces:committed-info-rate     uint32
+     |  |  |  +--rw org-openroadm-eth-interfaces:committed-burst-size    uint16
+     |  |  +--ro org-openroadm-eth-interfaces:no-oam-function?                empty
+     |  |  +--ro org-openroadm-eth-interfaces:no-maint-testsignal-function?   empty
+     |  |  +--rw org-openroadm-eth-interfaces:parent-flexo-allocation!
+     |  |  |  +--rw org-openroadm-eth-interfaces:trib-port-number    uint16
+     |  |  |  +--rw org-openroadm-eth-interfaces:iid*                uint16
+     |  |  +--rw org-openroadm-eth-interfaces:maint-testsignal
+     |  |  |  +---x org-openroadm-eth-interfaces:clear-diagnostics
+     |  |  |  |  +---w org-openroadm-eth-interfaces:input
+     |  |  |  |  |  +---w org-openroadm-eth-interfaces:type?   testsig-type
+     |  |  |  |  +--ro org-openroadm-eth-interfaces:output
+     |  |  |  |     +--ro org-openroadm-eth-interfaces:status            org-openroadm-common-types:rpc-status
+     |  |  |  |     +--ro org-openroadm-eth-interfaces:status-message?   string
+     |  |  |  +--rw org-openroadm-eth-interfaces:enabled?             boolean
+     |  |  |  +--rw org-openroadm-eth-interfaces:testPattern          enumeration
+     |  |  |  +--rw org-openroadm-eth-interfaces:type?                testsig-type
+     |  |  |  +--ro org-openroadm-eth-interfaces:inSync?              boolean
+     |  |  |  +--ro org-openroadm-eth-interfaces:seconds              uint32
+     |  |  |  +--ro org-openroadm-eth-interfaces:bitErrors?           uint32
+     |  |  |  +--ro org-openroadm-eth-interfaces:bitErrorRate?        decimal64
+     |  |  +--rw org-openroadm-eth-interfaces:maint-loopback
+     |  |     +--rw org-openroadm-eth-interfaces:enabled?   boolean
+     |  |     +--rw org-openroadm-eth-interfaces:type?      enumeration
+     |  +--rw org-openroadm-fcc-interfaces:fcc
+     |  |  +--rw org-openroadm-fcc-interfaces:fcc-channel-type?   enumeration
+     |  +--rw org-openroadm-gcc-interfaces:gcc
+     |  |  +--rw org-openroadm-gcc-interfaces:gcc-channel-type?   enumeration
      |  +--rw org-openroadm-ip:ipv4!
      |  |  +--rw org-openroadm-ip:enabled?             boolean
      |  |  +--rw org-openroadm-ip:forwarding?          boolean
@@ -563,6 +604,59 @@ module: org-openroadm-device
      |  |  |  +--ro org-openroadm-ip:prefix-length    uint8
      |  |  +--ro org-openroadm-ip:origin?       ip-address-origin
      |  |  +--ro org-openroadm-ip:status?       ipv6-address-status
+     |  +--rw org-openroadm-media-channel-interfaces:mc-ttp
+     |  |  +--rw org-openroadm-media-channel-interfaces:min-freq?      org-openroadm-common-optical-channel-types:frequency-THz
+     |  |  +--rw org-openroadm-media-channel-interfaces:max-freq?      org-openroadm-common-optical-channel-types:frequency-THz
+     |  |  +--ro org-openroadm-media-channel-interfaces:center-freq?   org-openroadm-common-optical-channel-types:frequency-THz
+     |  |  +--ro org-openroadm-media-channel-interfaces:slot-width?    org-openroadm-common-optical-channel-types:frequency-GHz
+     |  +--rw org-openroadm-network-media-channel-interfaces:nmc-ctp
+     |  |  +--rw org-openroadm-network-media-channel-interfaces:frequency?                org-openroadm-common-optical-channel-types:frequency-THz
+     |  |  +--rw org-openroadm-network-media-channel-interfaces:width?                    org-openroadm-common-optical-channel-types:frequency-GHz
+     |  |  +--rw org-openroadm-network-media-channel-interfaces:full-bandwidth-at-3dB?    org-openroadm-common-optical-channel-types:frequency-GHz
+     |  |  +--rw org-openroadm-network-media-channel-interfaces:full-bandwidth-at-10dB?   org-openroadm-common-optical-channel-types:frequency-GHz
+     |  +--rw org-openroadm-optical-channel-interfaces:och
+     |  |  +--rw org-openroadm-optical-channel-interfaces:provision-mode?             org-openroadm-common-optical-channel-types:provision-mode-type
+     |  |  +--rw org-openroadm-optical-channel-interfaces:rate?                       identityref
+     |  |  +--rw org-openroadm-optical-channel-interfaces:frequency?                  org-openroadm-common-optical-channel-types:frequency-THz
+     |  |  +--ro org-openroadm-optical-channel-interfaces:width?                      org-openroadm-common-optical-channel-types:frequency-GHz
+     |  |  +--ro org-openroadm-optical-channel-interfaces:full-bandwidth-at-3dB?      org-openroadm-common-optical-channel-types:frequency-GHz
+     |  |  +--ro org-openroadm-optical-channel-interfaces:full-bandwidth-at-10dB?     org-openroadm-common-optical-channel-types:frequency-GHz
+     |  |  +--rw org-openroadm-optical-channel-interfaces:enable-laser?               enumeration
+     |  |  +--ro org-openroadm-optical-channel-interfaces:laser-status?               enumeration
+     |  |  +--rw org-openroadm-optical-channel-interfaces:modulation-format?          org-openroadm-common-optical-channel-types:modulation-format
+     |  |  +--rw org-openroadm-optical-channel-interfaces:transmit-power?             org-openroadm-common-link-types:power-dBm
+     |  |  +--rw org-openroadm-optical-channel-interfaces:optical-operational-mode?   string
+     |  |  +--ro org-openroadm-optical-channel-interfaces:operational-mode-params
+     |  |     +--ro org-openroadm-optical-channel-interfaces:spectral-width?   org-openroadm-common-optical-channel-types:frequency-GHz
+     |  +--rw org-openroadm-optical-transport-interfaces:ots
+     |  |  +--rw org-openroadm-optical-transport-interfaces:fiber-type?                       enumeration
+     |  |  +--rw org-openroadm-optical-transport-interfaces:span-loss-receive?                org-openroadm-common-link-types:ratio-dB
+     |  |  +--rw org-openroadm-optical-transport-interfaces:span-loss-transmit?               org-openroadm-common-link-types:ratio-dB
+     |  |  +--rw org-openroadm-optical-transport-interfaces:ingress-span-loss-aging-margin?   org-openroadm-common-link-types:ratio-dB
+     |  |  +--rw org-openroadm-optical-transport-interfaces:eol-max-load-pIn?                 org-openroadm-common-link-types:power-dBm
+     |  +--rw org-openroadm-optical-tributary-signal-interfaces:otsi
+     |  |  +--rw org-openroadm-optical-tributary-signal-interfaces:provision-mode?             org-openroadm-common-optical-channel-types:provision-mode-type
+     |  |  +--rw org-openroadm-optical-tributary-signal-interfaces:otsi-rate?                  identityref
+     |  |  +--rw org-openroadm-optical-tributary-signal-interfaces:otsi-member-id?             uint16
+     |  |  +--rw org-openroadm-optical-tributary-signal-interfaces:frequency?                  org-openroadm-common-optical-channel-types:frequency-THz
+     |  |  +--ro org-openroadm-optical-tributary-signal-interfaces:width?                      org-openroadm-common-optical-channel-types:frequency-GHz
+     |  |  +--ro org-openroadm-optical-tributary-signal-interfaces:full-bandwidth-at-3dB?      org-openroadm-common-optical-channel-types:frequency-GHz
+     |  |  +--ro org-openroadm-optical-tributary-signal-interfaces:full-bandwidth-at-10dB?     org-openroadm-common-optical-channel-types:frequency-GHz
+     |  |  +--rw org-openroadm-optical-tributary-signal-interfaces:enable-laser?               enumeration
+     |  |  +--ro org-openroadm-optical-tributary-signal-interfaces:laser-status?               enumeration
+     |  |  +--rw org-openroadm-optical-tributary-signal-interfaces:modulation-format?          org-openroadm-common-optical-channel-types:modulation-format
+     |  |  +--rw org-openroadm-optical-tributary-signal-interfaces:transmit-power?             org-openroadm-common-link-types:power-dBm
+     |  |  +--rw org-openroadm-optical-tributary-signal-interfaces:fec?                        identityref
+     |  |  +--rw org-openroadm-optical-tributary-signal-interfaces:optical-operational-mode?   string
+     |  |  +--ro org-openroadm-optical-tributary-signal-interfaces:operational-mode-params
+     |  |  |  +--ro org-openroadm-optical-tributary-signal-interfaces:spectral-width?   org-openroadm-common-optical-channel-types:frequency-GHz
+     |  |  +--ro org-openroadm-optical-tributary-signal-interfaces:supported-group-if?         -> /org-openroadm-device:org-openroadm-device/interface/name
+     |  |  +--rw org-openroadm-optical-tributary-signal-interfaces:flexo!
+     |  |     +--rw org-openroadm-optical-tributary-signal-interfaces:foic-type?             identityref
+     |  |     +--rw org-openroadm-optical-tributary-signal-interfaces:iid*                   uint8
+     |  |     +--ro org-openroadm-optical-tributary-signal-interfaces:accepted-group-id*     uint32
+     |  |     +--ro org-openroadm-optical-tributary-signal-interfaces:accepted-iid*          uint8
+     |  |     +--ro org-openroadm-optical-tributary-signal-interfaces:accepted-payload-id*   org-openroadm-otn-common-types:flexo-payload-type-def
      |  +--rw org-openroadm-otn-odu-interfaces:odu!
      |  |  +--rw org-openroadm-otn-odu-interfaces:rate?                                  identityref
      |  |  +--rw org-openroadm-otn-odu-interfaces:oducn-n-rate?                          uint16
@@ -660,43 +754,6 @@ module: org-openroadm-device
      |  |     +--ro org-openroadm-otn-odu-interfaces:seconds              uint32
      |  |     +--ro org-openroadm-otn-odu-interfaces:bitErrors?           uint32
      |  |     +--ro org-openroadm-otn-odu-interfaces:bitErrorRate?        decimal64
-     |  +--rw org-openroadm-eth-interfaces:ethernet
-     |  |  +--rw org-openroadm-eth-interfaces:speed?                          uint32
-     |  |  +--rw org-openroadm-eth-interfaces:eth-function?                   eth-function-type
-     |  |  +--rw org-openroadm-eth-interfaces:fec?                            identityref
-     |  |  +--rw org-openroadm-eth-interfaces:egress-consequent-action?       enumeration
-     |  |  +--rw org-openroadm-eth-interfaces:duplex?                         enumeration
-     |  |  +--rw org-openroadm-eth-interfaces:auto-negotiation?               enumeration
-     |  |  +--rw org-openroadm-eth-interfaces:enable-laser?                   enumeration
-     |  |  +--ro org-openroadm-eth-interfaces:laser-status?                   enumeration
-     |  |  +--ro org-openroadm-eth-interfaces:curr-speed?                     string
-     |  |  +--ro org-openroadm-eth-interfaces:curr-duplex?                    string
-     |  |  +--ro org-openroadm-eth-interfaces:max-frame-size?                 uint32
-     |  |  +--rw org-openroadm-eth-interfaces:subrate-eth-sla!
-     |  |  |  +--rw org-openroadm-eth-interfaces:committed-info-rate     uint32
-     |  |  |  +--rw org-openroadm-eth-interfaces:committed-burst-size    uint16
-     |  |  +--ro org-openroadm-eth-interfaces:no-oam-function?                empty
-     |  |  +--ro org-openroadm-eth-interfaces:no-maint-testsignal-function?   empty
-     |  |  +--rw org-openroadm-eth-interfaces:parent-flexo-allocation!
-     |  |  |  +--rw org-openroadm-eth-interfaces:trib-port-number    uint16
-     |  |  |  +--rw org-openroadm-eth-interfaces:iid*                uint16
-     |  |  +--rw org-openroadm-eth-interfaces:maint-testsignal
-     |  |  |  +---x org-openroadm-eth-interfaces:clear-diagnostics
-     |  |  |  |  +---w org-openroadm-eth-interfaces:input
-     |  |  |  |  |  +---w org-openroadm-eth-interfaces:type?   testsig-type
-     |  |  |  |  +--ro org-openroadm-eth-interfaces:output
-     |  |  |  |     +--ro org-openroadm-eth-interfaces:status            org-openroadm-common-types:rpc-status
-     |  |  |  |     +--ro org-openroadm-eth-interfaces:status-message?   string
-     |  |  |  +--rw org-openroadm-eth-interfaces:enabled?             boolean
-     |  |  |  +--rw org-openroadm-eth-interfaces:testPattern          enumeration
-     |  |  |  +--rw org-openroadm-eth-interfaces:type?                testsig-type
-     |  |  |  +--ro org-openroadm-eth-interfaces:inSync?              boolean
-     |  |  |  +--ro org-openroadm-eth-interfaces:seconds              uint32
-     |  |  |  +--ro org-openroadm-eth-interfaces:bitErrors?           uint32
-     |  |  |  +--ro org-openroadm-eth-interfaces:bitErrorRate?        decimal64
-     |  |  +--rw org-openroadm-eth-interfaces:maint-loopback
-     |  |     +--rw org-openroadm-eth-interfaces:enabled?   boolean
-     |  |     +--rw org-openroadm-eth-interfaces:type?      enumeration
      |  +--rw org-openroadm-otn-otu-interfaces:otu
      |  |  +--rw org-openroadm-otn-otu-interfaces:rate?                      identityref
      |  |  +--rw org-openroadm-otn-otu-interfaces:otu4-member-id?            uint16
@@ -723,101 +780,56 @@ module: org-openroadm-device
      |  |  +--rw org-openroadm-otn-otu-interfaces:parent-flexo-allocation!
      |  |     +--rw org-openroadm-otn-otu-interfaces:trib-port-number    uint8
      |  |     +--rw org-openroadm-otn-otu-interfaces:iid*                uint8
-     |  +--rw org-openroadm-optical-transport-interfaces:ots
-     |  |  +--rw org-openroadm-optical-transport-interfaces:fiber-type?                       enumeration
-     |  |  +--rw org-openroadm-optical-transport-interfaces:span-loss-receive?                org-openroadm-common-link-types:ratio-dB
-     |  |  +--rw org-openroadm-optical-transport-interfaces:span-loss-transmit?               org-openroadm-common-link-types:ratio-dB
-     |  |  +--rw org-openroadm-optical-transport-interfaces:ingress-span-loss-aging-margin?   org-openroadm-common-link-types:ratio-dB
-     |  |  +--rw org-openroadm-optical-transport-interfaces:eol-max-load-pIn?                 org-openroadm-common-link-types:power-dBm
-     |  +--rw org-openroadm-gcc-interfaces:gcc
-     |  |  +--rw org-openroadm-gcc-interfaces:gcc-channel-type?   enumeration
-     |  +--rw org-openroadm-optical-tributary-signal-interfaces:otsi
-     |  |  +--rw org-openroadm-optical-tributary-signal-interfaces:provision-mode?             org-openroadm-common-optical-channel-types:provision-mode-type
-     |  |  +--rw org-openroadm-optical-tributary-signal-interfaces:otsi-rate?                  identityref
-     |  |  +--rw org-openroadm-optical-tributary-signal-interfaces:otsi-member-id?             uint16
-     |  |  +--rw org-openroadm-optical-tributary-signal-interfaces:frequency?                  org-openroadm-common-optical-channel-types:frequency-THz
-     |  |  +--ro org-openroadm-optical-tributary-signal-interfaces:width?                      org-openroadm-common-optical-channel-types:frequency-GHz
-     |  |  +--ro org-openroadm-optical-tributary-signal-interfaces:full-bandwidth-at-3dB?      org-openroadm-common-optical-channel-types:frequency-GHz
-     |  |  +--ro org-openroadm-optical-tributary-signal-interfaces:full-bandwidth-at-10dB?     org-openroadm-common-optical-channel-types:frequency-GHz
-     |  |  +--rw org-openroadm-optical-tributary-signal-interfaces:enable-laser?               enumeration
-     |  |  +--ro org-openroadm-optical-tributary-signal-interfaces:laser-status?               enumeration
-     |  |  +--rw org-openroadm-optical-tributary-signal-interfaces:modulation-format?          org-openroadm-common-optical-channel-types:modulation-format
-     |  |  +--rw org-openroadm-optical-tributary-signal-interfaces:transmit-power?             org-openroadm-common-link-types:power-dBm
-     |  |  +--rw org-openroadm-optical-tributary-signal-interfaces:fec?                        identityref
-     |  |  +--rw org-openroadm-optical-tributary-signal-interfaces:optical-operational-mode?   string
-     |  |  +--ro org-openroadm-optical-tributary-signal-interfaces:operational-mode-params
-     |  |  |  +--ro org-openroadm-optical-tributary-signal-interfaces:spectral-width?   org-openroadm-common-optical-channel-types:frequency-GHz
-     |  |  +--ro org-openroadm-optical-tributary-signal-interfaces:supported-group-if?         -> /org-openroadm-device:org-openroadm-device/interface/name
-     |  |  +--rw org-openroadm-optical-tributary-signal-interfaces:flexo!
-     |  |     +--rw org-openroadm-optical-tributary-signal-interfaces:foic-type?             identityref
-     |  |     +--rw org-openroadm-optical-tributary-signal-interfaces:iid*                   uint8
-     |  |     +--ro org-openroadm-optical-tributary-signal-interfaces:accepted-group-id*     uint32
-     |  |     +--ro org-openroadm-optical-tributary-signal-interfaces:accepted-iid*          uint8
-     |  |     +--ro org-openroadm-optical-tributary-signal-interfaces:accepted-payload-id*   org-openroadm-otn-common-types:flexo-payload-type-def
-     |  +--rw org-openroadm-fcc-interfaces:fcc
-     |  |  +--rw org-openroadm-fcc-interfaces:fcc-channel-type?   enumeration
-     |  +--rw org-openroadm-optical-channel-interfaces:och
-     |  |  +--rw org-openroadm-optical-channel-interfaces:provision-mode?             org-openroadm-common-optical-channel-types:provision-mode-type
-     |  |  +--rw org-openroadm-optical-channel-interfaces:rate?                       identityref
-     |  |  +--rw org-openroadm-optical-channel-interfaces:frequency?                  org-openroadm-common-optical-channel-types:frequency-THz
-     |  |  +--ro org-openroadm-optical-channel-interfaces:width?                      org-openroadm-common-optical-channel-types:frequency-GHz
-     |  |  +--ro org-openroadm-optical-channel-interfaces:full-bandwidth-at-3dB?      org-openroadm-common-optical-channel-types:frequency-GHz
-     |  |  +--ro org-openroadm-optical-channel-interfaces:full-bandwidth-at-10dB?     org-openroadm-common-optical-channel-types:frequency-GHz
-     |  |  +--rw org-openroadm-optical-channel-interfaces:enable-laser?               enumeration
-     |  |  +--ro org-openroadm-optical-channel-interfaces:laser-status?               enumeration
-     |  |  +--rw org-openroadm-optical-channel-interfaces:modulation-format?          org-openroadm-common-optical-channel-types:modulation-format
-     |  |  +--rw org-openroadm-optical-channel-interfaces:transmit-power?             org-openroadm-common-link-types:power-dBm
-     |  |  +--rw org-openroadm-optical-channel-interfaces:optical-operational-mode?   string
-     |  |  +--ro org-openroadm-optical-channel-interfaces:operational-mode-params
-     |  |     +--ro org-openroadm-optical-channel-interfaces:spectral-width?   org-openroadm-common-optical-channel-types:frequency-GHz
      |  +--rw org-openroadm-otsi-group-interfaces:otsi-group
-     |  |  +--rw org-openroadm-otsi-group-interfaces:group-rate?              identityref
-     |  |  +--rw org-openroadm-otsi-group-interfaces:group-id?                uint32
-     |  |  +--rw org-openroadm-otsi-group-interfaces:flexo-group-container!
-     |  |  |  +--rw org-openroadm-otsi-group-interfaces:payload-id?   org-openroadm-otn-common-types:flexo-payload-type-def
-     |  |  |  +--ro org-openroadm-otsi-group-interfaces:tx-msi* [index]
-     |  |  |  |  +--ro org-openroadm-otsi-group-interfaces:index          uint16
-     |  |  |  |  +--ro org-openroadm-otsi-group-interfaces:instance-id?   uint16
-     |  |  |  |  +--ro org-openroadm-otsi-group-interfaces:occupation?    boolean
-     |  |  |  |  +--ro org-openroadm-otsi-group-interfaces:trib-port?     uint16
-     |  |  |  +--ro org-openroadm-otsi-group-interfaces:rx-msi* [index]
-     |  |  |  |  +--ro org-openroadm-otsi-group-interfaces:index          uint16
-     |  |  |  |  +--ro org-openroadm-otsi-group-interfaces:instance-id?   uint16
-     |  |  |  |  +--ro org-openroadm-otsi-group-interfaces:occupation?    boolean
-     |  |  |  |  +--ro org-openroadm-otsi-group-interfaces:trib-port?     uint16
-     |  |  |  +--ro org-openroadm-otsi-group-interfaces:exp-msi* [index]
-     |  |  |     +--ro org-openroadm-otsi-group-interfaces:index          uint16
-     |  |  |     +--ro org-openroadm-otsi-group-interfaces:instance-id?   uint16
-     |  |  |     +--ro org-openroadm-otsi-group-interfaces:occupation?    boolean
-     |  |  |     +--ro org-openroadm-otsi-group-interfaces:trib-port?     uint16
-     |  |  +--rw org-openroadm-otsi-group-interfaces:maint-testsignal
-     |  |  |  +---x org-openroadm-otsi-group-interfaces:clear-diagnostics
-     |  |  |  |  +---w org-openroadm-otsi-group-interfaces:input
-     |  |  |  |  |  +---w org-openroadm-otsi-group-interfaces:type?   testsig-type
-     |  |  |  |  +--ro org-openroadm-otsi-group-interfaces:output
-     |  |  |  |     +--ro org-openroadm-otsi-group-interfaces:status            org-openroadm-common-types:rpc-status
-     |  |  |  |     +--ro org-openroadm-otsi-group-interfaces:status-message?   string
-     |  |  |  +--rw org-openroadm-otsi-group-interfaces:enabled?             boolean
-     |  |  |  +--rw org-openroadm-otsi-group-interfaces:testPattern          enumeration
-     |  |  |  +--rw org-openroadm-otsi-group-interfaces:type?                testsig-type
-     |  |  |  +--ro org-openroadm-otsi-group-interfaces:inSync?              boolean
-     |  |  |  +--ro org-openroadm-otsi-group-interfaces:seconds              uint32
-     |  |  |  +--ro org-openroadm-otsi-group-interfaces:bitErrors?           uint32
-     |  |  |  +--ro org-openroadm-otsi-group-interfaces:bitErrorRate?        decimal64
-     |  |  +--rw org-openroadm-otsi-group-interfaces:maint-loopback
-     |  |     +--rw org-openroadm-otsi-group-interfaces:enabled?   boolean
-     |  |     +--rw org-openroadm-otsi-group-interfaces:type?      enumeration
-     |  +--rw org-openroadm-media-channel-interfaces:mc-ttp
-     |  |  +--rw org-openroadm-media-channel-interfaces:min-freq?      org-openroadm-common-optical-channel-types:frequency-THz
-     |  |  +--rw org-openroadm-media-channel-interfaces:max-freq?      org-openroadm-common-optical-channel-types:frequency-THz
-     |  |  +--ro org-openroadm-media-channel-interfaces:center-freq?   org-openroadm-common-optical-channel-types:frequency-THz
-     |  |  +--ro org-openroadm-media-channel-interfaces:slot-width?    org-openroadm-common-optical-channel-types:frequency-GHz
-     |  +--rw org-openroadm-network-media-channel-interfaces:nmc-ctp
-     |     +--rw org-openroadm-network-media-channel-interfaces:frequency?                org-openroadm-common-optical-channel-types:frequency-THz
-     |     +--rw org-openroadm-network-media-channel-interfaces:width?                    org-openroadm-common-optical-channel-types:frequency-GHz
-     |     +--rw org-openroadm-network-media-channel-interfaces:full-bandwidth-at-3dB?    org-openroadm-common-optical-channel-types:frequency-GHz
-     |     +--rw org-openroadm-network-media-channel-interfaces:full-bandwidth-at-10dB?   org-openroadm-common-optical-channel-types:frequency-GHz
+     |     +--rw org-openroadm-otsi-group-interfaces:group-rate?              identityref
+     |     +--rw org-openroadm-otsi-group-interfaces:group-id?                uint32
+     |     +--rw org-openroadm-otsi-group-interfaces:flexo-group-container!
+     |     |  +--rw org-openroadm-otsi-group-interfaces:payload-id?   org-openroadm-otn-common-types:flexo-payload-type-def
+     |     |  +--ro org-openroadm-otsi-group-interfaces:tx-msi* [index]
+     |     |  |  +--ro org-openroadm-otsi-group-interfaces:index          uint16
+     |     |  |  +--ro org-openroadm-otsi-group-interfaces:instance-id?   uint16
+     |     |  |  +--ro org-openroadm-otsi-group-interfaces:occupation?    boolean
+     |     |  |  +--ro org-openroadm-otsi-group-interfaces:trib-port?     uint16
+     |     |  +--ro org-openroadm-otsi-group-interfaces:rx-msi* [index]
+     |     |  |  +--ro org-openroadm-otsi-group-interfaces:index          uint16
+     |     |  |  +--ro org-openroadm-otsi-group-interfaces:instance-id?   uint16
+     |     |  |  +--ro org-openroadm-otsi-group-interfaces:occupation?    boolean
+     |     |  |  +--ro org-openroadm-otsi-group-interfaces:trib-port?     uint16
+     |     |  +--ro org-openroadm-otsi-group-interfaces:exp-msi* [index]
+     |     |     +--ro org-openroadm-otsi-group-interfaces:index          uint16
+     |     |     +--ro org-openroadm-otsi-group-interfaces:instance-id?   uint16
+     |     |     +--ro org-openroadm-otsi-group-interfaces:occupation?    boolean
+     |     |     +--ro org-openroadm-otsi-group-interfaces:trib-port?     uint16
+     |     +--rw org-openroadm-otsi-group-interfaces:maint-testsignal
+     |     |  +---x org-openroadm-otsi-group-interfaces:clear-diagnostics
+     |     |  |  +---w org-openroadm-otsi-group-interfaces:input
+     |     |  |  |  +---w org-openroadm-otsi-group-interfaces:type?   testsig-type
+     |     |  |  +--ro org-openroadm-otsi-group-interfaces:output
+     |     |  |     +--ro org-openroadm-otsi-group-interfaces:status            org-openroadm-common-types:rpc-status
+     |     |  |     +--ro org-openroadm-otsi-group-interfaces:status-message?   string
+     |     |  +--rw org-openroadm-otsi-group-interfaces:enabled?             boolean
+     |     |  +--rw org-openroadm-otsi-group-interfaces:testPattern          enumeration
+     |     |  +--rw org-openroadm-otsi-group-interfaces:type?                testsig-type
+     |     |  +--ro org-openroadm-otsi-group-interfaces:inSync?              boolean
+     |     |  +--ro org-openroadm-otsi-group-interfaces:seconds              uint32
+     |     |  +--ro org-openroadm-otsi-group-interfaces:bitErrors?           uint32
+     |     |  +--ro org-openroadm-otsi-group-interfaces:bitErrorRate?        decimal64
+     |     +--rw org-openroadm-otsi-group-interfaces:maint-loopback
+     |        +--rw org-openroadm-otsi-group-interfaces:enabled?   boolean
+     |        +--rw org-openroadm-otsi-group-interfaces:type?      enumeration
      +--rw protection-grps
+     |  +--rw org-openroadm-prot-equipment-aps:circuit-pack-pg* [name]
+     |  |  +--rw org-openroadm-prot-equipment-aps:name                 string
+     |  |  +--rw org-openroadm-prot-equipment-aps:prot-architecture    prot-architecture-type
+     |  |  +--ro org-openroadm-prot-equipment-aps:service-state        pg-service-state-type
+     |  |  +--ro org-openroadm-prot-equipment-aps:redundancy-state     pg-redundancy-state-type
+     |  |  +--ro org-openroadm-prot-equipment-aps:lockout-state?       pg-lockout-state-type
+     |  |  +--rw org-openroadm-prot-equipment-aps:cp-pg-descriptor* [name]
+     |  |     +--rw org-openroadm-prot-equipment-aps:name               string
+     |  |     +--rw org-openroadm-prot-equipment-aps:pg-circuit-pack    -> /org-openroadm-device:org-openroadm-device/circuit-packs/circuit-pack-name
+     |  |     +--ro org-openroadm-prot-equipment-aps:member-state       pg-member-state-type
+     |  |     +--ro org-openroadm-prot-equipment-aps:switch-request     pg-member-switch-request-type
+     |  |     +--ro org-openroadm-prot-equipment-aps:member-active      boolean
      |  +--rw org-openroadm-prot-otn-linear-aps:odu-sncp-pg* [name]
      |  |  +--rw org-openroadm-prot-otn-linear-aps:name                   string
      |  |  +--rw org-openroadm-prot-otn-linear-aps:level                  protection-level-type
@@ -836,30 +848,18 @@ module: org-openroadm-device
      |  |  +--ro org-openroadm-prot-otn-linear-aps:active-if?             -> /org-openroadm-device:org-openroadm-device/interface/name
      |  |  +--ro org-openroadm-prot-otn-linear-aps:request-state?         request-state-type
      |  +--rw org-openroadm-prot-otn-linear-aps:client-sncp-pg* [name]
-     |  |  +--rw org-openroadm-prot-otn-linear-aps:name                   string
-     |  |  +--rw org-openroadm-prot-otn-linear-aps:switching-direction?   switching-direction-type
-     |  |  +--rw org-openroadm-prot-otn-linear-aps:revertive?             boolean
-     |  |  +--rw org-openroadm-prot-otn-linear-aps:sd-enable?             boolean
-     |  |  +--rw org-openroadm-prot-otn-linear-aps:wait-to-restore?       uint8
-     |  |  +--rw org-openroadm-prot-otn-linear-aps:holdoff-timer
-     |  |  |  +--rw org-openroadm-prot-otn-linear-aps:holdoff?              uint8
-     |  |  |  +--rw org-openroadm-prot-otn-linear-aps:holdoff-multiplier?   uint8
-     |  |  +--rw org-openroadm-prot-otn-linear-aps:working-if             -> /org-openroadm-device:org-openroadm-device/interface/name
-     |  |  +--rw org-openroadm-prot-otn-linear-aps:pg-interfaces*         -> /org-openroadm-device:org-openroadm-device/interface/name
-     |  |  +--ro org-openroadm-prot-otn-linear-aps:active-if?             -> /org-openroadm-device:org-openroadm-device/interface/name
-     |  |  +--ro org-openroadm-prot-otn-linear-aps:request-state?         request-state-type
-     |  +--rw org-openroadm-prot-equipment-aps:circuit-pack-pg* [name]
-     |     +--rw org-openroadm-prot-equipment-aps:name                 string
-     |     +--rw org-openroadm-prot-equipment-aps:prot-architecture    prot-architecture-type
-     |     +--ro org-openroadm-prot-equipment-aps:service-state        pg-service-state-type
-     |     +--ro org-openroadm-prot-equipment-aps:redundancy-state     pg-redundancy-state-type
-     |     +--ro org-openroadm-prot-equipment-aps:lockout-state?       pg-lockout-state-type
-     |     +--rw org-openroadm-prot-equipment-aps:cp-pg-descriptor* [name]
-     |        +--rw org-openroadm-prot-equipment-aps:name               string
-     |        +--rw org-openroadm-prot-equipment-aps:pg-circuit-pack    -> /org-openroadm-device:org-openroadm-device/circuit-packs/circuit-pack-name
-     |        +--ro org-openroadm-prot-equipment-aps:member-state       pg-member-state-type
-     |        +--ro org-openroadm-prot-equipment-aps:switch-request     pg-member-switch-request-type
-     |        +--ro org-openroadm-prot-equipment-aps:member-active      boolean
+     |     +--rw org-openroadm-prot-otn-linear-aps:name                   string
+     |     +--rw org-openroadm-prot-otn-linear-aps:switching-direction?   switching-direction-type
+     |     +--rw org-openroadm-prot-otn-linear-aps:revertive?             boolean
+     |     +--rw org-openroadm-prot-otn-linear-aps:sd-enable?             boolean
+     |     +--rw org-openroadm-prot-otn-linear-aps:wait-to-restore?       uint8
+     |     +--rw org-openroadm-prot-otn-linear-aps:holdoff-timer
+     |     |  +--rw org-openroadm-prot-otn-linear-aps:holdoff?              uint8
+     |     |  +--rw org-openroadm-prot-otn-linear-aps:holdoff-multiplier?   uint8
+     |     +--rw org-openroadm-prot-otn-linear-aps:working-if             -> /org-openroadm-device:org-openroadm-device/interface/name
+     |     +--rw org-openroadm-prot-otn-linear-aps:pg-interfaces*         -> /org-openroadm-device:org-openroadm-device/interface/name
+     |     +--ro org-openroadm-prot-otn-linear-aps:active-if?             -> /org-openroadm-device:org-openroadm-device/interface/name
+     |     +--ro org-openroadm-prot-otn-linear-aps:request-state?         request-state-type
      +--ro protection-profiles
      |  +--ro org-openroadm-prot-otn-linear-aps:protection-profile* [profile-name]
      |     +--ro org-openroadm-prot-otn-linear-aps:profile-name            string
@@ -871,48 +871,6 @@ module: org-openroadm-device
      |     +--ro org-openroadm-prot-otn-linear-aps:pg-capabilities-list*   pg-capabilities-type
      +--rw protocols
      |  +--rw lifecycle-state?                      org-openroadm-common-state-types:lifecycle-state
-     |  +--rw org-openroadm-gnmi:gnmi
-     |  |  +--rw org-openroadm-gnmi:enabled?          boolean
-     |  |  +--rw org-openroadm-gnmi:certificate-id?   -> /org-openroadm-device:org-openroadm-device/org-openroadm-security:security/certificate/certificate-id
-     |  |  +--rw org-openroadm-gnmi:port?             inet:port-number
-     |  +--rw org-openroadm-rstp:rstp
-     |  |  +--ro org-openroadm-rstp:max-bridge-instances?   uint32
-     |  |  +--rw org-openroadm-rstp:rstp-bridge-instance* [bridge-name]
-     |  |     +--rw org-openroadm-rstp:bridge-name    string
-     |  |     +--rw org-openroadm-rstp:rstp-config
-     |  |     |  +--rw org-openroadm-rstp:bridge-priority?          uint32
-     |  |     |  +--rw org-openroadm-rstp:shutdown?                 empty
-     |  |     |  +--rw org-openroadm-rstp:hold-time?                uint32
-     |  |     |  +--rw org-openroadm-rstp:hello-time?               uint32
-     |  |     |  +--rw org-openroadm-rstp:max-age?                  uint32
-     |  |     |  +--rw org-openroadm-rstp:forward-delay?            uint32
-     |  |     |  +--rw org-openroadm-rstp:transmit-hold-count?      uint32
-     |  |     |  +--rw org-openroadm-rstp:rstp-bridge-port-table* [ifname]
-     |  |     |     +--rw org-openroadm-rstp:ifname      -> /org-openroadm-device:org-openroadm-device/interface/name
-     |  |     |     +--rw org-openroadm-rstp:cost?       uint32
-     |  |     |     +--rw org-openroadm-rstp:priority?   uint32
-     |  |     +--ro org-openroadm-rstp:rstp-state
-     |  |        +--ro org-openroadm-rstp:rstp-bridge-attr
-     |  |        |  +--ro org-openroadm-rstp:root-bridge-port?         uint32
-     |  |        |  +--ro org-openroadm-rstp:root-path-cost?           uint32
-     |  |        |  +--ro org-openroadm-rstp:root-bridge-priority?     uint32
-     |  |        |  +--ro org-openroadm-rstp:root-bridge-id?           bridge-id-type
-     |  |        |  +--ro org-openroadm-rstp:root-hold-time?           uint32
-     |  |        |  +--ro org-openroadm-rstp:root-hello-time?          uint32
-     |  |        |  +--ro org-openroadm-rstp:root-max-age?             uint32
-     |  |        |  +--ro org-openroadm-rstp:root-forward-delay?       uint32
-     |  |        |  +--ro org-openroadm-rstp:bridge-id?                bridge-id-type
-     |  |        |  +--ro org-openroadm-rstp:topo-change-count?        uint32
-     |  |        |  +--ro org-openroadm-rstp:time-since-topo-change?   uint32
-     |  |        +--ro org-openroadm-rstp:rstp-bridge-port-attr
-     |  |           +--ro org-openroadm-rstp:rstp-bridge-port-table* [ifname]
-     |  |              +--ro org-openroadm-rstp:ifname                    string
-     |  |              +--ro org-openroadm-rstp:bridge-port-state?        enumeration
-     |  |              +--ro org-openroadm-rstp:bridge-port-role?         enumeration
-     |  |              +--ro org-openroadm-rstp:bridge-port-id?           uint32
-     |  |              +--ro org-openroadm-rstp:oper-edge-bridge-port?    empty
-     |  |              +--ro org-openroadm-rstp:designated-bridge-port?   uint32
-     |  |              +--ro org-openroadm-rstp:designated-bridgeid?      bridge-id-type
      |  +--rw org-openroadm-dhcp:ipv4-dhcp-relay
      |  |  +--rw org-openroadm-dhcp:ipv4-server-group* [server-group-name]
      |  |     +--rw org-openroadm-dhcp:server-group-name    string
@@ -923,24 +881,66 @@ module: org-openroadm-device
      |  |     +--rw org-openroadm-dhcp:server-group-name    string
      |  |     +--rw org-openroadm-dhcp:interface-name*      -> /org-openroadm-device:org-openroadm-device/interface/name
      |  |     +--rw org-openroadm-dhcp:server-address*      ietf-inet-types:ipv6-address
+     |  +--rw org-openroadm-gnmi:gnmi
+     |  |  +--rw org-openroadm-gnmi:enabled?          boolean
+     |  |  +--rw org-openroadm-gnmi:certificate-id?   -> /org-openroadm-device:org-openroadm-device/org-openroadm-security:security/certificate/certificate-id
+     |  |  +--rw org-openroadm-gnmi:port?             inet:port-number
      |  +--rw org-openroadm-lldp:lldp
-     |     +--rw org-openroadm-lldp:global-config
-     |     |  +--rw org-openroadm-lldp:adminStatus?           enumeration
-     |     |  +--rw org-openroadm-lldp:msgTxInterval?         uint16
-     |     |  +--rw org-openroadm-lldp:msgTxHoldMultiplier?   uint8
-     |     +--rw org-openroadm-lldp:port-config* [ifName]
-     |     |  +--rw org-openroadm-lldp:ifName         -> /org-openroadm-device:org-openroadm-device/interface/name
-     |     |  +--rw org-openroadm-lldp:adminStatus?   enumeration
-     |     +--ro org-openroadm-lldp:nbr-list
-     |        +--ro org-openroadm-lldp:if-name* [ifName]
-     |           +--ro org-openroadm-lldp:ifName                      string
-     |           +--ro org-openroadm-lldp:remoteSysName?              string
-     |           +--ro org-openroadm-lldp:remoteMgmtAddressSubType?   ianaaf:address-family
-     |           +--ro org-openroadm-lldp:remoteMgmtAddress?          inet:ip-address
-     |           +--ro org-openroadm-lldp:remotePortIdSubType?        enumeration
-     |           +--ro org-openroadm-lldp:remotePortId?               string
-     |           +--ro org-openroadm-lldp:remoteChassisIdSubType?     enumeration
-     |           +--ro org-openroadm-lldp:remoteChassisId?            string
+     |  |  +--rw org-openroadm-lldp:global-config
+     |  |  |  +--rw org-openroadm-lldp:adminStatus?           enumeration
+     |  |  |  +--rw org-openroadm-lldp:msgTxInterval?         uint16
+     |  |  |  +--rw org-openroadm-lldp:msgTxHoldMultiplier?   uint8
+     |  |  +--rw org-openroadm-lldp:port-config* [ifName]
+     |  |  |  +--rw org-openroadm-lldp:ifName         -> /org-openroadm-device:org-openroadm-device/interface/name
+     |  |  |  +--rw org-openroadm-lldp:adminStatus?   enumeration
+     |  |  +--ro org-openroadm-lldp:nbr-list
+     |  |     +--ro org-openroadm-lldp:if-name* [ifName]
+     |  |        +--ro org-openroadm-lldp:ifName                      string
+     |  |        +--ro org-openroadm-lldp:remoteSysName?              string
+     |  |        +--ro org-openroadm-lldp:remoteMgmtAddressSubType?   ianaaf:address-family
+     |  |        +--ro org-openroadm-lldp:remoteMgmtAddress?          inet:ip-address
+     |  |        +--ro org-openroadm-lldp:remotePortIdSubType?        enumeration
+     |  |        +--ro org-openroadm-lldp:remotePortId?               string
+     |  |        +--ro org-openroadm-lldp:remoteChassisIdSubType?     enumeration
+     |  |        +--ro org-openroadm-lldp:remoteChassisId?            string
+     |  +--rw org-openroadm-rstp:rstp
+     |     +--ro org-openroadm-rstp:max-bridge-instances?   uint32
+     |     +--rw org-openroadm-rstp:rstp-bridge-instance* [bridge-name]
+     |        +--rw org-openroadm-rstp:bridge-name    string
+     |        +--rw org-openroadm-rstp:rstp-config
+     |        |  +--rw org-openroadm-rstp:bridge-priority?          uint32
+     |        |  +--rw org-openroadm-rstp:shutdown?                 empty
+     |        |  +--rw org-openroadm-rstp:hold-time?                uint32
+     |        |  +--rw org-openroadm-rstp:hello-time?               uint32
+     |        |  +--rw org-openroadm-rstp:max-age?                  uint32
+     |        |  +--rw org-openroadm-rstp:forward-delay?            uint32
+     |        |  +--rw org-openroadm-rstp:transmit-hold-count?      uint32
+     |        |  +--rw org-openroadm-rstp:rstp-bridge-port-table* [ifname]
+     |        |     +--rw org-openroadm-rstp:ifname      -> /org-openroadm-device:org-openroadm-device/interface/name
+     |        |     +--rw org-openroadm-rstp:cost?       uint32
+     |        |     +--rw org-openroadm-rstp:priority?   uint32
+     |        +--ro org-openroadm-rstp:rstp-state
+     |           +--ro org-openroadm-rstp:rstp-bridge-attr
+     |           |  +--ro org-openroadm-rstp:root-bridge-port?         uint32
+     |           |  +--ro org-openroadm-rstp:root-path-cost?           uint32
+     |           |  +--ro org-openroadm-rstp:root-bridge-priority?     uint32
+     |           |  +--ro org-openroadm-rstp:root-bridge-id?           bridge-id-type
+     |           |  +--ro org-openroadm-rstp:root-hold-time?           uint32
+     |           |  +--ro org-openroadm-rstp:root-hello-time?          uint32
+     |           |  +--ro org-openroadm-rstp:root-max-age?             uint32
+     |           |  +--ro org-openroadm-rstp:root-forward-delay?       uint32
+     |           |  +--ro org-openroadm-rstp:bridge-id?                bridge-id-type
+     |           |  +--ro org-openroadm-rstp:topo-change-count?        uint32
+     |           |  +--ro org-openroadm-rstp:time-since-topo-change?   uint32
+     |           +--ro org-openroadm-rstp:rstp-bridge-port-attr
+     |              +--ro org-openroadm-rstp:rstp-bridge-port-table* [ifname]
+     |                 +--ro org-openroadm-rstp:ifname                    string
+     |                 +--ro org-openroadm-rstp:bridge-port-state?        enumeration
+     |                 +--ro org-openroadm-rstp:bridge-port-role?         enumeration
+     |                 +--ro org-openroadm-rstp:bridge-port-id?           uint32
+     |                 +--ro org-openroadm-rstp:oper-edge-bridge-port?    empty
+     |                 +--ro org-openroadm-rstp:designated-bridge-port?   uint32
+     |                 +--ro org-openroadm-rstp:designated-bridgeid?      bridge-id-type
      +--ro internal-link* [internal-link-name]
      |  +--ro internal-link-name    string
      |  +--ro source
@@ -983,8 +983,8 @@ module: org-openroadm-device
      |  |  +--rw circuit-pack-name    -> /org-openroadm-device/circuit-packs/circuit-pack-name
      |  |  +--rw port-name            -> /org-openroadm-device/circuit-packs[circuit-pack-name=current()/../circuit-pack-name]/ports/port-name
      |  +--rw osc-port
-     |  |  +--rw circuit-pack-name    -> /org-openroadm-device/circuit-packs/circuit-pack-name
-     |  |  +--rw port-name            -> /org-openroadm-device/circuit-packs[circuit-pack-name=current()/../circuit-pack-name]/ports/port-name
+     |  |  +--rw circuit-pack-name?   -> /org-openroadm-device/circuit-packs/circuit-pack-name
+     |  |  +--rw port-name?           -> /org-openroadm-device/circuit-packs[circuit-pack-name=current()/../circuit-pack-name]/ports/port-name
      |  +--rw otdr-port
      |  |  +--rw circuit-pack-name?   -> /org-openroadm-device/circuit-packs/circuit-pack-name
      |  |  +--rw port-name?           -> /org-openroadm-device/circuit-packs[circuit-pack-name=current()/../circuit-pack-name]/ports/port-name
@@ -1035,8 +1035,8 @@ module: org-openroadm-device
      |  |  +--rw port-name                           -> /org-openroadm-device/circuit-packs[circuit-pack-name=current()/../circuit-pack-name]/ports/port-name
      |  +--rw osc-port* [port-direction]
      |  |  +--rw port-direction       org-openroadm-common-alarm-pm-types:direction
-     |  |  +--rw circuit-pack-name    -> /org-openroadm-device/circuit-packs/circuit-pack-name
-     |  |  +--rw port-name            -> /org-openroadm-device/circuit-packs[circuit-pack-name=current()/../circuit-pack-name]/ports/port-name
+     |  |  +--rw circuit-pack-name?   -> /org-openroadm-device/circuit-packs/circuit-pack-name
+     |  |  +--rw port-name?           -> /org-openroadm-device/circuit-packs[circuit-pack-name=current()/../circuit-pack-name]/ports/port-name
      |  +--rw otdr-port* [otdr-direction]
      |     +--rw otdr-direction       string
      |     +--rw circuit-pack-name    -> /org-openroadm-device/circuit-packs/circuit-pack-name

--- a/model/Network/org-openroadm-amplifier.yang
+++ b/model/Network/org-openroadm-amplifier.yang
@@ -9,7 +9,7 @@ module org-openroadm-amplifier {
   }
   import org-openroadm-common-link-types {
     prefix org-openroadm-common-link-types;
-    revision-date 2019-11-29;
+    revision-date 2024-03-29;
   }
 
   organization
@@ -46,6 +46,10 @@ module org-openroadm-amplifier {
      ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
      POSSIBILITY OF SUCH DAMAGE.";
 
+  revision 2024-03-29 {
+    description
+      "Version 15.0";
+  }
   revision 2021-09-24 {
     description
       "Version 10.0";

--- a/model/Network/org-openroadm-common-network.yang
+++ b/model/Network/org-openroadm-common-network.yang
@@ -13,7 +13,7 @@ module org-openroadm-common-network {
   }
   import org-openroadm-network-types {
     prefix org-openroadm-network-types;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
   import org-openroadm-common-state-types {
     prefix org-openroadm-common-state-types;
@@ -59,6 +59,10 @@ module org-openroadm-common-network {
      ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
      POSSIBILITY OF SUCH DAMAGE.";
 
+  revision 2024-03-29 {
+    description
+      "Version 15.0";
+  }
   revision 2023-12-08 {
     description
       "Version 14.1";

--- a/model/Network/org-openroadm-degree.yang
+++ b/model/Network/org-openroadm-degree.yang
@@ -5,7 +5,7 @@ module org-openroadm-degree {
 
   import org-openroadm-common-link-types {
     prefix org-openroadm-common-link-types;
-    revision-date 2019-11-29;
+    revision-date 2024-03-29;
   }
   import org-openroadm-network-types {
     prefix org-openroadm-network-types;

--- a/model/Network/org-openroadm-degree.yang
+++ b/model/Network/org-openroadm-degree.yang
@@ -9,7 +9,7 @@ module org-openroadm-degree {
   }
   import org-openroadm-network-types {
     prefix org-openroadm-network-types;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
 
   organization
@@ -46,6 +46,10 @@ module org-openroadm-degree {
      ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
      POSSIBILITY OF SUCH DAMAGE.";
 
+  revision 2024-03-29 {
+    description
+      "Version 15.0";
+  }
   revision 2023-12-08 {
     description
       "Version 14.1";

--- a/model/Network/org-openroadm-link.yang
+++ b/model/Network/org-openroadm-link.yang
@@ -13,7 +13,7 @@ module org-openroadm-link {
   }
   import org-openroadm-common-link-types {
     prefix org-openroadm-common-link-types;
-    revision-date 2019-11-29;
+    revision-date 2024-03-29;
   }
   import org-openroadm-common-node-types {
     prefix org-openroadm-common-node-types;
@@ -21,7 +21,7 @@ module org-openroadm-link {
   }
   import org-openroadm-amplifier {
     prefix org-openroadm-amplifier;
-    revision-date 2021-09-24;
+    revision-date 2024-03-29;
   }
   import org-openroadm-network-types {
     prefix org-openroadm-network-types;

--- a/model/Network/org-openroadm-link.yang
+++ b/model/Network/org-openroadm-link.yang
@@ -25,11 +25,11 @@ module org-openroadm-link {
   }
   import org-openroadm-network-types {
     prefix org-openroadm-network-types;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
   import org-openroadm-common-network {
     prefix cnet;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
 
   organization
@@ -66,6 +66,10 @@ module org-openroadm-link {
      ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
      POSSIBILITY OF SUCH DAMAGE.";
 
+  revision 2024-03-29 {
+    description
+      "Version 15.0";
+  }
   revision 2023-12-08 {
     description
       "Version 14.1";

--- a/model/Network/org-openroadm-network-topology-types.yang
+++ b/model/Network/org-openroadm-network-topology-types.yang
@@ -17,7 +17,7 @@ module org-openroadm-network-topology-types {
   }
   import org-openroadm-port-types {
     prefix org-openroadm-port-types;
-    revision-date 2023-05-26;
+    revision-date 2024-03-29;
   }
 
   organization
@@ -51,6 +51,10 @@ module org-openroadm-network-topology-types {
      ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
      POSSIBILITY OF SUCH DAMAGE.";
 
+  revision 2024-03-29 {
+    description
+      "Version 15.0";
+  }
   revision 2023-05-26 {
     description
       "Version 13.1";

--- a/model/Network/org-openroadm-network-topology.yang
+++ b/model/Network/org-openroadm-network-topology.yang
@@ -13,7 +13,7 @@ module org-openroadm-network-topology {
   }
   import org-openroadm-network-types {
     prefix org-openroadm-network-types;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
   import org-openroadm-srg {
     prefix srg;
@@ -21,11 +21,11 @@ module org-openroadm-network-topology {
   }
   import org-openroadm-degree {
     prefix dgr;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
   import org-openroadm-xponder {
     prefix xpdr;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
   import org-openroadm-external-pluggable {
     prefix plg;
@@ -33,11 +33,11 @@ module org-openroadm-network-topology {
   }
   import org-openroadm-link {
     prefix link;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
   import org-openroadm-common-network {
     prefix cnet;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
 
   organization
@@ -73,6 +73,10 @@ module org-openroadm-network-topology {
      ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
      POSSIBILITY OF SUCH DAMAGE.";
 
+  revision 2024-03-29 {
+    description
+      "Version 15.0";
+  }
   revision 2023-12-08 {
     description
       "Version 14.1";

--- a/model/Network/org-openroadm-network-types.yang
+++ b/model/Network/org-openroadm-network-types.yang
@@ -17,7 +17,7 @@ module org-openroadm-network-types {
   }
   import org-openroadm-common-types {
     prefix org-openroadm-common-types;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
   import org-openroadm-common-node-types {
     prefix org-openroadm-common-node-types;
@@ -55,6 +55,10 @@ module org-openroadm-network-types {
      ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
      POSSIBILITY OF SUCH DAMAGE.";
 
+  revision 2024-03-29 {
+    description
+      "Version 15.0";
+  }
   revision 2023-12-08 {
     description
       "Version 14.1";

--- a/model/Network/org-openroadm-network-types.yang
+++ b/model/Network/org-openroadm-network-types.yang
@@ -13,7 +13,7 @@ module org-openroadm-network-types {
   }
   import org-openroadm-port-types {
     prefix org-openroadm-port-types;
-    revision-date 2023-05-26;
+    revision-date 2024-03-29;
   }
   import org-openroadm-common-types {
     prefix org-openroadm-common-types;

--- a/model/Network/org-openroadm-network.yang
+++ b/model/Network/org-openroadm-network.yang
@@ -9,7 +9,7 @@ module org-openroadm-network {
   }
   import org-openroadm-network-types {
     prefix nt;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
   import org-openroadm-roadm {
     prefix roadm;
@@ -21,7 +21,7 @@ module org-openroadm-network {
   }
   import org-openroadm-xponder {
     prefix xpdr;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
   import ietf-inet-types {
     prefix inet;
@@ -29,11 +29,11 @@ module org-openroadm-network {
   }
   import org-openroadm-common-types {
     prefix org-openroadm-common-types;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
   import org-openroadm-common-network {
     prefix cnet;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
 
   organization
@@ -67,6 +67,10 @@ module org-openroadm-network {
      ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
      POSSIBILITY OF SUCH DAMAGE.";
 
+  revision 2024-03-29 {
+    description
+      "Version 15.0";
+  }
   revision 2023-12-08 {
     description
       "Version 14.1";

--- a/model/Network/org-openroadm-otn-network-topology.yang
+++ b/model/Network/org-openroadm-otn-network-topology.yang
@@ -13,7 +13,7 @@ module org-openroadm-otn-network-topology {
   }
   import org-openroadm-network-types {
     prefix org-openroadm-network-types;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
   import org-openroadm-network-topology-types {
     prefix org-openroadm-network-topology-types;
@@ -21,11 +21,11 @@ module org-openroadm-otn-network-topology {
   }
   import org-openroadm-xponder {
     prefix xpdr;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
   import org-openroadm-common-network {
     prefix cnet;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
 
   organization
@@ -61,6 +61,10 @@ module org-openroadm-otn-network-topology {
      ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
      POSSIBILITY OF SUCH DAMAGE.";
 
+  revision 2024-03-29 {
+    description
+      "Version 15.0";
+  }
   revision 2023-12-08 {
     description
       "Version 14.1";

--- a/model/Network/org-openroadm-otn-network-topology.yang
+++ b/model/Network/org-openroadm-otn-network-topology.yang
@@ -17,7 +17,7 @@ module org-openroadm-otn-network-topology {
   }
   import org-openroadm-network-topology-types {
     prefix org-openroadm-network-topology-types;
-    revision-date 2023-05-26;
+    revision-date 2024-03-29;
   }
   import org-openroadm-xponder {
     prefix xpdr;

--- a/model/Network/org-openroadm-xponder.yang
+++ b/model/Network/org-openroadm-xponder.yang
@@ -5,7 +5,7 @@ module org-openroadm-xponder {
 
   import org-openroadm-network-types {
     prefix org-openroadm-network-types;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
   import org-openroadm-common-equipment-types {
     prefix org-openroadm-common-equipment-types;
@@ -61,6 +61,10 @@ module org-openroadm-xponder {
      ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
      POSSIBILITY OF SUCH DAMAGE.";
 
+  revision 2024-03-29 {
+    description
+      "Version 15.0";
+  }
   revision 2023-12-08 {
     description
       "Version 14.1";

--- a/model/Network/tree-view-network-full.txt
+++ b/model/Network/tree-view-network-full.txt
@@ -15,6 +15,7 @@ module: ietf-network
         |  +--rw supporting-node* [network-ref node-ref]
         |  |  +--rw network-ref    -> ../../../supporting-network/network-ref
         |  |  +--rw node-ref       -> /networks/network/node/node-id
+        |  +--rw cn:clli?                         string
         |  +--rw nt:termination-point* [tp-id]
         |  |  +--rw nt:tp-id                                       tp-id
         |  |  +--rw nt:supporting-termination-point* [network-ref node-ref tp-ref]
@@ -178,7 +179,6 @@ module: ietf-network
         |  |     +--rw otn-topo:service-format?                  org-openroadm-service-format:service-format
         |  |     +--rw otn-topo:service-rate?                    uint32
         |  |     +--rw otn-topo:other-service-format-and-rate?   string
-        |  +--rw cn:clli?                         string
         |  +--rw cnet:node-type?                  org-openroadm-network-types:openroadm-node-type
         |  +--rw cnet:node-subtype?               org-openroadm-common-node-types:node-subtypes
         |  +--rw cnet:lifecycle-state?            org-openroadm-common-state-types:lifecycle-state

--- a/model/Network/tree-view-network-full.txt
+++ b/model/Network/tree-view-network-full.txt
@@ -15,7 +15,6 @@ module: ietf-network
         |  +--rw supporting-node* [network-ref node-ref]
         |  |  +--rw network-ref    -> ../../../supporting-network/network-ref
         |  |  +--rw node-ref       -> /networks/network/node/node-id
-        |  +--rw cn:clli?                         string
         |  +--rw nt:termination-point* [tp-id]
         |  |  +--rw nt:tp-id                                       tp-id
         |  |  +--rw nt:supporting-termination-point* [network-ref node-ref tp-ref]
@@ -179,6 +178,7 @@ module: ietf-network
         |  |     +--rw otn-topo:service-format?                  org-openroadm-service-format:service-format
         |  |     +--rw otn-topo:service-rate?                    uint32
         |  |     +--rw otn-topo:other-service-format-and-rate?   string
+        |  +--rw cn:clli?                         string
         |  +--rw cnet:node-type?                  org-openroadm-network-types:openroadm-node-type
         |  +--rw cnet:node-subtype?               org-openroadm-common-node-types:node-subtypes
         |  +--rw cnet:lifecycle-state?            org-openroadm-common-state-types:lifecycle-state
@@ -372,3 +372,4 @@ module: ietf-network
            +--rw cnet:SRLG-name?     string
            +--rw cnet:SRLG-type?     org-openroadm-common-types:SRLG-type
            +--rw cnet:SRLG-length?   decimal64
+

--- a/model/Network/tree-view-network.txt
+++ b/model/Network/tree-view-network.txt
@@ -9,9 +9,9 @@ module: org-openroadm-common-network
 
   augment /nd:networks/nd:network/nd:network-types:
     +--rw openroadm-common-network!
+       +--rw otn-topo:otn-topology!
        +--rw topo:openroadm-topology!
        +--rw net:openroadm-network!
-       +--rw otn-topo:otn-topology!
   augment /nd:networks/nd:network:
     +--rw SRLG-list* [SRLG-Id]
        +--rw SRLG-Id        uint32

--- a/model/Network/tree-view-network.txt
+++ b/model/Network/tree-view-network.txt
@@ -9,9 +9,9 @@ module: org-openroadm-common-network
 
   augment /nd:networks/nd:network/nd:network-types:
     +--rw openroadm-common-network!
-       +--rw otn-topo:otn-topology!
        +--rw topo:openroadm-topology!
        +--rw net:openroadm-network!
+       +--rw otn-topo:otn-topology!
   augment /nd:networks/nd:network:
     +--rw SRLG-list* [SRLG-Id]
        +--rw SRLG-Id        uint32

--- a/model/Service/org-openroadm-ber-test.yang
+++ b/model/Service/org-openroadm-ber-test.yang
@@ -4,7 +4,7 @@ module org-openroadm-ber-test {
 
   import org-openroadm-common-service-types {
     prefix org-openroadm-common-service-types;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
   import org-openroadm-common-ber-test {
     prefix org-openroadm-common-ber-test;
@@ -48,6 +48,10 @@ module org-openroadm-ber-test {
       ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
       POSSIBILITY OF SUCH DAMAGE";
 
+  revision 2024-03-29 {
+    description
+      "Version 15.0";
+  }
   revision 2023-12-08 {
     description
       "Version 14.1";

--- a/model/Service/org-openroadm-common-service-types.yang
+++ b/model/Service/org-openroadm-common-service-types.yang
@@ -1760,24 +1760,42 @@ module org-openroadm-common-service-types {
       type org-openroadm-common-state-types:lifecycle-state;
     }
     leaf equipment-rack {
-        type string;
-      }
-      leaf equipment-shelf {
-        type string;
-      }
-      leaf equipment-slot {
-        type string;
-      }
-      leaf equipment-sub-slot {
-        type string;
-      }
-      leaf is-reused {
-        type boolean;
-        description
-          "This is set true if the equipment-required is being reused for
-          service roll";
-      }
+      type string;
+    }
+    leaf equipment-shelf {
+      type string;
+    }
+    leaf equipment-slot {
+      type string;
+    }
+    leaf equipment-sub-slot {
+      type string;
+    }
+    leaf is-reused {
+      type boolean;
+      description
+        "This is set true if the equipment-required is being reused for
+        service roll";
+    }
     uses service-port-list;
+    leaf is-regen {
+      type boolean;
+      description
+        "Used to indicate if the intermediate site is a regen site or not.
+        It is used primarly in the feasibility check output";
+    }
+    leaf-list regen-purpose {
+      description
+        "Used to indicate the purpose of the regenerator";
+      type enumeration {
+        enum reach {
+          value 1;
+        }
+        enum recolor {
+          value 2;
+        }
+      }
+    }
   }
 
   grouping eventHorizon {

--- a/model/Service/org-openroadm-common-service-types.yang
+++ b/model/Service/org-openroadm-common-service-types.yang
@@ -16,7 +16,7 @@ module org-openroadm-common-service-types {
   }
   import org-openroadm-topology {
     prefix org-openroadm-topology;
-    revision-date 2023-05-26;
+    revision-date 2024-03-29;
   }
   import org-openroadm-common-equipment-types {
     prefix org-openroadm-common-equipment-types;
@@ -64,11 +64,11 @@ module org-openroadm-common-service-types {
   }
   import org-openroadm-common-link-types {
     prefix org-openroadm-common-link-types;
-    revision-date 2019-11-29;
+    revision-date 2024-03-29;
   }
   import org-openroadm-resource {
     prefix org-openroadm-resource;
-    revision-date 2023-05-26;
+    revision-date 2024-03-29;
   }
 
 

--- a/model/Service/org-openroadm-common-service-types.yang
+++ b/model/Service/org-openroadm-common-service-types.yang
@@ -12,7 +12,7 @@ module org-openroadm-common-service-types {
   }
   import org-openroadm-routing-constraints {
     prefix org-openroadm-routing-constraints;
-    revision-date 2022-12-09;
+    revision-date 2024-03-29;
   }
   import org-openroadm-topology {
     prefix org-openroadm-topology;

--- a/model/Service/org-openroadm-common-service-types.yang
+++ b/model/Service/org-openroadm-common-service-types.yang
@@ -40,7 +40,7 @@ module org-openroadm-common-service-types {
   }
   import org-openroadm-common-types {
     prefix org-openroadm-common-types;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
   import org-openroadm-equipment-states-types {
     prefix org-openroadm-equipment-states-types;
@@ -105,6 +105,10 @@ module org-openroadm-common-service-types {
       ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
       POSSIBILITY OF SUCH DAMAGE";
 
+  revision 2024-03-29 {
+    description
+      "Version 15.0";
+  }
   revision 2023-12-08 {
     description
       "Version 14.1";

--- a/model/Service/org-openroadm-controller-customization.yang
+++ b/model/Service/org-openroadm-controller-customization.yang
@@ -13,7 +13,7 @@ module org-openroadm-controller-customization {
   }
   import org-openroadm-common-service-types {
     prefix org-openroadm-common-service-types;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
   import org-openroadm-common-optical-channel-types {
     prefix org-openroadm-common-optical-channel-types;
@@ -53,6 +53,10 @@ module org-openroadm-controller-customization {
       ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
       POSSIBILITY OF SUCH DAMAGE";
 
+  revision 2024-03-29 {
+    description
+      "Version 15.0";
+  }
   revision 2023-12-08 {
     description
       "Version 14.1";

--- a/model/Service/org-openroadm-controller-customization.yang
+++ b/model/Service/org-openroadm-controller-customization.yang
@@ -717,6 +717,35 @@ module org-openroadm-controller-customization {
           }
         }
       }
+      container srg-restriction {
+        list node-srg-restriction {
+          key "node-id";
+          leaf node-id {
+            type org-openroadm-common-node-types:node-id-type;
+            description
+              "ROADM node-id";
+          }
+          list srg-list {
+            key "srg-number";
+            leaf srg-number {
+              type uint16;
+              description
+                "SRG-number of a given ROADM";
+            }
+            leaf restriction-type {
+              type restriction-type;
+              default "both";
+            }
+            leaf-list restriction-scopes {
+              description
+                "Restriction scope applicable for the srg-restriction.
+                Default scope is set to all RPCs";
+              type restriction-scope;
+              default "all";
+            }
+          }
+        }
+      }
     }
     container default-behaviour {
       description

--- a/model/Service/org-openroadm-controller-customization.yang
+++ b/model/Service/org-openroadm-controller-customization.yang
@@ -5,7 +5,7 @@ module org-openroadm-controller-customization {
 
   import org-openroadm-common-link-types {
     prefix org-openroadm-common-link-types;
-    revision-date 2019-11-29;
+    revision-date 2024-03-29;
   }
   import org-openroadm-common-node-types {
     prefix org-openroadm-common-node-types;

--- a/model/Service/org-openroadm-operational-mode-catalog.yang
+++ b/model/Service/org-openroadm-operational-mode-catalog.yang
@@ -295,7 +295,7 @@ module org-openroadm-operational-mode-catalog {
     container Add {
       description
         "add block-specification";
-      list add-openroadm-operational-mode {
+      list openroadm-operational-mode {
         key "openroadm-operational-mode-id";
         description
           "defines the openroadm operational mode pointing to an official specification ";
@@ -303,6 +303,11 @@ module org-openroadm-operational-mode-catalog {
           type string;
           description
             "openroadm operational mode which points to a specific spreadsheet of optical specifications";
+        }
+        leaf max-channel-number {
+            type uint8;
+            description
+                "Max Number of channels authorized on Add-block to guaranty transponders specifications";
         }
         leaf incremental-osnr {
             type org-openroadm-common-link-types:ratio-dB;

--- a/model/Service/org-openroadm-operational-mode-catalog.yang
+++ b/model/Service/org-openroadm-operational-mode-catalog.yang
@@ -12,7 +12,7 @@ module org-openroadm-operational-mode-catalog {
   }
   import org-openroadm-common-types {
     prefix org-openroadm-common-types;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
 
   organization
@@ -48,6 +48,10 @@ module org-openroadm-operational-mode-catalog {
       ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
       POSSIBILITY OF SUCH DAMAGE";
 
+  revision 2024-03-29 {
+    description
+      "Version 15.0";
+  }
   revision 2023-12-08 {
     description
       "Version 14.1";

--- a/model/Service/org-openroadm-operational-mode-catalog.yang
+++ b/model/Service/org-openroadm-operational-mode-catalog.yang
@@ -8,7 +8,7 @@ module org-openroadm-operational-mode-catalog {
   }
   import org-openroadm-common-link-types {
     prefix org-openroadm-common-link-types;
-    revision-date 2019-11-29;
+    revision-date 2024-03-29;
   }
   import org-openroadm-common-types {
     prefix org-openroadm-common-types;

--- a/model/Service/org-openroadm-routing-constraints.yang
+++ b/model/Service/org-openroadm-routing-constraints.yang
@@ -44,6 +44,10 @@ module org-openroadm-routing-constraints {
       ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
       POSSIBILITY OF SUCH DAMAGE";
 
+  revision 2024-03-29 {
+    description
+      "Version 15.0";
+  }
   revision 2022-12-09 {
     description
       "Version 12.1";
@@ -143,6 +147,20 @@ module org-openroadm-routing-constraints {
         ordered-by user;
         description
           "Supporting service(s) to exclude from this route.";
+      }
+      list node-srg {
+        key "node-id";
+        leaf node-id {
+          type org-openroadm-common-node-types:node-id-type;
+          description
+            "Given ROADM node-id";
+        }
+        list srg-list {
+          key "srg-number";
+          leaf srg-number {
+            type uint16;
+          }
+        }
       }
     }
     container include {

--- a/model/Service/org-openroadm-service.yang
+++ b/model/Service/org-openroadm-service.yang
@@ -1906,7 +1906,27 @@ rpc add-openroadm-operational-modes-to-catalog {
       ";
     list services {
       key "service-name";
-      uses org-openroadm-common-service-types:service;
+      uses org-openroadm-common-service-types:service {
+        augment "service-a-end" {
+          list equipment-required {
+            key "equipment-identifier";
+            description
+              "List of required equipment, including equipment type, state and
+              quantity";
+            uses org-openroadm-common-service-types:equipment-info;
+          }
+        }
+        augment "service-z-end" {
+          list equipment-required {
+            key "equipment-identifier";
+            description
+              "List of required equipment, including equipment type, state and
+              quantity";
+            uses org-openroadm-common-service-types:equipment-info;
+          }
+        }
+      }
+      uses org-openroadm-common-service-types:intermediate-site-container;
     }
   }
   container versioned-service-list {

--- a/model/Service/org-openroadm-service.yang
+++ b/model/Service/org-openroadm-service.yang
@@ -21,7 +21,7 @@ module org-openroadm-service {
   }
   import org-openroadm-resource {
     prefix org-openroadm-resource;
-    revision-date 2023-05-26;
+    revision-date 2024-03-29;
   }
   import org-openroadm-common-service-types {
     prefix org-openroadm-common-service-types;
@@ -33,7 +33,7 @@ module org-openroadm-service {
   }
   import org-openroadm-topology {
     prefix org-openroadm-topology;
-    revision-date 2023-05-26;
+    revision-date 2024-03-29;
   }
   import org-openroadm-operational-mode-catalog {
     prefix org-openroadm-operational-mode-catalog;
@@ -45,7 +45,7 @@ module org-openroadm-service {
   }
   import org-openroadm-common-link-types {
     prefix org-openroadm-common-link-types;
-    revision-date 2019-11-29;
+    revision-date 2024-03-29;
   }
 
   organization

--- a/model/Service/org-openroadm-service.yang
+++ b/model/Service/org-openroadm-service.yang
@@ -13,7 +13,7 @@ module org-openroadm-service {
   }
   import org-openroadm-common-types {
     prefix org-openroadm-common-types;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
   import org-openroadm-resource-types {
     prefix org-openroadm-resource-types;
@@ -25,11 +25,11 @@ module org-openroadm-service {
   }
   import org-openroadm-common-service-types {
     prefix org-openroadm-common-service-types;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
   import org-openroadm-controller-customization {
     prefix org-openroadm-controller-customization;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
   import org-openroadm-topology {
     prefix org-openroadm-topology;
@@ -37,7 +37,7 @@ module org-openroadm-service {
   }
   import org-openroadm-operational-mode-catalog {
     prefix org-openroadm-operational-mode-catalog;
-    revision-date 2023-12-08;
+    revision-date 2024-03-29;
   }
   import org-openroadm-common-optical-channel-types {
     prefix org-openroadm-common-optical-channel-types;
@@ -81,6 +81,10 @@ module org-openroadm-service {
       ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
       POSSIBILITY OF SUCH DAMAGE";
 
+  revision 2024-03-29 {
+    description
+      "Version 15.0";
+  }
   revision 2023-12-08 {
     description
       "Version 14.1";

--- a/model/Service/org-openroadm-service.yang
+++ b/model/Service/org-openroadm-service.yang
@@ -9,7 +9,7 @@ module org-openroadm-service {
   }
   import org-openroadm-routing-constraints {
     prefix org-openroadm-routing-constraints;
-    revision-date 2022-12-09;
+    revision-date 2024-03-29;
   }
   import org-openroadm-common-types {
     prefix org-openroadm-common-types;

--- a/model/Service/org-openroadm-topology.yang
+++ b/model/Service/org-openroadm-topology.yang
@@ -4,7 +4,7 @@ module org-openroadm-topology {
 
   import org-openroadm-resource {
     prefix org-openroadm-resource;
-    revision-date 2023-05-26;
+    revision-date 2024-03-29;
   }
   import org-openroadm-network-resource {
     prefix org-openroadm-network-resource;
@@ -12,7 +12,7 @@ module org-openroadm-topology {
   }
   import org-openroadm-port-types {
     prefix org-openroadm-port-types;
-    revision-date 2023-05-26;
+    revision-date 2024-03-29;
   }
 
   organization
@@ -48,6 +48,10 @@ module org-openroadm-topology {
       ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
       POSSIBILITY OF SUCH DAMAGE";
 
+  revision 2024-03-29 {
+    description
+      "Version 15.0";
+  }
   revision 2023-05-26 {
     description
       "Version 13.1";

--- a/model/Service/tree-view-service.txt
+++ b/model/Service/tree-view-service.txt
@@ -538,11 +538,24 @@ module: org-openroadm-service
   |     |  +--rw project-id?                      string
   |     |  +--rw project-note?                    string
   |     |  +--rw optical-attributes
-  |     |     +--rw operational-mode?    string
-  |     |     +--rw rx-estimated-osnr?   org-openroadm-common-link-types:ratio-dB
-  |     |     +--rw rx-estimated-gsnr?   org-openroadm-common-link-types:ratio-dB
-  |     |     +--rw max-output-power?    org-openroadm-common-link-types:ratio-dB
-  |     |     +--rw min-output-power?    org-openroadm-common-link-types:ratio-dB
+  |     |  |  +--rw operational-mode?    string
+  |     |  |  +--rw rx-estimated-osnr?   org-openroadm-common-link-types:ratio-dB
+  |     |  |  +--rw rx-estimated-gsnr?   org-openroadm-common-link-types:ratio-dB
+  |     |  |  +--rw max-output-power?    org-openroadm-common-link-types:ratio-dB
+  |     |  |  +--rw min-output-power?    org-openroadm-common-link-types:ratio-dB
+  |     |  +--rw equipment-required* [equipment-identifier]
+  |     |     +--rw equipment-type?         string
+  |     |     +--rw equipment-identifier    string
+  |     |     +--rw lifecycle-state?        org-openroadm-common-state-types:lifecycle-state
+  |     |     +--rw equipment-rack?         string
+  |     |     +--rw equipment-shelf?        string
+  |     |     +--rw equipment-slot?         string
+  |     |     +--rw equipment-sub-slot?     string
+  |     |     +--rw is-reused?              boolean
+  |     |     +--rw port* [circuit-pack-name port-name]
+  |     |        +--rw circuit-pack-name    string
+  |     |        +--rw port-name            string
+  |     |        +--rw lifecycle-state?     org-openroadm-common-state-types:lifecycle-state
   |     +--rw service-z-end
   |     |  +--rw service-format                   org-openroadm-service-format:service-format
   |     |  +--rw service-rate?                    uint32
@@ -654,11 +667,24 @@ module: org-openroadm-service
   |     |  +--rw project-id?                      string
   |     |  +--rw project-note?                    string
   |     |  +--rw optical-attributes
-  |     |     +--rw operational-mode?    string
-  |     |     +--rw rx-estimated-osnr?   org-openroadm-common-link-types:ratio-dB
-  |     |     +--rw rx-estimated-gsnr?   org-openroadm-common-link-types:ratio-dB
-  |     |     +--rw max-output-power?    org-openroadm-common-link-types:ratio-dB
-  |     |     +--rw min-output-power?    org-openroadm-common-link-types:ratio-dB
+  |     |  |  +--rw operational-mode?    string
+  |     |  |  +--rw rx-estimated-osnr?   org-openroadm-common-link-types:ratio-dB
+  |     |  |  +--rw rx-estimated-gsnr?   org-openroadm-common-link-types:ratio-dB
+  |     |  |  +--rw max-output-power?    org-openroadm-common-link-types:ratio-dB
+  |     |  |  +--rw min-output-power?    org-openroadm-common-link-types:ratio-dB
+  |     |  +--rw equipment-required* [equipment-identifier]
+  |     |     +--rw equipment-type?         string
+  |     |     +--rw equipment-identifier    string
+  |     |     +--rw lifecycle-state?        org-openroadm-common-state-types:lifecycle-state
+  |     |     +--rw equipment-rack?         string
+  |     |     +--rw equipment-shelf?        string
+  |     |     +--rw equipment-slot?         string
+  |     |     +--rw equipment-sub-slot?     string
+  |     |     +--rw is-reused?              boolean
+  |     |     +--rw port* [circuit-pack-name port-name]
+  |     |        +--rw circuit-pack-name    string
+  |     |        +--rw port-name            string
+  |     |        +--rw lifecycle-state?     org-openroadm-common-state-types:lifecycle-state
   |     +--rw hard-constraints
   |     |  +--rw customer-code*      string
   |     |  +--rw operational-mode*   string
@@ -1339,6 +1365,23 @@ module: org-openroadm-service
   |     |        |        +--rw link-id            string
   |     |        +--rw network-resource-type    identityref
   |     +--rw is-bandwidth-locked?         boolean
+  |     +--rw intermediate-site* [clli]
+  |        +--rw clli    string
+  |        +--rw node* [node-id]
+  |           +--rw node-id               org-openroadm-common-node-types:node-id-type
+  |           +--rw equipment-required* [equipment-identifier]
+  |              +--rw equipment-type?         string
+  |              +--rw equipment-identifier    string
+  |              +--rw lifecycle-state?        org-openroadm-common-state-types:lifecycle-state
+  |              +--rw equipment-rack?         string
+  |              +--rw equipment-shelf?        string
+  |              +--rw equipment-slot?         string
+  |              +--rw equipment-sub-slot?     string
+  |              +--rw is-reused?              boolean
+  |              +--rw port* [circuit-pack-name port-name]
+  |                 +--rw circuit-pack-name    string
+  |                 +--rw port-name            string
+  |                 +--rw lifecycle-state?     org-openroadm-common-state-types:lifecycle-state
   +--rw versioned-service-list
   |  +--rw services* [service-name version-number]
   |     +--rw version-number               uint64

--- a/model/Service/tree-view-service.txt
+++ b/model/Service/tree-view-service.txt
@@ -901,7 +901,15 @@ module: org-openroadm-service
   |     |  |  |     |  +--rw versioned-service-name       string
   |     |  |  |     |  +--rw version-number               uint64
   |     |  |  |     +--:(temp-service)
-  |     |  |  |        +--rw common-id                    string
+  |     |  |  |     |  +--rw common-id                    string
+  |     |  |  |     +--:(slot)
+  |     |  |  |     |  +--rw slot
+  |     |  |  |     |     +--rw shelf-name    string
+  |     |  |  |     |     +--rw slot-name     string
+  |     |  |  |     +--:(cp-slot)
+  |     |  |  |        +--rw cp-slot
+  |     |  |  |           +--rw circuit-pack-name    string
+  |     |  |  |           +--rw slot-name            string
   |     |  |  +--rw resourceType
   |     |  |     +--rw type         resource-type-enum
   |     |  |     +--rw extension?   string
@@ -1008,7 +1016,15 @@ module: org-openroadm-service
   |     |     |     |  +--rw versioned-service-name       string
   |     |     |     |  +--rw version-number               uint64
   |     |     |     +--:(temp-service)
-  |     |     |        +--rw common-id                    string
+  |     |     |     |  +--rw common-id                    string
+  |     |     |     +--:(slot)
+  |     |     |     |  +--rw slot
+  |     |     |     |     +--rw shelf-name    string
+  |     |     |     |     +--rw slot-name     string
+  |     |     |     +--:(cp-slot)
+  |     |     |        +--rw cp-slot
+  |     |     |           +--rw circuit-pack-name    string
+  |     |     |           +--rw slot-name            string
   |     |     +--rw resourceType
   |     |        +--rw type         resource-type-enum
   |     |        +--rw extension?   string
@@ -1119,7 +1135,15 @@ module: org-openroadm-service
   |     |     |  |     |  +--rw versioned-service-name       string
   |     |     |  |     |  +--rw version-number               uint64
   |     |     |  |     +--:(temp-service)
-  |     |     |  |        +--rw common-id                    string
+  |     |     |  |     |  +--rw common-id                    string
+  |     |     |  |     +--:(slot)
+  |     |     |  |     |  +--rw slot
+  |     |     |  |     |     +--rw shelf-name    string
+  |     |     |  |     |     +--rw slot-name     string
+  |     |     |  |     +--:(cp-slot)
+  |     |     |  |        +--rw cp-slot
+  |     |     |  |           +--rw circuit-pack-name    string
+  |     |     |  |           +--rw slot-name            string
   |     |     |  +--rw resourceType
   |     |     |     +--rw type         resource-type-enum
   |     |     |     +--rw extension?   string
@@ -1226,7 +1250,15 @@ module: org-openroadm-service
   |     |        |     |  +--rw versioned-service-name       string
   |     |        |     |  +--rw version-number               uint64
   |     |        |     +--:(temp-service)
-  |     |        |        +--rw common-id                    string
+  |     |        |     |  +--rw common-id                    string
+  |     |        |     +--:(slot)
+  |     |        |     |  +--rw slot
+  |     |        |     |     +--rw shelf-name    string
+  |     |        |     |     +--rw slot-name     string
+  |     |        |     +--:(cp-slot)
+  |     |        |        +--rw cp-slot
+  |     |        |           +--rw circuit-pack-name    string
+  |     |        |           +--rw slot-name            string
   |     |        +--rw resourceType
   |     |           +--rw type         resource-type-enum
   |     |           +--rw extension?   string
@@ -1815,7 +1847,15 @@ module: org-openroadm-service
   |     |  |  |     |  +--rw versioned-service-name       string
   |     |  |  |     |  +--rw version-number               uint64
   |     |  |  |     +--:(temp-service)
-  |     |  |  |        +--rw common-id                    string
+  |     |  |  |     |  +--rw common-id                    string
+  |     |  |  |     +--:(slot)
+  |     |  |  |     |  +--rw slot
+  |     |  |  |     |     +--rw shelf-name    string
+  |     |  |  |     |     +--rw slot-name     string
+  |     |  |  |     +--:(cp-slot)
+  |     |  |  |        +--rw cp-slot
+  |     |  |  |           +--rw circuit-pack-name    string
+  |     |  |  |           +--rw slot-name            string
   |     |  |  +--rw resourceType
   |     |  |     +--rw type         resource-type-enum
   |     |  |     +--rw extension?   string
@@ -1922,7 +1962,15 @@ module: org-openroadm-service
   |     |     |     |  +--rw versioned-service-name       string
   |     |     |     |  +--rw version-number               uint64
   |     |     |     +--:(temp-service)
-  |     |     |        +--rw common-id                    string
+  |     |     |     |  +--rw common-id                    string
+  |     |     |     +--:(slot)
+  |     |     |     |  +--rw slot
+  |     |     |     |     +--rw shelf-name    string
+  |     |     |     |     +--rw slot-name     string
+  |     |     |     +--:(cp-slot)
+  |     |     |        +--rw cp-slot
+  |     |     |           +--rw circuit-pack-name    string
+  |     |     |           +--rw slot-name            string
   |     |     +--rw resourceType
   |     |        +--rw type         resource-type-enum
   |     |        +--rw extension?   string
@@ -2033,7 +2081,15 @@ module: org-openroadm-service
   |     |     |  |     |  +--rw versioned-service-name       string
   |     |     |  |     |  +--rw version-number               uint64
   |     |     |  |     +--:(temp-service)
-  |     |     |  |        +--rw common-id                    string
+  |     |     |  |     |  +--rw common-id                    string
+  |     |     |  |     +--:(slot)
+  |     |     |  |     |  +--rw slot
+  |     |     |  |     |     +--rw shelf-name    string
+  |     |     |  |     |     +--rw slot-name     string
+  |     |     |  |     +--:(cp-slot)
+  |     |     |  |        +--rw cp-slot
+  |     |     |  |           +--rw circuit-pack-name    string
+  |     |     |  |           +--rw slot-name            string
   |     |     |  +--rw resourceType
   |     |     |     +--rw type         resource-type-enum
   |     |     |     +--rw extension?   string
@@ -2140,7 +2196,15 @@ module: org-openroadm-service
   |     |        |     |  +--rw versioned-service-name       string
   |     |        |     |  +--rw version-number               uint64
   |     |        |     +--:(temp-service)
-  |     |        |        +--rw common-id                    string
+  |     |        |     |  +--rw common-id                    string
+  |     |        |     +--:(slot)
+  |     |        |     |  +--rw slot
+  |     |        |     |     +--rw shelf-name    string
+  |     |        |     |     +--rw slot-name     string
+  |     |        |     +--:(cp-slot)
+  |     |        |        +--rw cp-slot
+  |     |        |           +--rw circuit-pack-name    string
+  |     |        |           +--rw slot-name            string
   |     |        +--rw resourceType
   |     |           +--rw type         resource-type-enum
   |     |           +--rw extension?   string
@@ -2754,7 +2818,15 @@ module: org-openroadm-service
   |     |  |  |     |  +--rw versioned-service-name       string
   |     |  |  |     |  +--rw version-number               uint64
   |     |  |  |     +--:(temp-service)
-  |     |  |  |        +--rw common-id                    string
+  |     |  |  |     |  +--rw common-id                    string
+  |     |  |  |     +--:(slot)
+  |     |  |  |     |  +--rw slot
+  |     |  |  |     |     +--rw shelf-name    string
+  |     |  |  |     |     +--rw slot-name     string
+  |     |  |  |     +--:(cp-slot)
+  |     |  |  |        +--rw cp-slot
+  |     |  |  |           +--rw circuit-pack-name    string
+  |     |  |  |           +--rw slot-name            string
   |     |  |  +--rw resourceType
   |     |  |     +--rw type         resource-type-enum
   |     |  |     +--rw extension?   string
@@ -2861,7 +2933,15 @@ module: org-openroadm-service
   |     |     |     |  +--rw versioned-service-name       string
   |     |     |     |  +--rw version-number               uint64
   |     |     |     +--:(temp-service)
-  |     |     |        +--rw common-id                    string
+  |     |     |     |  +--rw common-id                    string
+  |     |     |     +--:(slot)
+  |     |     |     |  +--rw slot
+  |     |     |     |     +--rw shelf-name    string
+  |     |     |     |     +--rw slot-name     string
+  |     |     |     +--:(cp-slot)
+  |     |     |        +--rw cp-slot
+  |     |     |           +--rw circuit-pack-name    string
+  |     |     |           +--rw slot-name            string
   |     |     +--rw resourceType
   |     |        +--rw type         resource-type-enum
   |     |        +--rw extension?   string
@@ -2972,7 +3052,15 @@ module: org-openroadm-service
   |     |     |  |     |  +--rw versioned-service-name       string
   |     |     |  |     |  +--rw version-number               uint64
   |     |     |  |     +--:(temp-service)
-  |     |     |  |        +--rw common-id                    string
+  |     |     |  |     |  +--rw common-id                    string
+  |     |     |  |     +--:(slot)
+  |     |     |  |     |  +--rw slot
+  |     |     |  |     |     +--rw shelf-name    string
+  |     |     |  |     |     +--rw slot-name     string
+  |     |     |  |     +--:(cp-slot)
+  |     |     |  |        +--rw cp-slot
+  |     |     |  |           +--rw circuit-pack-name    string
+  |     |     |  |           +--rw slot-name            string
   |     |     |  +--rw resourceType
   |     |     |     +--rw type         resource-type-enum
   |     |     |     +--rw extension?   string
@@ -3079,7 +3167,15 @@ module: org-openroadm-service
   |     |        |     |  +--rw versioned-service-name       string
   |     |        |     |  +--rw version-number               uint64
   |     |        |     +--:(temp-service)
-  |     |        |        +--rw common-id                    string
+  |     |        |     |  +--rw common-id                    string
+  |     |        |     +--:(slot)
+  |     |        |     |  +--rw slot
+  |     |        |     |     +--rw shelf-name    string
+  |     |        |     |     +--rw slot-name     string
+  |     |        |     +--:(cp-slot)
+  |     |        |        +--rw cp-slot
+  |     |        |           +--rw circuit-pack-name    string
+  |     |        |           +--rw slot-name            string
   |     |        +--rw resourceType
   |     |           +--rw type         resource-type-enum
   |     |           +--rw extension?   string
@@ -6192,7 +6288,15 @@ module: org-openroadm-service
     |     |  |  |  |     |  +--ro versioned-service-name       string
     |     |  |  |  |     |  +--ro version-number               uint64
     |     |  |  |  |     +--:(temp-service)
-    |     |  |  |  |        +--ro common-id                    string
+    |     |  |  |  |     |  +--ro common-id                    string
+    |     |  |  |  |     +--:(slot)
+    |     |  |  |  |     |  +--ro slot
+    |     |  |  |  |     |     +--ro shelf-name    string
+    |     |  |  |  |     |     +--ro slot-name     string
+    |     |  |  |  |     +--:(cp-slot)
+    |     |  |  |  |        +--ro cp-slot
+    |     |  |  |  |           +--ro circuit-pack-name    string
+    |     |  |  |  |           +--ro slot-name            string
     |     |  |  |  +--ro resourceType
     |     |  |  |     +--ro type         resource-type-enum
     |     |  |  |     +--ro extension?   string
@@ -6299,7 +6403,15 @@ module: org-openroadm-service
     |     |  |     |     |  +--ro versioned-service-name       string
     |     |  |     |     |  +--ro version-number               uint64
     |     |  |     |     +--:(temp-service)
-    |     |  |     |        +--ro common-id                    string
+    |     |  |     |     |  +--ro common-id                    string
+    |     |  |     |     +--:(slot)
+    |     |  |     |     |  +--ro slot
+    |     |  |     |     |     +--ro shelf-name    string
+    |     |  |     |     |     +--ro slot-name     string
+    |     |  |     |     +--:(cp-slot)
+    |     |  |     |        +--ro cp-slot
+    |     |  |     |           +--ro circuit-pack-name    string
+    |     |  |     |           +--ro slot-name            string
     |     |  |     +--ro resourceType
     |     |  |        +--ro type         resource-type-enum
     |     |  |        +--ro extension?   string
@@ -6410,7 +6522,15 @@ module: org-openroadm-service
     |     |  |     |  |     |  +--ro versioned-service-name       string
     |     |  |     |  |     |  +--ro version-number               uint64
     |     |  |     |  |     +--:(temp-service)
-    |     |  |     |  |        +--ro common-id                    string
+    |     |  |     |  |     |  +--ro common-id                    string
+    |     |  |     |  |     +--:(slot)
+    |     |  |     |  |     |  +--ro slot
+    |     |  |     |  |     |     +--ro shelf-name    string
+    |     |  |     |  |     |     +--ro slot-name     string
+    |     |  |     |  |     +--:(cp-slot)
+    |     |  |     |  |        +--ro cp-slot
+    |     |  |     |  |           +--ro circuit-pack-name    string
+    |     |  |     |  |           +--ro slot-name            string
     |     |  |     |  +--ro resourceType
     |     |  |     |     +--ro type         resource-type-enum
     |     |  |     |     +--ro extension?   string
@@ -6517,7 +6637,15 @@ module: org-openroadm-service
     |     |  |        |     |  +--ro versioned-service-name       string
     |     |  |        |     |  +--ro version-number               uint64
     |     |  |        |     +--:(temp-service)
-    |     |  |        |        +--ro common-id                    string
+    |     |  |        |     |  +--ro common-id                    string
+    |     |  |        |     +--:(slot)
+    |     |  |        |     |  +--ro slot
+    |     |  |        |     |     +--ro shelf-name    string
+    |     |  |        |     |     +--ro slot-name     string
+    |     |  |        |     +--:(cp-slot)
+    |     |  |        |        +--ro cp-slot
+    |     |  |        |           +--ro circuit-pack-name    string
+    |     |  |        |           +--ro slot-name            string
     |     |  |        +--ro resourceType
     |     |  |           +--ro type         resource-type-enum
     |     |  |           +--ro extension?   string
@@ -7097,7 +7225,15 @@ module: org-openroadm-service
     |        |  |  |  |     |  +--ro versioned-service-name       string
     |        |  |  |  |     |  +--ro version-number               uint64
     |        |  |  |  |     +--:(temp-service)
-    |        |  |  |  |        +--ro common-id                    string
+    |        |  |  |  |     |  +--ro common-id                    string
+    |        |  |  |  |     +--:(slot)
+    |        |  |  |  |     |  +--ro slot
+    |        |  |  |  |     |     +--ro shelf-name    string
+    |        |  |  |  |     |     +--ro slot-name     string
+    |        |  |  |  |     +--:(cp-slot)
+    |        |  |  |  |        +--ro cp-slot
+    |        |  |  |  |           +--ro circuit-pack-name    string
+    |        |  |  |  |           +--ro slot-name            string
     |        |  |  |  +--ro resourceType
     |        |  |  |     +--ro type         resource-type-enum
     |        |  |  |     +--ro extension?   string
@@ -7204,7 +7340,15 @@ module: org-openroadm-service
     |        |  |     |     |  +--ro versioned-service-name       string
     |        |  |     |     |  +--ro version-number               uint64
     |        |  |     |     +--:(temp-service)
-    |        |  |     |        +--ro common-id                    string
+    |        |  |     |     |  +--ro common-id                    string
+    |        |  |     |     +--:(slot)
+    |        |  |     |     |  +--ro slot
+    |        |  |     |     |     +--ro shelf-name    string
+    |        |  |     |     |     +--ro slot-name     string
+    |        |  |     |     +--:(cp-slot)
+    |        |  |     |        +--ro cp-slot
+    |        |  |     |           +--ro circuit-pack-name    string
+    |        |  |     |           +--ro slot-name            string
     |        |  |     +--ro resourceType
     |        |  |        +--ro type         resource-type-enum
     |        |  |        +--ro extension?   string
@@ -7315,7 +7459,15 @@ module: org-openroadm-service
     |        |  |     |  |     |  +--ro versioned-service-name       string
     |        |  |     |  |     |  +--ro version-number               uint64
     |        |  |     |  |     +--:(temp-service)
-    |        |  |     |  |        +--ro common-id                    string
+    |        |  |     |  |     |  +--ro common-id                    string
+    |        |  |     |  |     +--:(slot)
+    |        |  |     |  |     |  +--ro slot
+    |        |  |     |  |     |     +--ro shelf-name    string
+    |        |  |     |  |     |     +--ro slot-name     string
+    |        |  |     |  |     +--:(cp-slot)
+    |        |  |     |  |        +--ro cp-slot
+    |        |  |     |  |           +--ro circuit-pack-name    string
+    |        |  |     |  |           +--ro slot-name            string
     |        |  |     |  +--ro resourceType
     |        |  |     |     +--ro type         resource-type-enum
     |        |  |     |     +--ro extension?   string
@@ -7422,7 +7574,15 @@ module: org-openroadm-service
     |        |  |        |     |  +--ro versioned-service-name       string
     |        |  |        |     |  +--ro version-number               uint64
     |        |  |        |     +--:(temp-service)
-    |        |  |        |        +--ro common-id                    string
+    |        |  |        |     |  +--ro common-id                    string
+    |        |  |        |     +--:(slot)
+    |        |  |        |     |  +--ro slot
+    |        |  |        |     |     +--ro shelf-name    string
+    |        |  |        |     |     +--ro slot-name     string
+    |        |  |        |     +--:(cp-slot)
+    |        |  |        |        +--ro cp-slot
+    |        |  |        |           +--ro circuit-pack-name    string
+    |        |  |        |           +--ro slot-name            string
     |        |  |        +--ro resourceType
     |        |  |           +--ro type         resource-type-enum
     |        |  |           +--ro extension?   string
@@ -8130,7 +8290,15 @@ module: org-openroadm-service
     |        |  |  |  |     |  +--ro versioned-service-name       string
     |        |  |  |  |     |  +--ro version-number               uint64
     |        |  |  |  |     +--:(temp-service)
-    |        |  |  |  |        +--ro common-id                    string
+    |        |  |  |  |     |  +--ro common-id                    string
+    |        |  |  |  |     +--:(slot)
+    |        |  |  |  |     |  +--ro slot
+    |        |  |  |  |     |     +--ro shelf-name    string
+    |        |  |  |  |     |     +--ro slot-name     string
+    |        |  |  |  |     +--:(cp-slot)
+    |        |  |  |  |        +--ro cp-slot
+    |        |  |  |  |           +--ro circuit-pack-name    string
+    |        |  |  |  |           +--ro slot-name            string
     |        |  |  |  +--ro resourceType
     |        |  |  |     +--ro type         resource-type-enum
     |        |  |  |     +--ro extension?   string
@@ -8237,7 +8405,15 @@ module: org-openroadm-service
     |        |  |     |     |  +--ro versioned-service-name       string
     |        |  |     |     |  +--ro version-number               uint64
     |        |  |     |     +--:(temp-service)
-    |        |  |     |        +--ro common-id                    string
+    |        |  |     |     |  +--ro common-id                    string
+    |        |  |     |     +--:(slot)
+    |        |  |     |     |  +--ro slot
+    |        |  |     |     |     +--ro shelf-name    string
+    |        |  |     |     |     +--ro slot-name     string
+    |        |  |     |     +--:(cp-slot)
+    |        |  |     |        +--ro cp-slot
+    |        |  |     |           +--ro circuit-pack-name    string
+    |        |  |     |           +--ro slot-name            string
     |        |  |     +--ro resourceType
     |        |  |        +--ro type         resource-type-enum
     |        |  |        +--ro extension?   string
@@ -8348,7 +8524,15 @@ module: org-openroadm-service
     |        |  |     |  |     |  +--ro versioned-service-name       string
     |        |  |     |  |     |  +--ro version-number               uint64
     |        |  |     |  |     +--:(temp-service)
-    |        |  |     |  |        +--ro common-id                    string
+    |        |  |     |  |     |  +--ro common-id                    string
+    |        |  |     |  |     +--:(slot)
+    |        |  |     |  |     |  +--ro slot
+    |        |  |     |  |     |     +--ro shelf-name    string
+    |        |  |     |  |     |     +--ro slot-name     string
+    |        |  |     |  |     +--:(cp-slot)
+    |        |  |     |  |        +--ro cp-slot
+    |        |  |     |  |           +--ro circuit-pack-name    string
+    |        |  |     |  |           +--ro slot-name            string
     |        |  |     |  +--ro resourceType
     |        |  |     |     +--ro type         resource-type-enum
     |        |  |     |     +--ro extension?   string
@@ -8455,7 +8639,15 @@ module: org-openroadm-service
     |        |  |        |     |  +--ro versioned-service-name       string
     |        |  |        |     |  +--ro version-number               uint64
     |        |  |        |     +--:(temp-service)
-    |        |  |        |        +--ro common-id                    string
+    |        |  |        |     |  +--ro common-id                    string
+    |        |  |        |     +--:(slot)
+    |        |  |        |     |  +--ro slot
+    |        |  |        |     |     +--ro shelf-name    string
+    |        |  |        |     |     +--ro slot-name     string
+    |        |  |        |     +--:(cp-slot)
+    |        |  |        |        +--ro cp-slot
+    |        |  |        |           +--ro circuit-pack-name    string
+    |        |  |        |           +--ro slot-name            string
     |        |  |        +--ro resourceType
     |        |  |           +--ro type         resource-type-enum
     |        |  |           +--ro extension?   string
@@ -11641,7 +11833,15 @@ module: org-openroadm-service
     |  |  |  |     |  +--ro versioned-service-name       string
     |  |  |  |     |  +--ro version-number               uint64
     |  |  |  |     +--:(temp-service)
-    |  |  |  |        +--ro common-id                    string
+    |  |  |  |     |  +--ro common-id                    string
+    |  |  |  |     +--:(slot)
+    |  |  |  |     |  +--ro slot
+    |  |  |  |     |     +--ro shelf-name    string
+    |  |  |  |     |     +--ro slot-name     string
+    |  |  |  |     +--:(cp-slot)
+    |  |  |  |        +--ro cp-slot
+    |  |  |  |           +--ro circuit-pack-name    string
+    |  |  |  |           +--ro slot-name            string
     |  |  |  +--ro resourceType
     |  |  |     +--ro type         resource-type-enum
     |  |  |     +--ro extension?   string
@@ -11748,7 +11948,15 @@ module: org-openroadm-service
     |  |     |     |  +--ro versioned-service-name       string
     |  |     |     |  +--ro version-number               uint64
     |  |     |     +--:(temp-service)
-    |  |     |        +--ro common-id                    string
+    |  |     |     |  +--ro common-id                    string
+    |  |     |     +--:(slot)
+    |  |     |     |  +--ro slot
+    |  |     |     |     +--ro shelf-name    string
+    |  |     |     |     +--ro slot-name     string
+    |  |     |     +--:(cp-slot)
+    |  |     |        +--ro cp-slot
+    |  |     |           +--ro circuit-pack-name    string
+    |  |     |           +--ro slot-name            string
     |  |     +--ro resourceType
     |  |        +--ro type         resource-type-enum
     |  |        +--ro extension?   string
@@ -11859,7 +12067,15 @@ module: org-openroadm-service
     |  |     |  |     |  +--ro versioned-service-name       string
     |  |     |  |     |  +--ro version-number               uint64
     |  |     |  |     +--:(temp-service)
-    |  |     |  |        +--ro common-id                    string
+    |  |     |  |     |  +--ro common-id                    string
+    |  |     |  |     +--:(slot)
+    |  |     |  |     |  +--ro slot
+    |  |     |  |     |     +--ro shelf-name    string
+    |  |     |  |     |     +--ro slot-name     string
+    |  |     |  |     +--:(cp-slot)
+    |  |     |  |        +--ro cp-slot
+    |  |     |  |           +--ro circuit-pack-name    string
+    |  |     |  |           +--ro slot-name            string
     |  |     |  +--ro resourceType
     |  |     |     +--ro type         resource-type-enum
     |  |     |     +--ro extension?   string
@@ -11966,7 +12182,15 @@ module: org-openroadm-service
     |  |        |     |  +--ro versioned-service-name       string
     |  |        |     |  +--ro version-number               uint64
     |  |        |     +--:(temp-service)
-    |  |        |        +--ro common-id                    string
+    |  |        |     |  +--ro common-id                    string
+    |  |        |     +--:(slot)
+    |  |        |     |  +--ro slot
+    |  |        |     |     +--ro shelf-name    string
+    |  |        |     |     +--ro slot-name     string
+    |  |        |     +--:(cp-slot)
+    |  |        |        +--ro cp-slot
+    |  |        |           +--ro circuit-pack-name    string
+    |  |        |           +--ro slot-name            string
     |  |        +--ro resourceType
     |  |           +--ro type         resource-type-enum
     |  |           +--ro extension?   string
@@ -12556,7 +12780,15 @@ module: org-openroadm-service
     |  |  |  |     |  +--ro versioned-service-name       string
     |  |  |  |     |  +--ro version-number               uint64
     |  |  |  |     +--:(temp-service)
-    |  |  |  |        +--ro common-id                    string
+    |  |  |  |     |  +--ro common-id                    string
+    |  |  |  |     +--:(slot)
+    |  |  |  |     |  +--ro slot
+    |  |  |  |     |     +--ro shelf-name    string
+    |  |  |  |     |     +--ro slot-name     string
+    |  |  |  |     +--:(cp-slot)
+    |  |  |  |        +--ro cp-slot
+    |  |  |  |           +--ro circuit-pack-name    string
+    |  |  |  |           +--ro slot-name            string
     |  |  |  +--ro resourceType
     |  |  |     +--ro type         resource-type-enum
     |  |  |     +--ro extension?   string
@@ -12663,7 +12895,15 @@ module: org-openroadm-service
     |  |     |     |  +--ro versioned-service-name       string
     |  |     |     |  +--ro version-number               uint64
     |  |     |     +--:(temp-service)
-    |  |     |        +--ro common-id                    string
+    |  |     |     |  +--ro common-id                    string
+    |  |     |     +--:(slot)
+    |  |     |     |  +--ro slot
+    |  |     |     |     +--ro shelf-name    string
+    |  |     |     |     +--ro slot-name     string
+    |  |     |     +--:(cp-slot)
+    |  |     |        +--ro cp-slot
+    |  |     |           +--ro circuit-pack-name    string
+    |  |     |           +--ro slot-name            string
     |  |     +--ro resourceType
     |  |        +--ro type         resource-type-enum
     |  |        +--ro extension?   string
@@ -12774,7 +13014,15 @@ module: org-openroadm-service
     |  |     |  |     |  +--ro versioned-service-name       string
     |  |     |  |     |  +--ro version-number               uint64
     |  |     |  |     +--:(temp-service)
-    |  |     |  |        +--ro common-id                    string
+    |  |     |  |     |  +--ro common-id                    string
+    |  |     |  |     +--:(slot)
+    |  |     |  |     |  +--ro slot
+    |  |     |  |     |     +--ro shelf-name    string
+    |  |     |  |     |     +--ro slot-name     string
+    |  |     |  |     +--:(cp-slot)
+    |  |     |  |        +--ro cp-slot
+    |  |     |  |           +--ro circuit-pack-name    string
+    |  |     |  |           +--ro slot-name            string
     |  |     |  +--ro resourceType
     |  |     |     +--ro type         resource-type-enum
     |  |     |     +--ro extension?   string
@@ -12881,7 +13129,15 @@ module: org-openroadm-service
     |  |        |     |  +--ro versioned-service-name       string
     |  |        |     |  +--ro version-number               uint64
     |  |        |     +--:(temp-service)
-    |  |        |        +--ro common-id                    string
+    |  |        |     |  +--ro common-id                    string
+    |  |        |     +--:(slot)
+    |  |        |     |  +--ro slot
+    |  |        |     |     +--ro shelf-name    string
+    |  |        |     |     +--ro slot-name     string
+    |  |        |     +--:(cp-slot)
+    |  |        |        +--ro cp-slot
+    |  |        |           +--ro circuit-pack-name    string
+    |  |        |           +--ro slot-name            string
     |  |        +--ro resourceType
     |  |           +--ro type         resource-type-enum
     |  |           +--ro extension?   string

--- a/model/Service/tree-view-service.txt
+++ b/model/Service/tree-view-service.txt
@@ -349,10 +349,17 @@ module: org-openroadm-controller-customization
        |  |  |     +---w link-restriction-type?   link-restriction-type
        |  |  |     +---w restriction-scopes*      restriction-scope
        |  |  +---w supporting-service-restriction
-       |  |     +---w supporting-service-list* [supporting-service]
-       |  |        +---w supporting-service                     string
-       |  |        +---w supporting-service-restriction-type?   link-restriction-type
-       |  |        +---w restriction-scopes*                    restriction-scope
+       |  |  |  +---w supporting-service-list* [supporting-service]
+       |  |  |     +---w supporting-service                     string
+       |  |  |     +---w supporting-service-restriction-type?   link-restriction-type
+       |  |  |     +---w restriction-scopes*                    restriction-scope
+       |  |  +---w srg-restriction
+       |  |     +---w node-srg-restriction* [node-id]
+       |  |        +---w node-id     org-openroadm-common-node-types:node-id-type
+       |  |        +---w srg-list* [srg-number]
+       |  |           +---w srg-number            uint16
+       |  |           +---w restriction-type?     restriction-type
+       |  |           +---w restriction-scopes*   restriction-scope
        |  +---w default-behaviour
        |  |  +---w default-backup-path-number?   uint16
        |  |  +---w reversion?                    boolean
@@ -676,6 +683,10 @@ module: org-openroadm-service
   |     |  |  |  +--rw link-network-id    string
   |     |  |  |  +--rw link-id            string
   |     |  |  +--rw supporting-service-name*   string
+  |     |  |  +--rw node-srg* [node-id]
+  |     |  |     +--rw node-id     org-openroadm-common-node-types:node-id-type
+  |     |  |     +--rw srg-list* [srg-number]
+  |     |  |        +--rw srg-number    uint16
   |     |  +--rw include
   |     |  |  +--rw is-explicit-routing?       boolean
   |     |  |  +--rw is-include-list-ordered?   boolean
@@ -732,6 +743,10 @@ module: org-openroadm-service
   |     |  |  |  +--rw link-network-id    string
   |     |  |  |  +--rw link-id            string
   |     |  |  +--rw supporting-service-name*   string
+  |     |  |  +--rw node-srg* [node-id]
+  |     |  |     +--rw node-id     org-openroadm-common-node-types:node-id-type
+  |     |  |     +--rw srg-list* [srg-number]
+  |     |  |        +--rw srg-number    uint16
   |     |  +--rw include
   |     |  |  +--rw is-explicit-routing?       boolean
   |     |  |  +--rw is-include-list-ordered?   boolean
@@ -1622,6 +1637,10 @@ module: org-openroadm-service
   |     |  |  |  +--rw link-network-id    string
   |     |  |  |  +--rw link-id            string
   |     |  |  +--rw supporting-service-name*   string
+  |     |  |  +--rw node-srg* [node-id]
+  |     |  |     +--rw node-id     org-openroadm-common-node-types:node-id-type
+  |     |  |     +--rw srg-list* [srg-number]
+  |     |  |        +--rw srg-number    uint16
   |     |  +--rw include
   |     |  |  +--rw is-explicit-routing?       boolean
   |     |  |  +--rw is-include-list-ordered?   boolean
@@ -1678,6 +1697,10 @@ module: org-openroadm-service
   |     |  |  |  +--rw link-network-id    string
   |     |  |  |  +--rw link-id            string
   |     |  |  +--rw supporting-service-name*   string
+  |     |  |  +--rw node-srg* [node-id]
+  |     |  |     +--rw node-id     org-openroadm-common-node-types:node-id-type
+  |     |  |     +--rw srg-list* [srg-number]
+  |     |  |        +--rw srg-number    uint16
   |     |  +--rw include
   |     |  |  +--rw is-explicit-routing?       boolean
   |     |  |  +--rw is-include-list-ordered?   boolean
@@ -2593,6 +2616,10 @@ module: org-openroadm-service
   |     |  |  |  +--rw link-network-id    string
   |     |  |  |  +--rw link-id            string
   |     |  |  +--rw supporting-service-name*   string
+  |     |  |  +--rw node-srg* [node-id]
+  |     |  |     +--rw node-id     org-openroadm-common-node-types:node-id-type
+  |     |  |     +--rw srg-list* [srg-number]
+  |     |  |        +--rw srg-number    uint16
   |     |  +--rw include
   |     |  |  +--rw is-explicit-routing?       boolean
   |     |  |  +--rw is-include-list-ordered?   boolean
@@ -2649,6 +2676,10 @@ module: org-openroadm-service
   |     |  |  |  +--rw link-network-id    string
   |     |  |  |  +--rw link-id            string
   |     |  |  +--rw supporting-service-name*   string
+  |     |  |  +--rw node-srg* [node-id]
+  |     |  |     +--rw node-id     org-openroadm-common-node-types:node-id-type
+  |     |  |     +--rw srg-list* [srg-number]
+  |     |  |        +--rw srg-number    uint16
   |     |  +--rw include
   |     |  |  +--rw is-explicit-routing?       boolean
   |     |  |  +--rw is-include-list-ordered?   boolean
@@ -3369,10 +3400,17 @@ module: org-openroadm-service
   |  |  |     +--rw link-restriction-type?   link-restriction-type
   |  |  |     +--rw restriction-scopes*      restriction-scope
   |  |  +--rw supporting-service-restriction
-  |  |     +--rw supporting-service-list* [supporting-service]
-  |  |        +--rw supporting-service                     string
-  |  |        +--rw supporting-service-restriction-type?   link-restriction-type
-  |  |        +--rw restriction-scopes*                    restriction-scope
+  |  |  |  +--rw supporting-service-list* [supporting-service]
+  |  |  |     +--rw supporting-service                     string
+  |  |  |     +--rw supporting-service-restriction-type?   link-restriction-type
+  |  |  |     +--rw restriction-scopes*                    restriction-scope
+  |  |  +--rw srg-restriction
+  |  |     +--rw node-srg-restriction* [node-id]
+  |  |        +--rw node-id     org-openroadm-common-node-types:node-id-type
+  |  |        +--rw srg-list* [srg-number]
+  |  |           +--rw srg-number            uint16
+  |  |           +--rw restriction-type?     restriction-type
+  |  |           +--rw restriction-scopes*   restriction-scope
   |  +--rw default-behaviour
   |  |  +--rw default-backup-path-number?   uint16
   |  |  +--rw reversion?                    boolean
@@ -3815,6 +3853,10 @@ module: org-openroadm-service
     |  |  |  |  |  +---w link-network-id    string
     |  |  |  |  |  +---w link-id            string
     |  |  |  |  +---w supporting-service-name*   string
+    |  |  |  |  +---w node-srg* [node-id]
+    |  |  |  |     +---w node-id     org-openroadm-common-node-types:node-id-type
+    |  |  |  |     +---w srg-list* [srg-number]
+    |  |  |  |        +---w srg-number    uint16
     |  |  |  +---w include
     |  |  |  |  +---w is-explicit-routing?       boolean
     |  |  |  |  +---w is-include-list-ordered?   boolean
@@ -3871,6 +3913,10 @@ module: org-openroadm-service
     |  |  |  |  |  +---w link-network-id    string
     |  |  |  |  |  +---w link-id            string
     |  |  |  |  +---w supporting-service-name*   string
+    |  |  |  |  +---w node-srg* [node-id]
+    |  |  |  |     +---w node-id     org-openroadm-common-node-types:node-id-type
+    |  |  |  |     +---w srg-list* [srg-number]
+    |  |  |  |        +---w srg-number    uint16
     |  |  |  +---w include
     |  |  |  |  +---w is-explicit-routing?       boolean
     |  |  |  |  +---w is-include-list-ordered?   boolean
@@ -3961,6 +4007,10 @@ module: org-openroadm-service
     |        |  |  |  +--ro link-network-id    string
     |        |  |  |  +--ro link-id            string
     |        |  |  +--ro supporting-service-name*   string
+    |        |  |  +--ro node-srg* [node-id]
+    |        |  |     +--ro node-id     org-openroadm-common-node-types:node-id-type
+    |        |  |     +--ro srg-list* [srg-number]
+    |        |  |        +--ro srg-number    uint16
     |        |  +--ro include
     |        |  |  +--ro is-explicit-routing?       boolean
     |        |  |  +--ro is-include-list-ordered?   boolean
@@ -4017,6 +4067,10 @@ module: org-openroadm-service
     |           |  |  +--ro link-network-id    string
     |           |  |  +--ro link-id            string
     |           |  +--ro supporting-service-name*   string
+    |           |  +--ro node-srg* [node-id]
+    |           |     +--ro node-id     org-openroadm-common-node-types:node-id-type
+    |           |     +--ro srg-list* [srg-number]
+    |           |        +--ro srg-number    uint16
     |           +--ro include
     |           |  +--ro is-explicit-routing?       boolean
     |           |  +--ro is-include-list-ordered?   boolean
@@ -4329,6 +4383,10 @@ module: org-openroadm-service
     |  |     |  |  |  +---w link-network-id    string
     |  |     |  |  |  +---w link-id            string
     |  |     |  |  +---w supporting-service-name*   string
+    |  |     |  |  +---w node-srg* [node-id]
+    |  |     |  |     +---w node-id     org-openroadm-common-node-types:node-id-type
+    |  |     |  |     +---w srg-list* [srg-number]
+    |  |     |  |        +---w srg-number    uint16
     |  |     |  +---w include
     |  |     |  |  +---w is-explicit-routing?       boolean
     |  |     |  |  +---w is-include-list-ordered?   boolean
@@ -4385,6 +4443,10 @@ module: org-openroadm-service
     |  |     |  |  |  +---w link-network-id    string
     |  |     |  |  |  +---w link-id            string
     |  |     |  |  +---w supporting-service-name*   string
+    |  |     |  |  +---w node-srg* [node-id]
+    |  |     |  |     +---w node-id     org-openroadm-common-node-types:node-id-type
+    |  |     |  |     +---w srg-list* [srg-number]
+    |  |     |  |        +---w srg-number    uint16
     |  |     |  +---w include
     |  |     |  |  +---w is-explicit-routing?       boolean
     |  |     |  |  +---w is-include-list-ordered?   boolean
@@ -4477,6 +4539,10 @@ module: org-openroadm-service
     |           |  |  |  +--ro link-network-id    string
     |           |  |  |  +--ro link-id            string
     |           |  |  +--ro supporting-service-name*   string
+    |           |  |  +--ro node-srg* [node-id]
+    |           |  |     +--ro node-id     org-openroadm-common-node-types:node-id-type
+    |           |  |     +--ro srg-list* [srg-number]
+    |           |  |        +--ro srg-number    uint16
     |           |  +--ro include
     |           |  |  +--ro is-explicit-routing?       boolean
     |           |  |  +--ro is-include-list-ordered?   boolean
@@ -4533,6 +4599,10 @@ module: org-openroadm-service
     |              |  |  +--ro link-network-id    string
     |              |  |  +--ro link-id            string
     |              |  +--ro supporting-service-name*   string
+    |              |  +--ro node-srg* [node-id]
+    |              |     +--ro node-id     org-openroadm-common-node-types:node-id-type
+    |              |     +--ro srg-list* [srg-number]
+    |              |        +--ro srg-number    uint16
     |              +--ro include
     |              |  +--ro is-explicit-routing?       boolean
     |              |  +--ro is-include-list-ordered?   boolean
@@ -4844,6 +4914,10 @@ module: org-openroadm-service
     |  |     |  |  |  +---w link-network-id    string
     |  |     |  |  |  +---w link-id            string
     |  |     |  |  +---w supporting-service-name*   string
+    |  |     |  |  +---w node-srg* [node-id]
+    |  |     |  |     +---w node-id     org-openroadm-common-node-types:node-id-type
+    |  |     |  |     +---w srg-list* [srg-number]
+    |  |     |  |        +---w srg-number    uint16
     |  |     |  +---w include
     |  |     |  |  +---w is-explicit-routing?       boolean
     |  |     |  |  +---w is-include-list-ordered?   boolean
@@ -4900,6 +4974,10 @@ module: org-openroadm-service
     |  |     |  |  |  +---w link-network-id    string
     |  |     |  |  |  +---w link-id            string
     |  |     |  |  +---w supporting-service-name*   string
+    |  |     |  |  +---w node-srg* [node-id]
+    |  |     |  |     +---w node-id     org-openroadm-common-node-types:node-id-type
+    |  |     |  |     +---w srg-list* [srg-number]
+    |  |     |  |        +---w srg-number    uint16
     |  |     |  +---w include
     |  |     |  |  +---w is-explicit-routing?       boolean
     |  |     |  |  +---w is-include-list-ordered?   boolean
@@ -4997,6 +5075,10 @@ module: org-openroadm-service
     |        |  |  |  |  +--ro link-network-id    string
     |        |  |  |  |  +--ro link-id            string
     |        |  |  |  +--ro supporting-service-name*   string
+    |        |  |  |  +--ro node-srg* [node-id]
+    |        |  |  |     +--ro node-id     org-openroadm-common-node-types:node-id-type
+    |        |  |  |     +--ro srg-list* [srg-number]
+    |        |  |  |        +--ro srg-number    uint16
     |        |  |  +--ro include
     |        |  |  |  +--ro is-explicit-routing?       boolean
     |        |  |  |  +--ro is-include-list-ordered?   boolean
@@ -5053,6 +5135,10 @@ module: org-openroadm-service
     |        |     |  |  +--ro link-network-id    string
     |        |     |  |  +--ro link-id            string
     |        |     |  +--ro supporting-service-name*   string
+    |        |     |  +--ro node-srg* [node-id]
+    |        |     |     +--ro node-id     org-openroadm-common-node-types:node-id-type
+    |        |     |     +--ro srg-list* [srg-number]
+    |        |     |        +--ro srg-number    uint16
     |        |     +--ro include
     |        |     |  +--ro is-explicit-routing?       boolean
     |        |     |  +--ro is-include-list-ordered?   boolean
@@ -5610,6 +5696,10 @@ module: org-openroadm-service
     |  |  |  |  |  +---w link-network-id    string
     |  |  |  |  |  +---w link-id            string
     |  |  |  |  +---w supporting-service-name*   string
+    |  |  |  |  +---w node-srg* [node-id]
+    |  |  |  |     +---w node-id     org-openroadm-common-node-types:node-id-type
+    |  |  |  |     +---w srg-list* [srg-number]
+    |  |  |  |        +---w srg-number    uint16
     |  |  |  +---w include
     |  |  |  |  +---w is-explicit-routing?       boolean
     |  |  |  |  +---w is-include-list-ordered?   boolean
@@ -5666,6 +5756,10 @@ module: org-openroadm-service
     |  |  |  |  |  +---w link-network-id    string
     |  |  |  |  |  +---w link-id            string
     |  |  |  |  +---w supporting-service-name*   string
+    |  |  |  |  +---w node-srg* [node-id]
+    |  |  |  |     +---w node-id     org-openroadm-common-node-types:node-id-type
+    |  |  |  |     +---w srg-list* [srg-number]
+    |  |  |  |        +---w srg-number    uint16
     |  |  |  +---w include
     |  |  |  |  +---w is-explicit-routing?       boolean
     |  |  |  |  +---w is-include-list-ordered?   boolean
@@ -5764,6 +5858,10 @@ module: org-openroadm-service
     |     |  |  |  |  +--ro link-network-id    string
     |     |  |  |  |  +--ro link-id            string
     |     |  |  |  +--ro supporting-service-name*   string
+    |     |  |  |  +--ro node-srg* [node-id]
+    |     |  |  |     +--ro node-id     org-openroadm-common-node-types:node-id-type
+    |     |  |  |     +--ro srg-list* [srg-number]
+    |     |  |  |        +--ro srg-number    uint16
     |     |  |  +--ro include
     |     |  |  |  +--ro is-explicit-routing?       boolean
     |     |  |  |  +--ro is-include-list-ordered?   boolean
@@ -5820,6 +5918,10 @@ module: org-openroadm-service
     |     |     |  |  +--ro link-network-id    string
     |     |     |  |  +--ro link-id            string
     |     |     |  +--ro supporting-service-name*   string
+    |     |     |  +--ro node-srg* [node-id]
+    |     |     |     +--ro node-id     org-openroadm-common-node-types:node-id-type
+    |     |     |     +--ro srg-list* [srg-number]
+    |     |     |        +--ro srg-number    uint16
     |     |     +--ro include
     |     |     |  +--ro is-explicit-routing?       boolean
     |     |     |  +--ro is-include-list-ordered?   boolean
@@ -7766,6 +7868,10 @@ module: org-openroadm-service
     |        |  |  |  |  +--ro link-network-id    string
     |        |  |  |  |  +--ro link-id            string
     |        |  |  |  +--ro supporting-service-name*   string
+    |        |  |  |  +--ro node-srg* [node-id]
+    |        |  |  |     +--ro node-id     org-openroadm-common-node-types:node-id-type
+    |        |  |  |     +--ro srg-list* [srg-number]
+    |        |  |  |        +--ro srg-number    uint16
     |        |  |  +--ro include
     |        |  |  |  +--ro is-explicit-routing?       boolean
     |        |  |  |  +--ro is-include-list-ordered?   boolean
@@ -7822,6 +7928,10 @@ module: org-openroadm-service
     |        |     |  |  +--ro link-network-id    string
     |        |     |  |  +--ro link-id            string
     |        |     |  +--ro supporting-service-name*   string
+    |        |     |  +--ro node-srg* [node-id]
+    |        |     |     +--ro node-id     org-openroadm-common-node-types:node-id-type
+    |        |     |     +--ro srg-list* [srg-number]
+    |        |     |        +--ro srg-number    uint16
     |        |     +--ro include
     |        |     |  +--ro is-explicit-routing?       boolean
     |        |     |  +--ro is-include-list-ordered?   boolean
@@ -9097,6 +9207,10 @@ module: org-openroadm-service
     |  |  |  |  |  +---w link-network-id    string
     |  |  |  |  |  +---w link-id            string
     |  |  |  |  +---w supporting-service-name*   string
+    |  |  |  |  +---w node-srg* [node-id]
+    |  |  |  |     +---w node-id     org-openroadm-common-node-types:node-id-type
+    |  |  |  |     +---w srg-list* [srg-number]
+    |  |  |  |        +---w srg-number    uint16
     |  |  |  +---w include
     |  |  |  |  +---w is-explicit-routing?       boolean
     |  |  |  |  +---w is-include-list-ordered?   boolean
@@ -9153,6 +9267,10 @@ module: org-openroadm-service
     |  |  |  |  |  +---w link-network-id    string
     |  |  |  |  |  +---w link-id            string
     |  |  |  |  +---w supporting-service-name*   string
+    |  |  |  |  +---w node-srg* [node-id]
+    |  |  |  |     +---w node-id     org-openroadm-common-node-types:node-id-type
+    |  |  |  |     +---w srg-list* [srg-number]
+    |  |  |  |        +---w srg-number    uint16
     |  |  |  +---w include
     |  |  |  |  +---w is-explicit-routing?       boolean
     |  |  |  |  +---w is-include-list-ordered?   boolean
@@ -9270,6 +9388,10 @@ module: org-openroadm-service
     |     |  |  |  |  +--ro link-network-id    string
     |     |  |  |  |  +--ro link-id            string
     |     |  |  |  +--ro supporting-service-name*   string
+    |     |  |  |  +--ro node-srg* [node-id]
+    |     |  |  |     +--ro node-id     org-openroadm-common-node-types:node-id-type
+    |     |  |  |     +--ro srg-list* [srg-number]
+    |     |  |  |        +--ro srg-number    uint16
     |     |  |  +--ro include
     |     |  |  |  +--ro is-explicit-routing?       boolean
     |     |  |  |  +--ro is-include-list-ordered?   boolean
@@ -9326,6 +9448,10 @@ module: org-openroadm-service
     |     |     |  |  +--ro link-network-id    string
     |     |     |  |  +--ro link-id            string
     |     |     |  +--ro supporting-service-name*   string
+    |     |     |  +--ro node-srg* [node-id]
+    |     |     |     +--ro node-id     org-openroadm-common-node-types:node-id-type
+    |     |     |     +--ro srg-list* [srg-number]
+    |     |     |        +--ro srg-number    uint16
     |     |     +--ro include
     |     |     |  +--ro is-explicit-routing?       boolean
     |     |     |  +--ro is-include-list-ordered?   boolean
@@ -9692,6 +9818,10 @@ module: org-openroadm-service
     |  |  |  |  |  +---w link-network-id    string
     |  |  |  |  |  +---w link-id            string
     |  |  |  |  +---w supporting-service-name*   string
+    |  |  |  |  +---w node-srg* [node-id]
+    |  |  |  |     +---w node-id     org-openroadm-common-node-types:node-id-type
+    |  |  |  |     +---w srg-list* [srg-number]
+    |  |  |  |        +---w srg-number    uint16
     |  |  |  +---w include
     |  |  |  |  +---w is-explicit-routing?       boolean
     |  |  |  |  +---w is-include-list-ordered?   boolean
@@ -9748,6 +9878,10 @@ module: org-openroadm-service
     |  |  |  |  |  +---w link-network-id    string
     |  |  |  |  |  +---w link-id            string
     |  |  |  |  +---w supporting-service-name*   string
+    |  |  |  |  +---w node-srg* [node-id]
+    |  |  |  |     +---w node-id     org-openroadm-common-node-types:node-id-type
+    |  |  |  |     +---w srg-list* [srg-number]
+    |  |  |  |        +---w srg-number    uint16
     |  |  |  +---w include
     |  |  |  |  +---w is-explicit-routing?       boolean
     |  |  |  |  +---w is-include-list-ordered?   boolean
@@ -9861,6 +9995,10 @@ module: org-openroadm-service
     |        |  |  |  +--ro link-network-id    string
     |        |  |  |  +--ro link-id            string
     |        |  |  +--ro supporting-service-name*   string
+    |        |  |  +--ro node-srg* [node-id]
+    |        |  |     +--ro node-id     org-openroadm-common-node-types:node-id-type
+    |        |  |     +--ro srg-list* [srg-number]
+    |        |  |        +--ro srg-number    uint16
     |        |  +--ro include
     |        |  |  +--ro is-explicit-routing?       boolean
     |        |  |  +--ro is-include-list-ordered?   boolean
@@ -9917,6 +10055,10 @@ module: org-openroadm-service
     |           |  |  +--ro link-network-id    string
     |           |  |  +--ro link-id            string
     |           |  +--ro supporting-service-name*   string
+    |           |  +--ro node-srg* [node-id]
+    |           |     +--ro node-id     org-openroadm-common-node-types:node-id-type
+    |           |     +--ro srg-list* [srg-number]
+    |           |        +--ro srg-number    uint16
     |           +--ro include
     |           |  +--ro is-explicit-routing?       boolean
     |           |  +--ro is-include-list-ordered?   boolean
@@ -10209,6 +10351,10 @@ module: org-openroadm-service
     |  |     |  |  |  +---w link-network-id    string
     |  |     |  |  |  +---w link-id            string
     |  |     |  |  +---w supporting-service-name*   string
+    |  |     |  |  +---w node-srg* [node-id]
+    |  |     |  |     +---w node-id     org-openroadm-common-node-types:node-id-type
+    |  |     |  |     +---w srg-list* [srg-number]
+    |  |     |  |        +---w srg-number    uint16
     |  |     |  +---w include
     |  |     |  |  +---w is-explicit-routing?       boolean
     |  |     |  |  +---w is-include-list-ordered?   boolean
@@ -10265,6 +10411,10 @@ module: org-openroadm-service
     |  |     |  |  |  +---w link-network-id    string
     |  |     |  |  |  +---w link-id            string
     |  |     |  |  +---w supporting-service-name*   string
+    |  |     |  |  +---w node-srg* [node-id]
+    |  |     |  |     +---w node-id     org-openroadm-common-node-types:node-id-type
+    |  |     |  |     +---w srg-list* [srg-number]
+    |  |     |  |        +---w srg-number    uint16
     |  |     |  +---w include
     |  |     |  |  +---w is-explicit-routing?       boolean
     |  |     |  |  +---w is-include-list-ordered?   boolean
@@ -10380,6 +10530,10 @@ module: org-openroadm-service
     |        |  |  |  +--ro link-network-id    string
     |        |  |  |  +--ro link-id            string
     |        |  |  +--ro supporting-service-name*   string
+    |        |  |  +--ro node-srg* [node-id]
+    |        |  |     +--ro node-id     org-openroadm-common-node-types:node-id-type
+    |        |  |     +--ro srg-list* [srg-number]
+    |        |  |        +--ro srg-number    uint16
     |        |  +--ro include
     |        |  |  +--ro is-explicit-routing?       boolean
     |        |  |  +--ro is-include-list-ordered?   boolean
@@ -10436,6 +10590,10 @@ module: org-openroadm-service
     |           |  |  +--ro link-network-id    string
     |           |  |  +--ro link-id            string
     |           |  +--ro supporting-service-name*   string
+    |           |  +--ro node-srg* [node-id]
+    |           |     +--ro node-id     org-openroadm-common-node-types:node-id-type
+    |           |     +--ro srg-list* [srg-number]
+    |           |        +--ro srg-number    uint16
     |           +--ro include
     |           |  +--ro is-explicit-routing?       boolean
     |           |  +--ro is-include-list-ordered?   boolean
@@ -10621,6 +10779,10 @@ module: org-openroadm-service
     |     |  |  |  +--ro link-network-id    string
     |     |  |  |  +--ro link-id            string
     |     |  |  +--ro supporting-service-name*   string
+    |     |  |  +--ro node-srg* [node-id]
+    |     |  |     +--ro node-id     org-openroadm-common-node-types:node-id-type
+    |     |  |     +--ro srg-list* [srg-number]
+    |     |  |        +--ro srg-number    uint16
     |     |  +--ro include
     |     |  |  +--ro is-explicit-routing?       boolean
     |     |  |  +--ro is-include-list-ordered?   boolean
@@ -10677,6 +10839,10 @@ module: org-openroadm-service
     |        |  |  +--ro link-network-id    string
     |        |  |  +--ro link-id            string
     |        |  +--ro supporting-service-name*   string
+    |        |  +--ro node-srg* [node-id]
+    |        |     +--ro node-id     org-openroadm-common-node-types:node-id-type
+    |        |     +--ro srg-list* [srg-number]
+    |        |        +--ro srg-number    uint16
     |        +--ro include
     |        |  +--ro is-explicit-routing?       boolean
     |        |  +--ro is-include-list-ordered?   boolean
@@ -10741,6 +10907,10 @@ module: org-openroadm-service
     |  |  |  |  |  +---w link-network-id    string
     |  |  |  |  |  +---w link-id            string
     |  |  |  |  +---w supporting-service-name*   string
+    |  |  |  |  +---w node-srg* [node-id]
+    |  |  |  |     +---w node-id     org-openroadm-common-node-types:node-id-type
+    |  |  |  |     +---w srg-list* [srg-number]
+    |  |  |  |        +---w srg-number    uint16
     |  |  |  +---w include
     |  |  |  |  +---w is-explicit-routing?       boolean
     |  |  |  |  +---w is-include-list-ordered?   boolean
@@ -10797,6 +10967,10 @@ module: org-openroadm-service
     |  |     |  |  +---w link-network-id    string
     |  |     |  |  +---w link-id            string
     |  |     |  +---w supporting-service-name*   string
+    |  |     |  +---w node-srg* [node-id]
+    |  |     |     +---w node-id     org-openroadm-common-node-types:node-id-type
+    |  |     |     +---w srg-list* [srg-number]
+    |  |     |        +---w srg-number    uint16
     |  |     +---w include
     |  |     |  +---w is-explicit-routing?       boolean
     |  |     |  +---w is-include-list-ordered?   boolean
@@ -11608,6 +11782,10 @@ module: org-openroadm-service
     |  |  |  |  +--ro link-network-id    string
     |  |  |  |  +--ro link-id            string
     |  |  |  +--ro supporting-service-name*   string
+    |  |  |  +--ro node-srg* [node-id]
+    |  |  |     +--ro node-id     org-openroadm-common-node-types:node-id-type
+    |  |  |     +--ro srg-list* [srg-number]
+    |  |  |        +--ro srg-number    uint16
     |  |  +--ro include
     |  |  |  +--ro is-explicit-routing?       boolean
     |  |  |  +--ro is-include-list-ordered?   boolean
@@ -11664,6 +11842,10 @@ module: org-openroadm-service
     |  |  |  |  +--ro link-network-id    string
     |  |  |  |  +--ro link-id            string
     |  |  |  +--ro supporting-service-name*   string
+    |  |  |  +--ro node-srg* [node-id]
+    |  |  |     +--ro node-id     org-openroadm-common-node-types:node-id-type
+    |  |  |     +--ro srg-list* [srg-number]
+    |  |  |        +--ro srg-number    uint16
     |  |  +--ro include
     |  |  |  +--ro is-explicit-routing?       boolean
     |  |  |  +--ro is-include-list-ordered?   boolean
@@ -12555,6 +12737,10 @@ module: org-openroadm-service
     |  |  |  |  +--ro link-network-id    string
     |  |  |  |  +--ro link-id            string
     |  |  |  +--ro supporting-service-name*   string
+    |  |  |  +--ro node-srg* [node-id]
+    |  |  |     +--ro node-id     org-openroadm-common-node-types:node-id-type
+    |  |  |     +--ro srg-list* [srg-number]
+    |  |  |        +--ro srg-number    uint16
     |  |  +--ro include
     |  |  |  +--ro is-explicit-routing?       boolean
     |  |  |  +--ro is-include-list-ordered?   boolean
@@ -12611,6 +12797,10 @@ module: org-openroadm-service
     |  |  |  |  +--ro link-network-id    string
     |  |  |  |  +--ro link-id            string
     |  |  |  +--ro supporting-service-name*   string
+    |  |  |  +--ro node-srg* [node-id]
+    |  |  |     +--ro node-id     org-openroadm-common-node-types:node-id-type
+    |  |  |     +--ro srg-list* [srg-number]
+    |  |  |        +--ro srg-number    uint16
     |  |  +--ro include
     |  |  |  +--ro is-explicit-routing?       boolean
     |  |  |  +--ro is-include-list-ordered?   boolean

--- a/model/Service/tree-view-service.txt
+++ b/model/Service/tree-view-service.txt
@@ -553,9 +553,11 @@ module: org-openroadm-service
   |     |     +--rw equipment-sub-slot?     string
   |     |     +--rw is-reused?              boolean
   |     |     +--rw port* [circuit-pack-name port-name]
-  |     |        +--rw circuit-pack-name    string
-  |     |        +--rw port-name            string
-  |     |        +--rw lifecycle-state?     org-openroadm-common-state-types:lifecycle-state
+  |     |     |  +--rw circuit-pack-name    string
+  |     |     |  +--rw port-name            string
+  |     |     |  +--rw lifecycle-state?     org-openroadm-common-state-types:lifecycle-state
+  |     |     +--rw is-regen?               boolean
+  |     |     +--rw regen-purpose*          enumeration
   |     +--rw service-z-end
   |     |  +--rw service-format                   org-openroadm-service-format:service-format
   |     |  +--rw service-rate?                    uint32
@@ -682,9 +684,11 @@ module: org-openroadm-service
   |     |     +--rw equipment-sub-slot?     string
   |     |     +--rw is-reused?              boolean
   |     |     +--rw port* [circuit-pack-name port-name]
-  |     |        +--rw circuit-pack-name    string
-  |     |        +--rw port-name            string
-  |     |        +--rw lifecycle-state?     org-openroadm-common-state-types:lifecycle-state
+  |     |     |  +--rw circuit-pack-name    string
+  |     |     |  +--rw port-name            string
+  |     |     |  +--rw lifecycle-state?     org-openroadm-common-state-types:lifecycle-state
+  |     |     +--rw is-regen?               boolean
+  |     |     +--rw regen-purpose*          enumeration
   |     +--rw hard-constraints
   |     |  +--rw customer-code*      string
   |     |  +--rw operational-mode*   string
@@ -1379,9 +1383,11 @@ module: org-openroadm-service
   |              +--rw equipment-sub-slot?     string
   |              +--rw is-reused?              boolean
   |              +--rw port* [circuit-pack-name port-name]
-  |                 +--rw circuit-pack-name    string
-  |                 +--rw port-name            string
-  |                 +--rw lifecycle-state?     org-openroadm-common-state-types:lifecycle-state
+  |              |  +--rw circuit-pack-name    string
+  |              |  +--rw port-name            string
+  |              |  +--rw lifecycle-state?     org-openroadm-common-state-types:lifecycle-state
+  |              +--rw is-regen?               boolean
+  |              +--rw regen-purpose*          enumeration
   +--rw versioned-service-list
   |  +--rw services* [service-name version-number]
   |     +--rw version-number               uint64
@@ -2503,9 +2509,11 @@ module: org-openroadm-service
   |     |     +--rw equipment-sub-slot?     string
   |     |     +--rw is-reused?              boolean
   |     |     +--rw port* [circuit-pack-name port-name]
-  |     |        +--rw circuit-pack-name    string
-  |     |        +--rw port-name            string
-  |     |        +--rw lifecycle-state?     org-openroadm-common-state-types:lifecycle-state
+  |     |     |  +--rw circuit-pack-name    string
+  |     |     |  +--rw port-name            string
+  |     |     |  +--rw lifecycle-state?     org-openroadm-common-state-types:lifecycle-state
+  |     |     +--rw is-regen?               boolean
+  |     |     +--rw regen-purpose*          enumeration
   |     +--rw service-z-end
   |     |  +--rw service-format                   org-openroadm-service-format:service-format
   |     |  +--rw service-rate?                    uint32
@@ -2632,9 +2640,11 @@ module: org-openroadm-service
   |     |     +--rw equipment-sub-slot?     string
   |     |     +--rw is-reused?              boolean
   |     |     +--rw port* [circuit-pack-name port-name]
-  |     |        +--rw circuit-pack-name    string
-  |     |        +--rw port-name            string
-  |     |        +--rw lifecycle-state?     org-openroadm-common-state-types:lifecycle-state
+  |     |     |  +--rw circuit-pack-name    string
+  |     |     |  +--rw port-name            string
+  |     |     |  +--rw lifecycle-state?     org-openroadm-common-state-types:lifecycle-state
+  |     |     +--rw is-regen?               boolean
+  |     |     +--rw regen-purpose*          enumeration
   |     +--rw hard-constraints
   |     |  +--rw customer-code*      string
   |     |  +--rw operational-mode*   string
@@ -3329,9 +3339,11 @@ module: org-openroadm-service
   |     |        +--rw equipment-sub-slot?     string
   |     |        +--rw is-reused?              boolean
   |     |        +--rw port* [circuit-pack-name port-name]
-  |     |           +--rw circuit-pack-name    string
-  |     |           +--rw port-name            string
-  |     |           +--rw lifecycle-state?     org-openroadm-common-state-types:lifecycle-state
+  |     |        |  +--rw circuit-pack-name    string
+  |     |        |  +--rw port-name            string
+  |     |        |  +--rw lifecycle-state?     org-openroadm-common-state-types:lifecycle-state
+  |     |        +--rw is-regen?               boolean
+  |     |        +--rw regen-purpose*          enumeration
   |     +--rw supporting-service-hierarchy* [service-identifier]
   |     |  +--rw service-identifier      string
   |     |  +--rw service-layer?          service-layer-type
@@ -6169,9 +6181,11 @@ module: org-openroadm-service
     |     |  |  +--ro equipment-sub-slot?     string
     |     |  |  +--ro is-reused?              boolean
     |     |  |  +--ro port* [circuit-pack-name port-name]
-    |     |  |     +--ro circuit-pack-name    string
-    |     |  |     +--ro port-name            string
-    |     |  |     +--ro lifecycle-state?     org-openroadm-common-state-types:lifecycle-state
+    |     |  |  |  +--ro circuit-pack-name    string
+    |     |  |  |  +--ro port-name            string
+    |     |  |  |  +--ro lifecycle-state?     org-openroadm-common-state-types:lifecycle-state
+    |     |  |  +--ro is-regen?               boolean
+    |     |  |  +--ro regen-purpose*          enumeration
     |     |  +--ro expected-settings-and-performances
     |     |     +--ro frequency?                  org-openroadm-common-optical-channel-types:frequency-THz
     |     |     +--ro width?                      org-openroadm-common-optical-channel-types:frequency-GHz
@@ -6300,9 +6314,11 @@ module: org-openroadm-service
     |     |  |  +--ro equipment-sub-slot?     string
     |     |  |  +--ro is-reused?              boolean
     |     |  |  +--ro port* [circuit-pack-name port-name]
-    |     |  |     +--ro circuit-pack-name    string
-    |     |  |     +--ro port-name            string
-    |     |  |     +--ro lifecycle-state?     org-openroadm-common-state-types:lifecycle-state
+    |     |  |  |  +--ro circuit-pack-name    string
+    |     |  |  |  +--ro port-name            string
+    |     |  |  |  +--ro lifecycle-state?     org-openroadm-common-state-types:lifecycle-state
+    |     |  |  +--ro is-regen?               boolean
+    |     |  |  +--ro regen-purpose*          enumeration
     |     |  +--ro expected-settings-and-performances
     |     |     +--ro frequency?                  org-openroadm-common-optical-channel-types:frequency-THz
     |     |     +--ro width?                      org-openroadm-common-optical-channel-types:frequency-GHz
@@ -6325,9 +6341,11 @@ module: org-openroadm-service
     |     |        +--ro equipment-sub-slot?     string
     |     |        +--ro is-reused?              boolean
     |     |        +--ro port* [circuit-pack-name port-name]
-    |     |           +--ro circuit-pack-name    string
-    |     |           +--ro port-name            string
-    |     |           +--ro lifecycle-state?     org-openroadm-common-state-types:lifecycle-state
+    |     |        |  +--ro circuit-pack-name    string
+    |     |        |  +--ro port-name            string
+    |     |        |  +--ro lifecycle-state?     org-openroadm-common-state-types:lifecycle-state
+    |     |        +--ro is-regen?               boolean
+    |     |        +--ro regen-purpose*          enumeration
     |     +--ro requested-service-topology
     |     |  +--ro topology
     |     |  |  +--ro aToZ* [id]
@@ -7106,9 +7124,11 @@ module: org-openroadm-service
     |        |  |  +--ro equipment-sub-slot?     string
     |        |  |  +--ro is-reused?              boolean
     |        |  |  +--ro port* [circuit-pack-name port-name]
-    |        |  |     +--ro circuit-pack-name    string
-    |        |  |     +--ro port-name            string
-    |        |  |     +--ro lifecycle-state?     org-openroadm-common-state-types:lifecycle-state
+    |        |  |  |  +--ro circuit-pack-name    string
+    |        |  |  |  +--ro port-name            string
+    |        |  |  |  +--ro lifecycle-state?     org-openroadm-common-state-types:lifecycle-state
+    |        |  |  +--ro is-regen?               boolean
+    |        |  |  +--ro regen-purpose*          enumeration
     |        |  +--ro expected-settings-and-performances
     |        |     +--ro frequency?                  org-openroadm-common-optical-channel-types:frequency-THz
     |        |     +--ro width?                      org-openroadm-common-optical-channel-types:frequency-GHz
@@ -7237,9 +7257,11 @@ module: org-openroadm-service
     |        |  |  +--ro equipment-sub-slot?     string
     |        |  |  +--ro is-reused?              boolean
     |        |  |  +--ro port* [circuit-pack-name port-name]
-    |        |  |     +--ro circuit-pack-name    string
-    |        |  |     +--ro port-name            string
-    |        |  |     +--ro lifecycle-state?     org-openroadm-common-state-types:lifecycle-state
+    |        |  |  |  +--ro circuit-pack-name    string
+    |        |  |  |  +--ro port-name            string
+    |        |  |  |  +--ro lifecycle-state?     org-openroadm-common-state-types:lifecycle-state
+    |        |  |  +--ro is-regen?               boolean
+    |        |  |  +--ro regen-purpose*          enumeration
     |        |  +--ro expected-settings-and-performances
     |        |     +--ro frequency?                  org-openroadm-common-optical-channel-types:frequency-THz
     |        |     +--ro width?                      org-openroadm-common-optical-channel-types:frequency-GHz
@@ -7262,9 +7284,11 @@ module: org-openroadm-service
     |        |        +--ro equipment-sub-slot?     string
     |        |        +--ro is-reused?              boolean
     |        |        +--ro port* [circuit-pack-name port-name]
-    |        |           +--ro circuit-pack-name    string
-    |        |           +--ro port-name            string
-    |        |           +--ro lifecycle-state?     org-openroadm-common-state-types:lifecycle-state
+    |        |        |  +--ro circuit-pack-name    string
+    |        |        |  +--ro port-name            string
+    |        |        |  +--ro lifecycle-state?     org-openroadm-common-state-types:lifecycle-state
+    |        |        +--ro is-regen?               boolean
+    |        |        +--ro regen-purpose*          enumeration
     |        +--ro requested-service-topology
     |        |  +--ro topology
     |        |  |  +--ro aToZ* [id]
@@ -8179,9 +8203,11 @@ module: org-openroadm-service
     |        |  |  +--ro equipment-sub-slot?     string
     |        |  |  +--ro is-reused?              boolean
     |        |  |  +--ro port* [circuit-pack-name port-name]
-    |        |  |     +--ro circuit-pack-name    string
-    |        |  |     +--ro port-name            string
-    |        |  |     +--ro lifecycle-state?     org-openroadm-common-state-types:lifecycle-state
+    |        |  |  |  +--ro circuit-pack-name    string
+    |        |  |  |  +--ro port-name            string
+    |        |  |  |  +--ro lifecycle-state?     org-openroadm-common-state-types:lifecycle-state
+    |        |  |  +--ro is-regen?               boolean
+    |        |  |  +--ro regen-purpose*          enumeration
     |        |  +--ro expected-settings-and-performances
     |        |     +--ro frequency?                  org-openroadm-common-optical-channel-types:frequency-THz
     |        |     +--ro width?                      org-openroadm-common-optical-channel-types:frequency-GHz
@@ -8310,9 +8336,11 @@ module: org-openroadm-service
     |        |  |  +--ro equipment-sub-slot?     string
     |        |  |  +--ro is-reused?              boolean
     |        |  |  +--ro port* [circuit-pack-name port-name]
-    |        |  |     +--ro circuit-pack-name    string
-    |        |  |     +--ro port-name            string
-    |        |  |     +--ro lifecycle-state?     org-openroadm-common-state-types:lifecycle-state
+    |        |  |  |  +--ro circuit-pack-name    string
+    |        |  |  |  +--ro port-name            string
+    |        |  |  |  +--ro lifecycle-state?     org-openroadm-common-state-types:lifecycle-state
+    |        |  |  +--ro is-regen?               boolean
+    |        |  |  +--ro regen-purpose*          enumeration
     |        |  +--ro expected-settings-and-performances
     |        |     +--ro frequency?                  org-openroadm-common-optical-channel-types:frequency-THz
     |        |     +--ro width?                      org-openroadm-common-optical-channel-types:frequency-GHz
@@ -8335,9 +8363,11 @@ module: org-openroadm-service
     |        |        +--ro equipment-sub-slot?     string
     |        |        +--ro is-reused?              boolean
     |        |        +--ro port* [circuit-pack-name port-name]
-    |        |           +--ro circuit-pack-name    string
-    |        |           +--ro port-name            string
-    |        |           +--ro lifecycle-state?     org-openroadm-common-state-types:lifecycle-state
+    |        |        |  +--ro circuit-pack-name    string
+    |        |        |  +--ro port-name            string
+    |        |        |  +--ro lifecycle-state?     org-openroadm-common-state-types:lifecycle-state
+    |        |        +--ro is-regen?               boolean
+    |        |        +--ro regen-purpose*          enumeration
     |        +--ro requested-service-topology
     |        |  +--ro topology
     |        |  |  +--ro aToZ* [id]

--- a/model/Service/tree-view-service.txt
+++ b/model/Service/tree-view-service.txt
@@ -3537,8 +3537,9 @@ module: org-openroadm-service
      |  |  |        +--rw D?                decimal64
      |  |  |        +--rw fiber-type?       enumeration
      |  |  +--rw Add
-     |  |  |  +--rw add-openroadm-operational-mode* [openroadm-operational-mode-id]
+     |  |  |  +--rw openroadm-operational-mode* [openroadm-operational-mode-id]
      |  |  |     +--rw openroadm-operational-mode-id    string
+     |  |  |     +--rw max-channel-number?              uint8
      |  |  |     +--rw incremental-osnr?                org-openroadm-common-link-types:ratio-dB
      |  |  |     +--rw per-channel-Pin-min?             org-openroadm-common-link-types:ratio-dB
      |  |  |     +--rw per-channel-Pin-max?             org-openroadm-common-link-types:ratio-dB
@@ -11408,8 +11409,9 @@ module: org-openroadm-service
     |  |     |  |        +---w D?                decimal64
     |  |     |  |        +---w fiber-type?       enumeration
     |  |     |  +---w Add
-    |  |     |  |  +---w add-openroadm-operational-mode* [openroadm-operational-mode-id]
+    |  |     |  |  +---w openroadm-operational-mode* [openroadm-operational-mode-id]
     |  |     |  |     +---w openroadm-operational-mode-id    string
+    |  |     |  |     +---w max-channel-number?              uint8
     |  |     |  |     +---w incremental-osnr?                org-openroadm-common-link-types:ratio-dB
     |  |     |  |     +---w per-channel-Pin-min?             org-openroadm-common-link-types:ratio-dB
     |  |     |  |     +---w per-channel-Pin-max?             org-openroadm-common-link-types:ratio-dB

--- a/model/Specifications/Readme.txt
+++ b/model/Specifications/Readme.txt
@@ -17,6 +17,11 @@ the RNC implements at least Service model 12.0.0.
 __ORrelease 13_1 : Introduce Optical specification version 6. To be used when
 the RNC implements at least Service model 12.0.0 and Common models R13.1.0 where
 pcs-dp-qam16 enum is introduced to support PCS modulation format.
+
+__ORrelease 15_0 : Use Optical specification version 6. To be used when the
+RNC implements at least Common models R13.1.0 and Service model 15.0.0 where
+max-channel-number is introduced in Catalog Add-Blocks parameters to
+differentiate MW-WR-Core-type2 from MW-WR-Core.
   
 After this operation, the operational modes catalog will then contain
 the translation of the [spec-release] version of OpenROADM optical specifications.

--- a/model/Specifications/apidoc-operational-modes-to-catalog-15_0-optical-spec-6_0.json
+++ b/model/Specifications/apidoc-operational-modes-to-catalog-15_0-optical-spec-6_0.json
@@ -1,0 +1,2098 @@
+{
+    "operational-mode-catalog": {
+        "openroadm-operational-modes": {
+            "grid-parameters": {
+                "min-central-frequency": "191.32500000",
+                "max-central-frequency": "196.12500000",
+                "central-frequency-granularity": "12.50000",
+                "min-spacing": "37.50000"
+            },
+            "xponders-pluggables": {
+                "xponder-pluggable-openroadm-operational-mode": [
+                    {
+                        "openroadm-operational-mode-id": "OR-W-100G-SC",
+                        "baud-rate": "28.0",
+                        "line-rate": "111.8",
+                        "modulation-format": "dp-qpsk",
+                        "min-TX-osnr": "33.000",
+                        "TX-OOB-osnr": {
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-OOB-osnr-multi-channel-value": "31.000",
+                            "min-OOB-osnr-single-channel-value": "43.000"
+                        },
+                        "output-power-range": {
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-output-power": "-5.000",
+                            "max-output-power": "0.000"
+                        },
+                        "min-RX-osnr-tolerance": "17.000",
+                        "min-input-power-at-RX-osnr": "-22.000",
+                        "max-input-power": "1.000",
+                        "channel-width": "40.00000",
+                        "fec-type": "org-openroadm-common-types:scfec",
+                        "penalties": [
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "18000",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "6",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "30",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-22",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "cross-talk-total-power-dB",
+                                "up-to-boundary": "15",
+                                "penalty-value": "0.200"
+                            },
+                            {
+                                "parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+                                "up-to-boundary": "4",
+                                "penalty-value": "0.200"
+                            }
+                        ]
+                    },
+                    {
+                        "openroadm-operational-mode-id": "OR-W-100G-oFEC-31.6Gbd",
+                        "baud-rate": "31.6",
+                        "line-rate": "126.3",
+                        "modulation-format": "dp-qpsk",
+                        "min-TX-osnr": "37.000",
+                        "TX-OOB-osnr": {
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-OOB-osnr-multi-channel-value": "36.000"
+                        },
+                        "output-power-range": {
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-output-power": "-5.000",
+                            "max-output-power": "0.000"
+                        },
+                        "min-RX-osnr-tolerance": "12.000",
+                        "min-input-power-at-RX-osnr": "-18.000",
+                        "max-input-power": "1.000",
+                        "channel-width": "37.88400",
+                        "fec-type": "org-openroadm-common-types:ofec",
+                        "min-roll-off": "0.05",
+                        "max-roll-off": "0.20",
+                        "penalties": [
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "4000",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "48000",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "1",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "2",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "4",
+                                "penalty-value": "2.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "6",
+                                "penalty-value": "4.000"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "10",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "30",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-18",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-20",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "cross-talk-total-power-dB",
+                                "up-to-boundary": "15",
+                                "penalty-value": "0.200"
+                            },
+                            {
+                                "parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+                                "up-to-boundary": "4",
+                                "penalty-value": "0.200"
+                            }
+                        ]
+                    },
+                    {
+                        "openroadm-operational-mode-id": "OR-W-200G-oFEC-31.6Gbd",
+                        "baud-rate": "31.6",
+                        "line-rate": "252.6",
+                        "modulation-format": "dp-qam16",
+                        "min-TX-osnr": "37.000",
+                        "TX-OOB-osnr": {
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-OOB-osnr-multi-channel-value": "36.000"
+                        },
+                        "output-power-range": {
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-output-power": "-5.000",
+                            "max-output-power": "0.000"
+                        },
+                        "min-RX-osnr-tolerance": "20.500",
+                        "min-input-power-at-RX-osnr": "-16.000",
+                        "max-input-power": "1.000",
+                        "channel-width": "37.88400",
+                        "fec-type": "org-openroadm-common-types:ofec",
+                        "min-roll-off": "0.05",
+                        "max-roll-off": "0.20",
+                        "penalties": [
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "4000",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "24000",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "1",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "2",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "4",
+                                "penalty-value": "2.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "6",
+                                "penalty-value": "4.000"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "10",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "30",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-16",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-18",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-20",
+                                "penalty-value": "2.000"
+                            },
+                            {
+                                "parameter-and-unit": "cross-talk-total-power-dB",
+                                "up-to-boundary": "15",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+                                "up-to-boundary": "4",
+                                "penalty-value": "0.500"
+                            }
+                        ]
+                    },
+                    {
+                        "openroadm-operational-mode-id": "OR-W-200G-oFEC-63.1Gbd",
+                        "baud-rate": "63.1",
+                        "line-rate": "252.6",
+                        "modulation-format": "dp-qpsk",
+                        "min-TX-osnr": "37.000",
+                        "TX-OOB-osnr": {
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-OOB-osnr-multi-channel-value": "36.000"
+                        },
+                        "output-power-range": {
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-output-power": "-5.000",
+                            "max-output-power": "0.000"
+                        },
+                        "min-RX-osnr-tolerance": "16.000",
+                        "min-input-power-at-RX-osnr": "-18.000",
+                        "max-input-power": "1.000",
+                        "channel-width": "75.72000",
+                        "fec-type": "org-openroadm-common-types:ofec",
+                        "min-roll-off": "0.05",
+                        "max-roll-off": "0.20",
+                        "penalties": [
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "4000",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "24000",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "1",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "2",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "4",
+                                "penalty-value": "2.500"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "10",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "25",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-18",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-20",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "cross-talk-total-power-dB",
+                                "up-to-boundary": "15",
+                                "penalty-value": "0.300"
+                            },
+                            {
+                                "parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+                                "up-to-boundary": "4",
+                                "penalty-value": "0.500"
+                            }
+                        ]
+                    },
+                    {
+                        "openroadm-operational-mode-id": "OR-W-300G-oFEC-63.1Gbd",
+                        "baud-rate": "63.1",
+                        "line-rate": "378.8",
+                        "modulation-format": "dp-qam8",
+                        "min-TX-osnr": "37.000",
+                        "TX-OOB-osnr": {
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-OOB-osnr-multi-channel-value": "36.000"
+                        },
+                        "output-power-range": {
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-output-power": "-5.000",
+                            "max-output-power": "0.000"
+                        },
+                        "min-RX-osnr-tolerance": "21.000",
+                        "min-input-power-at-RX-osnr": "-16.000",
+                        "max-input-power": "1.000",
+                        "channel-width": "75.72000",
+                        "fec-type": "org-openroadm-common-types:ofec",
+                        "min-roll-off": "0.05",
+                        "max-roll-off": "0.20",
+                        "penalties": [
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "4000",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "18000",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "1.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "2.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "4.00",
+                                "penalty-value": "2.500"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "10.00",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "25.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-16.00",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-18.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-20.00",
+                                "penalty-value": "2.000"
+                            },
+                            {
+                                "parameter-and-unit": "cross-talk-total-power-dB",
+                                "up-to-boundary": "15.00",
+                                "penalty-value": "0.300"
+                            },
+                            {
+                                "parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+                                "up-to-boundary": "4.0",
+                                "penalty-value": "0.500"
+                            }
+                        ]
+                    },
+                    {
+                        "openroadm-operational-mode-id": "OR-W-400G-oFEC-63.1Gbd",
+                        "baud-rate": "63.1",
+                        "line-rate": "505.1",
+                        "modulation-format": "dp-qam16",
+                        "min-TX-osnr": "37.000",
+                        "TX-OOB-osnr": {
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-OOB-osnr-multi-channel-value": "36.000"
+                        },
+                        "output-power-range": {
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-output-power": "-5.000",
+                            "max-output-power": "0.000"
+                        },
+                        "min-RX-osnr-tolerance": "24.000",
+                        "min-input-power-at-RX-osnr": "-14.000",
+                        "max-input-power": "1.000",
+                        "channel-width": "75.72000",
+                        "fec-type": "org-openroadm-common-types:ofec",
+                        "min-roll-off": "0.05",
+                        "max-roll-off": "0.20",
+                        "penalties": [
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "4000",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "12000",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "1.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "2.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "4.00",
+                                "penalty-value": "2.500"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "10.00",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "20.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-14",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-16.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-18.00",
+                                "penalty-value": "2.000"
+                            },
+                            {
+                                "parameter-and-unit": "cross-talk-total-power-dB",
+                                "up-to-boundary": "13.00",
+                                "penalty-value": "0.300"
+                            },
+                            {
+                                "parameter-and-unit": "cross-talk-total-power-dB",
+                                "up-to-boundary": "15.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+                                "up-to-boundary": "4.10",
+                                "penalty-value": "0.500"
+                            }
+                        ]
+                    },
+					{
+                        "openroadm-operational-mode-id": "OR-W-400G-oFEC-124Gbd",
+                        "baud-rate": "124.1",
+                        "line-rate": "422.6",
+                        "modulation-format": "dp-qpsk",
+                        "min-TX-osnr": "37.000",
+                        "TX-OOB-osnr": {
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-OOB-osnr-multi-channel-value": "36.000"
+                        },
+                        "output-power-range": {
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-output-power": "-5.000",
+                            "max-output-power": "0.000"
+                        },
+                        "min-RX-osnr-tolerance": "20.000",
+                        "min-input-power-at-RX-osnr": "-15.000",
+                        "max-input-power": "1.000",
+                        "channel-width": "148.92000",
+                        "fec-type": "org-openroadm-common-types:ofec",
+                        "min-roll-off": "0.05",
+                        "max-roll-off": "0.20",
+                        "penalties": [
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "4000",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "24000",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "1.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "2.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "4.00",
+                                "penalty-value": "2.500"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "10.00",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "25.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-15",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-18.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "cross-talk-total-power-dB",
+                                "up-to-boundary": "15.00",
+                                "penalty-value": "0.300"
+                            },
+                            {
+                                "parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+                                "up-to-boundary": "4.10",
+                                "penalty-value": "0.500"
+                            }
+                        ]
+                    },
+					{
+                        "openroadm-operational-mode-id": "OR-W-400G-oFEC-118Gbd",
+                        "baud-rate": "118.2",
+                        "line-rate": "422.6",
+                        "modulation-format": "dp-qpsk",
+                        "min-TX-osnr": "37.000",
+                        "TX-OOB-osnr": {
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-OOB-osnr-multi-channel-value": "36.000"
+                        },
+                        "output-power-range": {
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-output-power": "-5.000",
+                            "max-output-power": "0.000"
+                        },
+                        "min-RX-osnr-tolerance": "20.000",
+                        "min-input-power-at-RX-osnr": "-15.000",
+                        "max-input-power": "1.000",
+                        "channel-width": "141.84000",
+                        "fec-type": "org-openroadm-common-types:ofec",
+                        "min-roll-off": "0.05",
+                        "max-roll-off": "0.20",
+                        "penalties": [
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "4000",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "24000",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "1.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "2.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "4.00",
+                                "penalty-value": "2.500"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "10.00",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "25.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-15",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-18.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "cross-talk-total-power-dB",
+                                "up-to-boundary": "15.00",
+                                "penalty-value": "0.300"
+                            },
+                            {
+                                "parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+                                "up-to-boundary": "4.10",
+                                "penalty-value": "0.500"
+                            }
+                        ]
+                    },
+					{
+                        "openroadm-operational-mode-id": "OR-W-400G-oFEC-124Gbd_type2",
+                        "baud-rate": "124.1",
+                        "line-rate": "422.6",
+                        "modulation-format": "dp-qpsk",
+                        "min-TX-osnr": "37.000",
+                        "TX-OOB-osnr": {
+                            "WR-openroadm-operational-mode-id": "MW-WR-core-type2",
+                            "min-OOB-osnr-multi-channel-value": "36.000"
+                        },
+                        "output-power-range": {
+                            "WR-openroadm-operational-mode-id": "MW-WR-core-type2",
+                            "min-output-power": "-5.000",
+                            "max-output-power": "0.000"
+                        },
+                        "min-RX-osnr-tolerance": "20.000",
+                        "min-input-power-at-RX-osnr": "-15.000",
+                        "max-input-power": "1.000",
+                        "channel-width": "148.92000",
+                        "fec-type": "org-openroadm-common-types:ofec",
+                        "min-roll-off": "0.05",
+                        "max-roll-off": "0.20",
+                        "penalties": [
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "4000",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "24000",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "1.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "2.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "4.00",
+                                "penalty-value": "2.500"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "10.00",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "25.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-15",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-18.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "cross-talk-total-power-dB",
+                                "up-to-boundary": "15.00",
+                                "penalty-value": "0.300"
+                            },
+                            {
+                                "parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+                                "up-to-boundary": "4.10",
+                                "penalty-value": "0.500"
+                            }
+                        ]
+                    },
+					{
+                        "openroadm-operational-mode-id": "OR-W-400G-oFEC-118Gbd_type2",
+                        "baud-rate": "118.2",
+                        "line-rate": "422.6",
+                        "modulation-format": "dp-qpsk",
+                        "min-TX-osnr": "37.000",
+                        "TX-OOB-osnr": {
+                            "WR-openroadm-operational-mode-id": "MW-WR-core-type2",
+                            "min-OOB-osnr-multi-channel-value": "36.000"
+                        },
+                        "output-power-range": {
+                            "WR-openroadm-operational-mode-id": "MW-WR-core-type2",
+                            "min-output-power": "-5.000",
+                            "max-output-power": "0.000"
+                        },
+                        "min-RX-osnr-tolerance": "20.000",
+                        "min-input-power-at-RX-osnr": "-15.000",
+                        "max-input-power": "1.000",
+                        "channel-width": "141.84000",
+                        "fec-type": "org-openroadm-common-types:ofec",
+                        "min-roll-off": "0.05",
+                        "max-roll-off": "0.20",
+                        "penalties": [
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "4000",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "24000",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "1.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "2.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "4.00",
+                                "penalty-value": "2.500"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "10.00",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "25.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-15",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-18.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "cross-talk-total-power-dB",
+                                "up-to-boundary": "15.00",
+                                "penalty-value": "0.300"
+                            },
+                            {
+                                "parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+                                "up-to-boundary": "4.10",
+                                "penalty-value": "0.500"
+                            }
+                        ]
+                    },
+					{
+                        "openroadm-operational-mode-id": "OR-W-800G-oFEC-124Gbd",
+                        "baud-rate": "124.1",
+                        "line-rate": "845.1",
+                        "modulation-format": "dp-qam16",
+                        "min-TX-osnr": "37.000",
+                        "TX-OOB-osnr": {
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-OOB-osnr-multi-channel-value": "36.000"
+                        },
+                        "output-power-range": {
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-output-power": "-5.000",
+                            "max-output-power": "0.000"
+                        },
+                        "min-RX-osnr-tolerance": "27.200",
+                        "min-input-power-at-RX-osnr": "-11.000",
+                        "max-input-power": "1.000",
+                        "channel-width": "148.92000",
+                        "fec-type": "org-openroadm-common-types:ofec",
+                        "min-roll-off": "0.05",
+                        "max-roll-off": "0.20",
+                        "penalties": [
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "4000",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "12000",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "1.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "2.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "4.00",
+                                "penalty-value": "2.500"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "10.00",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "20.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-11.00",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-14.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "cross-talk-total-power-dB",
+                                "up-to-boundary": "13.00",
+                                "penalty-value": "0.300"
+                            },
+							{
+                                "parameter-and-unit": "cross-talk-total-power-dB",
+                                "up-to-boundary": "15.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+                                "up-to-boundary": "4.10",
+                                "penalty-value": "0.500"
+                            }
+                        ]
+                    },
+					{
+                        "openroadm-operational-mode-id": "OR-W-800G-oFEC-118Gbd",
+                        "baud-rate": "118.2",
+                        "line-rate": "845.1",
+                        "modulation-format": "dp-qam16",
+                        "min-TX-osnr": "37.000",
+                        "TX-OOB-osnr": {
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-OOB-osnr-multi-channel-value": "36.000"
+                        },
+                        "output-power-range": {
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-output-power": "-5.000",
+                            "max-output-power": "0.000"
+                        },
+                        "min-RX-osnr-tolerance": "27.000",
+                        "min-input-power-at-RX-osnr": "-11.000",
+                        "max-input-power": "1.000",
+                        "channel-width": "141.84000",
+                        "fec-type": "org-openroadm-common-types:ofec",
+                        "min-roll-off": "0.05",
+                        "max-roll-off": "0.20",
+                        "penalties": [
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "4000",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "12000",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "1.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "2.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "4.00",
+                                "penalty-value": "2.500"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "10.00",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "20.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-11.00",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-14.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "cross-talk-total-power-dB",
+                                "up-to-boundary": "13.00",
+                                "penalty-value": "0.300"
+                            },
+							{
+                                "parameter-and-unit": "cross-talk-total-power-dB",
+                                "up-to-boundary": "15.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+                                "up-to-boundary": "4.10",
+                                "penalty-value": "0.500"
+                            }
+                        ]
+                    },
+					{
+                        "openroadm-operational-mode-id": "OR-W-800G-oFEC-124Gbd_type2",
+                        "baud-rate": "124.1",
+                        "line-rate": "845.1",
+                        "modulation-format": "dp-qam16",
+                        "min-TX-osnr": "37.000",
+                        "TX-OOB-osnr": {
+                            "WR-openroadm-operational-mode-id": "MW-WR-core-type2",
+                            "min-OOB-osnr-multi-channel-value": "36.000"
+                        },
+                        "output-power-range": {
+                            "WR-openroadm-operational-mode-id": "MW-WR-core-type2",
+                            "min-output-power": "-5.000",
+                            "max-output-power": "0.000"
+                        },
+                        "min-RX-osnr-tolerance": "27.200",
+                        "min-input-power-at-RX-osnr": "-11.000",
+                        "max-input-power": "1.000",
+                        "channel-width": "148.92000",
+                        "fec-type": "org-openroadm-common-types:ofec",
+                        "min-roll-off": "0.05",
+                        "max-roll-off": "0.20",
+                        "penalties": [
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "4000",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "12000",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "1.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "2.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "4.00",
+                                "penalty-value": "2.500"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "10.00",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "20.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-11.00",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-14.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "cross-talk-total-power-dB",
+                                "up-to-boundary": "13.00",
+                                "penalty-value": "0.300"
+                            },
+							{
+                                "parameter-and-unit": "cross-talk-total-power-dB",
+                                "up-to-boundary": "15.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+                                "up-to-boundary": "4.10",
+                                "penalty-value": "0.500"
+                            }
+                        ]
+                    },
+					{
+                        "openroadm-operational-mode-id": "OR-W-800G-oFEC-118Gbd_type2",
+                        "baud-rate": "118.2",
+                        "line-rate": "845.1",
+                        "modulation-format": "dp-qam16",
+                        "min-TX-osnr": "37.000",
+                        "TX-OOB-osnr": {
+                            "WR-openroadm-operational-mode-id": "MW-WR-core-type2",
+                            "min-OOB-osnr-multi-channel-value": "36.000"
+                        },
+                        "output-power-range": {
+                            "WR-openroadm-operational-mode-id": "MW-WR-core-type2",
+                            "min-output-power": "-5.000",
+                            "max-output-power": "0.000"
+                        },
+                        "min-RX-osnr-tolerance": "27.000",
+                        "min-input-power-at-RX-osnr": "-11.000",
+                        "max-input-power": "1.000",
+                        "channel-width": "141.84000",
+                        "fec-type": "org-openroadm-common-types:ofec",
+                        "min-roll-off": "0.05",
+                        "max-roll-off": "0.20",
+                        "penalties": [
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "4000",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "12000",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "1.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "2.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "4.00",
+                                "penalty-value": "2.500"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "10.00",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "20.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-11.00",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-14.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "cross-talk-total-power-dB",
+                                "up-to-boundary": "13.00",
+                                "penalty-value": "0.300"
+                            },
+							{
+                                "parameter-and-unit": "cross-talk-total-power-dB",
+                                "up-to-boundary": "15.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+                                "up-to-boundary": "4.10",
+                                "penalty-value": "0.500"
+                            }
+                        ]
+                    },
+					{
+                        "openroadm-operational-mode-id": "OR-W-600G-oFEC-124Gbd",
+                        "baud-rate": "124.7",
+                        "line-rate": "633.9",
+                        "modulation-format": "pcs-dp-qam16",
+                        "min-TX-osnr": "37.000",
+                        "TX-OOB-osnr": {
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-OOB-osnr-multi-channel-value": "36.000"
+                        },
+                        "output-power-range": {
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-output-power": "-5.000",
+                            "max-output-power": "0.000"
+                        },
+                        "min-RX-osnr-tolerance": "99.999",
+                        "min-input-power-at-RX-osnr": "-11.000",
+                        "max-input-power": "1.000",
+                        "channel-width": "149.64000",
+                        "fec-type": "org-openroadm-common-types:ofec",
+                        "min-roll-off": "0.05",
+                        "max-roll-off": "0.20",
+                        "penalties": [
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "4000",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "22000",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "1.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "2.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "4.00",
+                                "penalty-value": "2.500"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "10.00",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "25.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-11.00",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-18.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "cross-talk-total-power-dB",
+                                "up-to-boundary": "15.00",
+                                "penalty-value": "0.300"
+                            },
+                            {
+                                "parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+                                "up-to-boundary": "4.10",
+                                "penalty-value": "0.500"
+                            }
+                        ]
+                    },
+					{
+                        "openroadm-operational-mode-id": "OR-W-600G-oFEC-118Gbd",
+                        "baud-rate": "118.8",
+                        "line-rate": "633.9",
+                        "modulation-format": "pcs-dp-qam16",
+                        "min-TX-osnr": "37.000",
+                        "TX-OOB-osnr": {
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-OOB-osnr-multi-channel-value": "36.000"
+                        },
+                        "output-power-range": {
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-output-power": "-5.000",
+                            "max-output-power": "0.000"
+                        },
+                        "min-RX-osnr-tolerance": "99.999",
+                        "min-input-power-at-RX-osnr": "-11.000",
+                        "max-input-power": "1.000",
+                        "channel-width": "142.56000",
+                        "fec-type": "org-openroadm-common-types:ofec",
+                        "min-roll-off": "0.05",
+                        "max-roll-off": "0.20",
+                        "penalties": [
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "4000",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "22000",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "1.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "2.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "4.00",
+                                "penalty-value": "2.500"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "10.00",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "25.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-11.00",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-18.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "cross-talk-total-power-dB",
+                                "up-to-boundary": "15.00",
+                                "penalty-value": "0.300"
+                            },
+                            {
+                                "parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+                                "up-to-boundary": "4.10",
+                                "penalty-value": "0.500"
+                            }
+                        ]
+                    },
+					{
+                        "openroadm-operational-mode-id": "OR-W-800G-oFEC-131GbdE",
+                        "baud-rate": "131.3",
+                        "line-rate": "845.1",
+                        "modulation-format": "pcs-dp-qam16",
+                        "min-TX-osnr": "37.000",
+                        "TX-OOB-osnr": {
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-OOB-osnr-multi-channel-value": "36.000"
+                        },
+                        "output-power-range": {
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-output-power": "-5.000",
+                            "max-output-power": "0.000"
+                        },
+                        "min-RX-osnr-tolerance": "25.000",
+                        "min-input-power-at-RX-osnr": "-11.000",
+                        "max-input-power": "1.000",
+                        "channel-width": "157.60800",
+                        "fec-type": "org-openroadm-common-types:ofec",
+                        "min-roll-off": "0.05",
+                        "max-roll-off": "0.20",
+                        "penalties": [
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "4000",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "20000",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "1.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "2.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "4.00",
+                                "penalty-value": "2.500"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "10.00",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "20.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-11.00",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-14.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "cross-talk-total-power-dB",
+                                "up-to-boundary": "13.00",
+                                "penalty-value": "0.300"
+                            },
+							{
+                                "parameter-and-unit": "cross-talk-total-power-dB",
+                                "up-to-boundary": "15.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+                                "up-to-boundary": "4.10",
+                                "penalty-value": "0.500"
+                            }
+                        ]
+                    },
+					{
+                        "openroadm-operational-mode-id": "OR-W-800G-oFEC-131GbdM",
+                        "baud-rate": "131.4",
+                        "line-rate": "845.1",
+                        "modulation-format": "pcs-dp-qam16",
+                        "min-TX-osnr": "37.000",
+                        "TX-OOB-osnr": {
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-OOB-osnr-multi-channel-value": "36.000"
+                        },
+                        "output-power-range": {
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-output-power": "-5.000",
+                            "max-output-power": "0.000"
+                        },
+                        "min-RX-osnr-tolerance": "26.000",
+                        "min-input-power-at-RX-osnr": "-11.000",
+                        "max-input-power": "1.000",
+                        "channel-width": "157.62000",
+                        "fec-type": "org-openroadm-common-types:ofec",
+                        "min-roll-off": "0.05",
+                        "max-roll-off": "0.20",
+                        "penalties": [
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "4000",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "20000",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "1.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "2.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "4.00",
+                                "penalty-value": "2.500"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "10.00",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "20.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-11.00",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-14.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "cross-talk-total-power-dB",
+                                "up-to-boundary": "13.00",
+                                "penalty-value": "0.300"
+                            },
+							{
+                                "parameter-and-unit": "cross-talk-total-power-dB",
+                                "up-to-boundary": "15.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+                                "up-to-boundary": "4.10",
+                                "penalty-value": "0.500"
+                            }
+                        ]
+                    },
+					{
+                        "openroadm-operational-mode-id": "OR-W-600G-oFEC-124Gbd_type2",
+                        "baud-rate": "124.7",
+                        "line-rate": "633.9",
+                        "modulation-format": "pcs-dp-qam16",
+                        "min-TX-osnr": "37.000",
+                        "TX-OOB-osnr": {
+                            "WR-openroadm-operational-mode-id": "MW-WR-core-type2",
+                            "min-OOB-osnr-multi-channel-value": "36.000"
+                        },
+                        "output-power-range": {
+                            "WR-openroadm-operational-mode-id": "MW-WR-core-type2",
+                            "min-output-power": "-5.000",
+                            "max-output-power": "0.000"
+                        },
+                        "min-RX-osnr-tolerance": "99.999",
+                        "min-input-power-at-RX-osnr": "-11.000",
+                        "max-input-power": "1.000",
+                        "channel-width": "149.64000",
+                        "fec-type": "org-openroadm-common-types:ofec",
+                        "min-roll-off": "0.05",
+                        "max-roll-off": "0.20",
+                        "penalties": [
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "4000",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "22000",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "1.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "2.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "4.00",
+                                "penalty-value": "2.500"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "10.00",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "25.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-11.00",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-18.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "cross-talk-total-power-dB",
+                                "up-to-boundary": "15.00",
+                                "penalty-value": "0.300"
+                            },
+                            {
+                                "parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+                                "up-to-boundary": "4.10",
+                                "penalty-value": "0.500"
+                            }
+                        ]
+                    },
+					{
+                        "openroadm-operational-mode-id": "OR-W-600G-oFEC-118Gbd_type2",
+                        "baud-rate": "118.8",
+                        "line-rate": "633.9",
+                        "modulation-format": "pcs-dp-qam16",
+                        "min-TX-osnr": "37.000",
+                        "TX-OOB-osnr": {
+                            "WR-openroadm-operational-mode-id": "MW-WR-core-type2",
+                            "min-OOB-osnr-multi-channel-value": "36.000"
+                        },
+                        "output-power-range": {
+                            "WR-openroadm-operational-mode-id": "MW-WR-core-type2",
+                            "min-output-power": "-5.000",
+                            "max-output-power": "0.000"
+                        },
+                        "min-RX-osnr-tolerance": "99.999",
+                        "min-input-power-at-RX-osnr": "-11.000",
+                        "max-input-power": "1.000",
+                        "channel-width": "142.56000",
+                        "fec-type": "org-openroadm-common-types:ofec",
+                        "min-roll-off": "0.05",
+                        "max-roll-off": "0.20",
+                        "penalties": [
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "4000",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "22000",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "1.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "2.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "4.00",
+                                "penalty-value": "2.500"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "10.00",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "25.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-11.00",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-18.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "cross-talk-total-power-dB",
+                                "up-to-boundary": "15.00",
+                                "penalty-value": "0.300"
+                            },
+                            {
+                                "parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+                                "up-to-boundary": "4.10",
+                                "penalty-value": "0.500"
+                            }
+                        ]
+                    },
+					{
+                        "openroadm-operational-mode-id": "OR-W-800G-oFEC-131GbdE_type2",
+                        "baud-rate": "131.3",
+                        "line-rate": "845.1",
+                        "modulation-format": "pcs-dp-qam16",
+                        "min-TX-osnr": "37.000",
+                        "TX-OOB-osnr": {
+                            "WR-openroadm-operational-mode-id": "MW-WR-core-type2",
+                            "min-OOB-osnr-multi-channel-value": "36.000"
+                        },
+                        "output-power-range": {
+                            "WR-openroadm-operational-mode-id": "MW-WR-core-type2",
+                            "min-output-power": "-5.000",
+                            "max-output-power": "0.000"
+                        },
+                        "min-RX-osnr-tolerance": "25.000",
+                        "min-input-power-at-RX-osnr": "-11.000",
+                        "max-input-power": "1.000",
+                        "channel-width": "157.60800",
+                        "fec-type": "org-openroadm-common-types:ofec",
+                        "min-roll-off": "0.05",
+                        "max-roll-off": "0.20",
+                        "penalties": [
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "4000",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "20000",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "1.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "2.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "4.00",
+                                "penalty-value": "2.500"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "10.00",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "20.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-11.00",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-14.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "cross-talk-total-power-dB",
+                                "up-to-boundary": "13.00",
+                                "penalty-value": "0.300"
+                            },
+							{
+                                "parameter-and-unit": "cross-talk-total-power-dB",
+                                "up-to-boundary": "15.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+                                "up-to-boundary": "4.10",
+                                "penalty-value": "0.500"
+                            }
+                        ]
+                    },
+					{
+                        "openroadm-operational-mode-id": "OR-W-800G-oFEC-131GbdM_type2",
+                        "baud-rate": "131.4",
+                        "line-rate": "845.1",
+                        "modulation-format": "pcs-dp-qam16",
+                        "min-TX-osnr": "37.000",
+                        "TX-OOB-osnr": {
+                            "WR-openroadm-operational-mode-id": "MW-WR-core-type2",
+                            "min-OOB-osnr-multi-channel-value": "36.000"
+                        },
+                        "output-power-range": {
+                            "WR-openroadm-operational-mode-id": "MW-WR-core-type2",
+                            "min-output-power": "-5.000",
+                            "max-output-power": "0.000"
+                        },
+                        "min-RX-osnr-tolerance": "26.000",
+                        "min-input-power-at-RX-osnr": "-11.000",
+                        "max-input-power": "1.000",
+                        "channel-width": "157.62000",
+                        "fec-type": "org-openroadm-common-types:ofec",
+                        "min-roll-off": "0.05",
+                        "max-roll-off": "0.20",
+                        "penalties": [
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "4000",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "20000",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "1.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "2.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "4.00",
+                                "penalty-value": "2.500"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "10.00",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "20.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-11.00",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-14.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "cross-talk-total-power-dB",
+                                "up-to-boundary": "13.00",
+                                "penalty-value": "0.300"
+                            },
+							{
+                                "parameter-and-unit": "cross-talk-total-power-dB",
+                                "up-to-boundary": "15.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+                                "up-to-boundary": "4.10",
+                                "penalty-value": "0.500"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "roadms": {
+                "Express": {
+                    "openroadm-operational-mode": {
+                        "openroadm-operational-mode-id": "MW-MW-core",
+                        "per-channel-Pin-min": "-21.000",
+                        "per-channel-Pin-max": "-9.000",
+                        "max-introduced-pdl": "1.500",
+                        "max-introduced-dgd": "3.00",
+                        "max-introduced-cd": "25.00",
+                        "osnr-polynomial-fit": {
+                            "A": "-0.00059520",
+                            "B": "-0.06250000",
+                            "C": "-1.07100000",
+                            "D": "27.99000000"
+                        },
+                        "mask-power-vs-pin": [
+                            {
+                                "lower-boundary": "0",
+                                "upper-boundary": "6",
+                                "C": "1.00000000",
+                                "D": "-9.00000000",
+                                "fiber-type": "smf"
+                            },
+                            {
+                                "lower-boundary": "6",
+                                "upper-boundary": "8",
+                                "C": "-0.00000000",
+                                "D": "-3.00000000",
+                                "fiber-type": "smf"
+                            },
+                            {
+                                "lower-boundary": "8",
+                                "upper-boundary": "23",
+                                "C": "0.33333334",
+                                "D": "-5.66666667",
+                                "fiber-type": "smf"
+                            },
+                            {
+                                "lower-boundary": "23",
+                                "upper-boundary": "27",
+                                "C": "0.00000000",
+                                "D": "2.00000000",
+                                "fiber-type": "smf"
+                            }
+                        ]
+                    }
+                },
+                "Add": {
+                    "openroadm-operational-mode": [
+	                    {
+	                        "openroadm-operational-mode-id": "MW-WR-core",
+	                        "max-channel-number": "16",
+	                        "incremental-osnr": "33.000",
+	                        "per-channel-Pin-min": "-6.000",
+	                        "per-channel-Pin-max": "3.000",
+	                        "max-introduced-pdl": "1.500",
+	                        "max-introduced-dgd": "3.00",
+	                        "max-introduced-cd": "25.00",
+	                        "mask-power-vs-pin": [
+	                            {
+	                                "lower-boundary": "0",
+	                                "upper-boundary": "6",
+	                                "C": "1.00000000",
+	                                "D": "-9.00000000",
+	                                "fiber-type": "smf"
+	                            },
+	                            {
+	                                "lower-boundary": "6",
+	                                "upper-boundary": "8",
+	                                "C": "-0.00000000",
+	                                "D": "-3.00000000",
+	                                "fiber-type": "smf"
+	                            },
+	                            {
+	                                "lower-boundary": "8",
+	                                "upper-boundary": "23",
+	                                "C": "0.33333334",
+	                                "D": "-5.66666667",
+	                                "fiber-type": "smf"
+	                            },
+	                            {
+	                                "lower-boundary": "23",
+	                                "upper-boundary": "27",
+	                                "C": "0.00000000",
+	                                "D": "2.00000000",
+	                                "fiber-type": "smf"
+	                            }
+	                        ]
+	                    },
+	                    {
+	                        "openroadm-operational-mode-id": "MW-WR-core-type2",
+	                        "max-channel-number": "4",
+	                        "incremental-osnr": "33.000",
+	                        "per-channel-Pin-min": "-6.000",
+	                        "per-channel-Pin-max": "3.000",
+	                        "max-introduced-pdl": "1.500",
+	                        "max-introduced-dgd": "3.00",
+	                        "max-introduced-cd": "25.00",
+	                        "mask-power-vs-pin": [
+	                            {
+	                                "lower-boundary": "0",
+	                                "upper-boundary": "6",
+	                                "C": "1.00000000",
+	                                "D": "-9.00000000",
+	                                "fiber-type": "smf"
+	                            },
+	                            {
+	                                "lower-boundary": "6",
+	                                "upper-boundary": "8",
+	                                "C": "-0.00000000",
+	                                "D": "-3.00000000",
+	                                "fiber-type": "smf"
+	                            },
+	                            {
+	                                "lower-boundary": "8",
+	                                "upper-boundary": "23",
+	                                "C": "0.33333334",
+	                                "D": "-5.66666667",
+	                                "fiber-type": "smf"
+	                            },
+	                            {
+	                                "lower-boundary": "23",
+	                                "upper-boundary": "27",
+	                                "C": "0.00000000",
+	                                "D": "2.00000000",
+	                                "fiber-type": "smf"
+	                            }
+	                        ]
+	                    }
+                    ]
+                },
+                "Drop": {
+                    "openroadm-operational-mode": {
+                        "openroadm-operational-mode-id": "MW-WR-core",
+                        "per-channel-Pin-min": "-25.000",
+                        "per-channel-Pin-max": "-9.000",
+                        "max-introduced-pdl": "1.500",
+                        "max-introduced-dgd": "3.00",
+                        "max-introduced-cd": "25.00",
+                        "osnr-polynomial-fit": {
+                            "A": "-0.00059520",
+                            "B": "-0.06250000",
+                            "C": "-1.07100000",
+                            "D": "27.99000000"
+                        },
+                        "per-channel-Pout-min": "-22.000",
+                        "per-channel-Pout-max": "1.000"
+                    }
+                }
+            },
+            "amplifiers": {
+				"Amplifier": {
+					"openroadm-operational-mode": [
+						{
+							"openroadm-operational-mode-id": "MWi-standard",
+							"per-channel-Pin-min": "-31.000",
+							"per-channel-Pin-max": "-9.000",
+							"max-introduced-pdl": "0.70",
+							"max-introduced-dgd": "3.00",
+							"max-introduced-cd": "0.00",
+							"osnr-polynomial-fit": {
+								"A": "-0.00059520",
+								"B": "-0.06250000",
+								"C": "-1.07100000",
+								"D": "28.99000000"
+							},
+							"mask-power-vs-pin": [
+								{
+									"lower-boundary": "0",
+									"upper-boundary": "6",
+									"C": "1.00000000",
+									"D": "-9.00000000",
+									"fiber-type": "smf"
+								},
+								{
+									"lower-boundary": "6",
+									"upper-boundary": "8",
+									"C": "-0.00000000",
+									"D": "-3.00000000",
+									"fiber-type": "smf"
+								},
+								{
+									"lower-boundary": "8",
+									"upper-boundary": "23",
+									"C": "0.33333334",
+									"D": "-5.66666667",
+									"fiber-type": "smf"
+								},
+								{
+									"lower-boundary": "23",
+									"upper-boundary": "31",
+									"C": "0.00000000",
+									"D": "2.00000000",
+									"fiber-type": "smf"
+								}
+							],
+							"min-gain": "0.000",
+							"max-gain": "27.000",
+							"max-extended-gain": "31.000",
+							"mask-gain-ripple-vs-tilt": [
+								{
+									"lower-boundary": "-4",
+									"upper-boundary": "-1",
+									"C": "-0.50",
+									"D": "1.00"
+								},
+								{
+									"lower-boundary": "-1",
+									"upper-boundary": "0",
+									"C": "0.50",
+									"D": "2.00"
+								}
+							]
+						},
+						{
+							"openroadm-operational-mode-id": "MWi-low-noise",
+							"per-channel-Pin-min": "-31.000",
+							"per-channel-Pin-max": "-9.000",
+							"max-introduced-pdl": "0.700",
+							"max-introduced-dgd": "3.00",
+							"max-introduced-cd": "0.00",
+							"osnr-polynomial-fit": {
+								"A": "-0.00081040",
+								"B": "-0.06221000",
+								"C": "-0.58890000",
+								"D": "37.62000000"
+							},
+							"mask-power-vs-pin": [
+								{
+									"lower-boundary": "0",
+									"upper-boundary": "6",
+									"C": "1.00000000",
+									"D": "-9.00000000",
+									"fiber-type": "smf"
+								},
+								{
+									"lower-boundary": "6",
+									"upper-boundary": "8",
+									"C": "-0.00000000",
+									"D": "-3.00000000",
+									"fiber-type": "smf"
+								},
+								{
+									"lower-boundary": "8",
+									"upper-boundary": "23",
+									"C": "0.33333334",
+									"D": "-5.66666667",
+									"fiber-type": "smf"
+								},
+								{
+									"lower-boundary": "23",
+									"upper-boundary": "31",
+									"C": "0.00000000",
+									"D": "2.00000000",
+									"fiber-type": "smf"
+								}
+							],
+							"min-gain": "0.000",
+							"max-gain": "27.000",
+							"max-extended-gain": "31.000",
+							 "mask-gain-ripple-vs-tilt": [
+								{
+									"lower-boundary": "-4",
+									"upper-boundary": "-1",
+									"C": "-0.50",
+									"D": "1.00"
+								},
+								{
+									"lower-boundary": "-1",
+									"upper-boundary": "0",
+									"C": "0.50",
+									"D": "2.00"
+								}
+							]
+						}
+					]
+				}
+			}
+        }
+    }
+}

--- a/model/Specifications/body-rpc-add-operational-modes-to-catalog-15_0-optical-spec-6_0.json
+++ b/model/Specifications/body-rpc-add-operational-modes-to-catalog-15_0-optical-spec-6_0.json
@@ -1,0 +1,2103 @@
+{
+	"input": {
+		    "sdnc-request-header": {
+			    "request-id": "load-OM-Catalog",
+			    "rpc-action": "fill-catalog-with-or-operational-modes",
+			    "request-system-id": "appname"
+		    },
+            "operational-mode-info": {
+                "grid-parameters": {
+                    "min-central-frequency": "191.32500000",
+                    "max-central-frequency": "196.12500000",
+                    "central-frequency-granularity": "12.50000",
+                    "min-spacing": "37.50000"
+                },
+                "xponders-pluggables": {
+                    "xponder-pluggable-openroadm-operational-mode": [
+                        {
+                            "openroadm-operational-mode-id": "OR-W-100G-SC",
+                            "baud-rate": "28.0",
+                            "line-rate": "111.8",
+                            "modulation-format": "dp-qpsk",
+                            "min-TX-osnr": "33.000",
+                            "TX-OOB-osnr": {
+                                "WR-openroadm-operational-mode-id": "MW-WR-core",
+                                "min-OOB-osnr-multi-channel-value": "31.000",
+                                "min-OOB-osnr-single-channel-value": "43.000"
+                            },
+                            "output-power-range": {
+                                "WR-openroadm-operational-mode-id": "MW-WR-core",
+                                "min-output-power": "-5.000",
+                                "max-output-power": "0.000"
+                            },
+                            "min-RX-osnr-tolerance": "17.000",
+                            "min-input-power-at-RX-osnr": "-22.000",
+                            "max-input-power": "1.000",
+                            "channel-width": "40.00000",
+                            "fec-type": "org-openroadm-common-types:scfec",
+                            "penalties": [
+                                {
+                                    "parameter-and-unit": "CD-ps/nm",
+                                    "up-to-boundary": "18000.00",
+                                    "penalty-value": "0.000"
+                                },
+                                {
+                                    "parameter-and-unit": "PDL-dB",
+                                    "up-to-boundary": "6.00",
+                                    "penalty-value": "0.000"
+                                },
+                                {
+                                    "parameter-and-unit": "PMD-ps",
+                                    "up-to-boundary": "30.00",
+                                    "penalty-value": "0.000"
+                                },
+                                {
+                                    "parameter-and-unit": "power-dBm",
+                                    "up-to-boundary": "-22.00",
+                                    "penalty-value": "0.000"
+                                },
+                                {
+                                    "parameter-and-unit": "cross-talk-total-power-dB",
+                                    "up-to-boundary": "15.00",
+                                    "penalty-value": "0.200"
+                                },
+                                {
+                                    "parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+                                    "up-to-boundary": "4.00",
+                                    "penalty-value": "0.200"
+                                }
+                            ]
+                        },
+                        {
+                            "openroadm-operational-mode-id": "OR-W-100G-oFEC-31.6Gbd",
+                            "baud-rate": "31.6",
+                            "line-rate": "126.3",
+                            "modulation-format": "dp-qpsk",
+                            "min-TX-osnr": "37.000",
+                            "TX-OOB-osnr": {
+                                "WR-openroadm-operational-mode-id": "MW-WR-core",
+                                "min-OOB-osnr-multi-channel-value": "36.000"
+                            },
+                            "output-power-range": {
+                                "WR-openroadm-operational-mode-id": "MW-WR-core",
+                                "min-output-power": "-5.000",
+                                "max-output-power": "0.000"
+                            },
+                            "min-RX-osnr-tolerance": "12.000",
+                            "min-input-power-at-RX-osnr": "-18.000",
+                            "max-input-power": "1.000",
+                            "channel-width": "37.88400",
+                            "fec-type": "ofec",
+                            "min-roll-off": "0.05",
+                            "max-roll-off": "0.20",
+                            "penalties": [
+                                {
+                                    "parameter-and-unit": "CD-ps/nm",
+                                    "up-to-boundary": "4000.00",
+                                    "penalty-value": "0.000"
+                                },
+                                {
+                                    "parameter-and-unit": "CD-ps/nm",
+                                    "up-to-boundary": "48000.00",
+                                    "penalty-value": "0.500"
+                                },
+                                {
+                                    "parameter-and-unit": "PDL-dB",
+                                    "up-to-boundary": "1.00",
+                                    "penalty-value": "0.500"
+                                },
+                                {
+                                    "parameter-and-unit": "PDL-dB",
+                                    "up-to-boundary": "2.00",
+                                    "penalty-value": "1.000"
+                                },
+                                {
+                                    "parameter-and-unit": "PDL-dB",
+                                    "up-to-boundary": "4.00",
+                                    "penalty-value": "2.500"
+                                },
+                                {
+                                    "parameter-and-unit": "PDL-dB",
+                                    "up-to-boundary": "6.00",
+                                    "penalty-value": "4.000"
+                                },
+                                {
+                                    "parameter-and-unit": "PMD-ps",
+                                    "up-to-boundary": "10.00",
+                                    "penalty-value": "0.000"
+                                },
+                                {
+                                    "parameter-and-unit": "PMD-ps",
+                                    "up-to-boundary": "30.00",
+                                    "penalty-value": "0.500"
+                                },
+                                {
+                                    "parameter-and-unit": "power-dBm",
+                                    "up-to-boundary": "-18.00",
+                                    "penalty-value": "0.000"
+                                },
+                                {
+                                    "parameter-and-unit": "power-dBm",
+                                    "up-to-boundary": "-20.00",
+                                    "penalty-value": "1.000"
+                                },
+                                {
+                                    "parameter-and-unit": "cross-talk-total-power-dB",
+                                    "up-to-boundary": "15.00",
+                                    "penalty-value": "0.200"
+                                },
+                                {
+                                    "parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+                                    "up-to-boundary": "4.0",
+                                    "penalty-value": "0.200"
+                                }
+                            ]
+                        },
+                        {
+                            "openroadm-operational-mode-id": "OR-W-200G-oFEC-31.6Gbd",
+                            "baud-rate": "31.6",
+                            "line-rate": "252.6",
+                            "modulation-format": "dp-qam16",
+                            "min-TX-osnr": "37.000",
+                            "TX-OOB-osnr": {
+                                "WR-openroadm-operational-mode-id": "MW-WR-core",
+                                "min-OOB-osnr-multi-channel-value": "36.000"
+                            },
+                            "output-power-range": {
+                                "WR-openroadm-operational-mode-id": "MW-WR-core",
+                                "min-output-power": "-5.000",
+                                "max-output-power": "0.000"
+                            },
+                            "min-RX-osnr-tolerance": "20.500",
+                            "min-input-power-at-RX-osnr": "-16.000",
+                            "max-input-power": "1.000",
+                            "channel-width": "37.88400",
+                            "fec-type": "ofec",
+                            "min-roll-off": "0.05",
+                            "max-roll-off": "0.20",
+                            "penalties": [
+                                {
+                                    "parameter-and-unit": "CD-ps/nm",
+                                    "up-to-boundary": "4000.00",
+                                    "penalty-value": "0.000"
+                                },
+                                {
+                                    "parameter-and-unit": "CD-ps/nm",
+                                    "up-to-boundary": "24000.00",
+                                    "penalty-value": "0.500"
+                                },
+                                {
+                                    "parameter-and-unit": "PDL-dB",
+                                    "up-to-boundary": "1.00",
+                                    "penalty-value": "0.500"
+                                },
+                                {
+                                    "parameter-and-unit": "PDL-dB",
+                                    "up-to-boundary": "2.00",
+                                    "penalty-value": "1.000"
+                                },
+                                {
+                                    "parameter-and-unit": "PDL-dB",
+                                    "up-to-boundary": "4.00",
+                                    "penalty-value": "2.500"
+                                },
+                                {
+                                    "parameter-and-unit": "PDL-dB",
+                                    "up-to-boundary": "6.00",
+                                    "penalty-value": "4.000"
+                                },
+                                {
+                                    "parameter-and-unit": "PMD-ps",
+                                    "up-to-boundary": "10.00",
+                                    "penalty-value": "0.000"
+                                },
+                                {
+                                    "parameter-and-unit": "PMD-ps",
+                                    "up-to-boundary": "30.00",
+                                    "penalty-value": "0.500"
+                                },
+                                {
+                                    "parameter-and-unit": "power-dBm",
+                                    "up-to-boundary": "-16.00",
+                                    "penalty-value": "0.000"
+                                },
+                                {
+                                    "parameter-and-unit": "power-dBm",
+                                    "up-to-boundary": "-18.00",
+                                    "penalty-value": "1.000"
+                                },
+                                {
+                                    "parameter-and-unit": "power-dBm",
+                                    "up-to-boundary": "-20.00",
+                                    "penalty-value": "2.000"
+                                },
+                                {
+                                    "parameter-and-unit": "cross-talk-total-power-dB",
+                                    "up-to-boundary": "15.00",
+                                    "penalty-value": "0.500"
+                                },
+                                {
+                                    "parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+                                    "up-to-boundary": "4.00",
+                                    "penalty-value": "0.500"
+                                }
+                            ]
+                        },
+                        {
+                            "openroadm-operational-mode-id": "OR-W-200G-oFEC-63.1Gbd",
+                            "baud-rate": "63.1",
+                            "line-rate": "252.6",
+                            "modulation-format": "dp-qpsk",
+                            "min-TX-osnr": "37.000",
+                            "TX-OOB-osnr": {
+                                "WR-openroadm-operational-mode-id": "MW-WR-core",
+                                "min-OOB-osnr-multi-channel-value": "36.000"
+                            },
+                            "output-power-range": {
+                                "WR-openroadm-operational-mode-id": "MW-WR-core",
+                                "min-output-power": "-5.000",
+                                "max-output-power": "0.000"
+                            },
+                            "min-RX-osnr-tolerance": "16.000",
+                            "min-input-power-at-RX-osnr": "-18.000",
+                            "max-input-power": "1.000",
+                            "channel-width": "75.72000",
+                            "fec-type": "ofec",
+                            "min-roll-off": "0.05",
+                            "max-roll-off": "0.20",
+                            "penalties": [
+                                {
+                                    "parameter-and-unit": "CD-ps/nm",
+                                    "up-to-boundary": "4000.00",
+                                    "penalty-value": "0.000"
+                                },
+                                {
+                                    "parameter-and-unit": "CD-ps/nm",
+                                    "up-to-boundary": "24000.00",
+                                    "penalty-value": "0.500"
+                                },
+                                {
+                                    "parameter-and-unit": "PDL-dB",
+                                    "up-to-boundary": "1.00",
+                                    "penalty-value": "0.500"
+                                },
+                                {
+                                    "parameter-and-unit": "PDL-dB",
+                                    "up-to-boundary": "2.00",
+                                    "penalty-value": "1.000"
+                                },
+                                {
+                                    "parameter-and-unit": "PDL-dB",
+                                    "up-to-boundary": "4.00",
+                                    "penalty-value": "2.500"
+                                },
+                                {
+                                    "parameter-and-unit": "PMD-ps",
+                                    "up-to-boundary": "10.00",
+                                    "penalty-value": "0.000"
+                                },
+                                {
+                                    "parameter-and-unit": "PMD-ps",
+                                    "up-to-boundary": "25.00",
+                                    "penalty-value": "0.500"
+                                },
+                                {
+                                    "parameter-and-unit": "power-dBm",
+                                    "up-to-boundary": "-18.00",
+                                    "penalty-value": "0.000"
+                                },
+                                {
+                                    "parameter-and-unit": "power-dBm",
+                                    "up-to-boundary": "-20.00",
+                                    "penalty-value": "1.000"
+                                },
+                                {
+                                    "parameter-and-unit": "cross-talk-total-power-dB",
+                                    "up-to-boundary": "15.00",
+                                    "penalty-value": "0.300"
+                                },
+                                {
+                                    "parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+                                    "up-to-boundary": "4.00",
+                                    "penalty-value": "0.500"
+                                }
+                            ]
+                        },
+                        {
+                            "openroadm-operational-mode-id": "OR-W-300G-oFEC-63.1Gbd",
+                            "baud-rate": "63.1",
+                            "line-rate": "378.8",
+                            "modulation-format": "dp-qam8",
+                            "min-TX-osnr": "37.000",
+                            "TX-OOB-osnr": {
+                                "WR-openroadm-operational-mode-id": "MW-WR-core",
+                                "min-OOB-osnr-multi-channel-value": "36.000"
+                            },
+                            "output-power-range": {
+                                "WR-openroadm-operational-mode-id": "MW-WR-core",
+                                "min-output-power": "-5.000",
+                                "max-output-power": "0.000"
+                            },
+                            "min-RX-osnr-tolerance": "21.000",
+                            "min-input-power-at-RX-osnr": "-16.000",
+                            "max-input-power": "1.000",
+                            "channel-width": "75.72000",
+                            "fec-type": "ofec",
+                            "min-roll-off": "0.05",
+                            "max-roll-off": "0.20",
+                            "penalties": [
+                                {
+                                    "parameter-and-unit": "CD-ps/nm",
+                                    "up-to-boundary": "4000.00",
+                                    "penalty-value": "0.000"
+                                },
+                                {
+                                    "parameter-and-unit": "CD-ps/nm",
+                                    "up-to-boundary": "18000.00",
+                                    "penalty-value": "0.500"
+                                },
+                                {
+                                    "parameter-and-unit": "PDL-dB",
+                                    "up-to-boundary": "1.00",
+                                    "penalty-value": "0.500"
+                                },
+                                {
+                                    "parameter-and-unit": "PDL-dB",
+                                    "up-to-boundary": "2.00",
+                                    "penalty-value": "1.000"
+                                },
+                                {
+                                    "parameter-and-unit": "PDL-dB",
+                                    "up-to-boundary": "4.00",
+                                    "penalty-value": "2.500"
+                                },
+                                {
+                                    "parameter-and-unit": "PMD-ps",
+                                    "up-to-boundary": "10.00",
+                                    "penalty-value": "0.000"
+                                },
+                                {
+                                    "parameter-and-unit": "PMD-ps",
+                                    "up-to-boundary": "25.00",
+                                    "penalty-value": "0.500"
+                                },
+                                {
+                                    "parameter-and-unit": "power-dBm",
+                                    "up-to-boundary": "-16.00",
+                                    "penalty-value": "0.000"
+                                },
+                                {
+                                    "parameter-and-unit": "power-dBm",
+                                    "up-to-boundary": "-18.00",
+                                    "penalty-value": "1.000"
+                                },
+                                {
+                                    "parameter-and-unit": "power-dBm",
+                                    "up-to-boundary": "-20.00",
+                                    "penalty-value": "2.000"
+                                },
+                                {
+                                    "parameter-and-unit": "cross-talk-total-power-dB",
+                                    "up-to-boundary": "15.00",
+                                    "penalty-value": "0.300"
+                                },
+                                {
+                                    "parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+                                    "up-to-boundary": "4.00",
+                                    "penalty-value": "0.500"
+                                }
+                            ]
+                        },
+                        {
+                            "openroadm-operational-mode-id": "OR-W-400G-oFEC-63.1Gbd",
+                            "baud-rate": "63.1",
+                            "line-rate": "505.1",
+                            "modulation-format": "dp-qam16",
+                            "min-TX-osnr": "37.000",
+                            "TX-OOB-osnr": {
+                                "WR-openroadm-operational-mode-id": "MW-WR-core",
+                                "min-OOB-osnr-multi-channel-value": "36.000"
+                            },
+                            "output-power-range": {
+                                "WR-openroadm-operational-mode-id": "MW-WR-core",
+                                "min-output-power": "-5.000",
+                                "max-output-power": "0.000"
+                            },
+                            "min-RX-osnr-tolerance": "24.000",
+                            "min-input-power-at-RX-osnr": "-14.000",
+                            "max-input-power": "1.000",
+                            "channel-width": "75.72000",
+                            "fec-type": "ofec",
+                            "min-roll-off": "0.05",
+                            "max-roll-off": "0.20",
+                            "penalties": [
+                                {
+                                    "parameter-and-unit": "CD-ps/nm",
+                                    "up-to-boundary": "4000.00",
+                                    "penalty-value": "0.000"
+                                },
+                                {
+                                    "parameter-and-unit": "CD-ps/nm",
+                                    "up-to-boundary": "12000.00",
+                                    "penalty-value": "0.500"
+                                },
+                                {
+                                    "parameter-and-unit": "PDL-dB",
+                                    "up-to-boundary": "1.00",
+                                    "penalty-value": "0.500"
+                                },
+                                {
+                                    "parameter-and-unit": "PDL-dB",
+                                    "up-to-boundary": "2.00",
+                                    "penalty-value": "1.000"
+                                },
+                                {
+                                    "parameter-and-unit": "PDL-dB",
+                                    "up-to-boundary": "4.00",
+                                    "penalty-value": "2.500"
+                                },
+                                {
+                                    "parameter-and-unit": "PMD-ps",
+                                    "up-to-boundary": "10.00",
+                                    "penalty-value": "0.000"
+                                },
+                                {
+                                    "parameter-and-unit": "PMD-ps",
+                                    "up-to-boundary": "20.00",
+                                    "penalty-value": "0.500"
+                                },
+                                {
+                                    "parameter-and-unit": "power-dBm",
+                                    "up-to-boundary": "-14.00",
+                                    "penalty-value": "0.000"
+                                },
+                                {
+                                    "parameter-and-unit": "power-dBm",
+                                    "up-to-boundary": "-16.00",
+                                    "penalty-value": "1.000"
+                                },
+                                {
+                                    "parameter-and-unit": "power-dBm",
+                                    "up-to-boundary": "-18.00",
+                                    "penalty-value": "2.000"
+                                },
+                                {
+                                    "parameter-and-unit": "cross-talk-total-power-dB",
+                                    "up-to-boundary": "13.00",
+                                    "penalty-value": "0.300"
+                                },
+                                {
+                                    "parameter-and-unit": "cross-talk-total-power-dB",
+                                    "up-to-boundary": "15.00",
+                                    "penalty-value": "0.500"
+                                },
+                                {
+                                    "parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+                                    "up-to-boundary": "4.00",
+                                    "penalty-value": "0.500"
+                                }
+                            ]
+                        },
+						{
+							"openroadm-operational-mode-id": "OR-W-400G-oFEC-124Gbd",
+							"baud-rate": "124.1",
+							"line-rate": "422.6",
+							"modulation-format": "dp-qpsk",
+							"min-TX-osnr": "37.000",
+							"TX-OOB-osnr": {
+								"WR-openroadm-operational-mode-id": "MW-WR-core",
+								"min-OOB-osnr-multi-channel-value": "36.000"
+							},
+							"output-power-range": {
+								"WR-openroadm-operational-mode-id": "MW-WR-core",
+								"min-output-power": "-5.000",
+								"max-output-power": "0.000"
+							},
+							"min-RX-osnr-tolerance": "20.000",
+							"min-input-power-at-RX-osnr": "-15.000",
+							"max-input-power": "1.000",
+							"channel-width": "148.92000",
+							"fec-type": "org-openroadm-common-types:ofec",
+							"min-roll-off": "0.05",
+							"max-roll-off": "0.20",
+							"penalties": [
+								{
+									"parameter-and-unit": "CD-ps/nm",
+									"up-to-boundary": "4000",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "CD-ps/nm",
+									"up-to-boundary": "24000",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "1.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "2.00",
+									"penalty-value": "1.000"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "4.00",
+									"penalty-value": "2.500"
+								},
+								{
+									"parameter-and-unit": "PMD-ps",
+									"up-to-boundary": "10.00",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "PMD-ps",
+									"up-to-boundary": "25.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "power-dBm",
+									"up-to-boundary": "-15",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "power-dBm",
+									"up-to-boundary": "-18.00",
+									"penalty-value": "1.000"
+								},
+								{
+									"parameter-and-unit": "cross-talk-total-power-dB",
+									"up-to-boundary": "15.00",
+									"penalty-value": "0.300"
+								},
+								{
+									"parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+									"up-to-boundary": "4.10",
+									"penalty-value": "0.500"
+								}
+							]
+						},
+						{
+							"openroadm-operational-mode-id": "OR-W-400G-oFEC-118Gbd",
+							"baud-rate": "118.2",
+							"line-rate": "422.6",
+							"modulation-format": "dp-qpsk",
+							"min-TX-osnr": "37.000",
+							"TX-OOB-osnr": {
+								"WR-openroadm-operational-mode-id": "MW-WR-core",
+								"min-OOB-osnr-multi-channel-value": "36.000"
+							},
+							"output-power-range": {
+								"WR-openroadm-operational-mode-id": "MW-WR-core",
+								"min-output-power": "-5.000",
+								"max-output-power": "0.000"
+							},
+							"min-RX-osnr-tolerance": "20.000",
+							"min-input-power-at-RX-osnr": "-15.000",
+							"max-input-power": "1.000",
+							"channel-width": "141.84000",
+							"fec-type": "org-openroadm-common-types:ofec",
+							"min-roll-off": "0.05",
+							"max-roll-off": "0.20",
+							"penalties": [
+								{
+									"parameter-and-unit": "CD-ps/nm",
+									"up-to-boundary": "4000",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "CD-ps/nm",
+									"up-to-boundary": "24000",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "1.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "2.00",
+									"penalty-value": "1.000"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "4.00",
+									"penalty-value": "2.500"
+								},
+								{
+									"parameter-and-unit": "PMD-ps",
+									"up-to-boundary": "10.00",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "PMD-ps",
+									"up-to-boundary": "25.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "power-dBm",
+									"up-to-boundary": "-15",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "power-dBm",
+									"up-to-boundary": "-18.00",
+									"penalty-value": "1.000"
+								},
+								{
+									"parameter-and-unit": "cross-talk-total-power-dB",
+									"up-to-boundary": "15.00",
+									"penalty-value": "0.300"
+								},
+								{
+									"parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+									"up-to-boundary": "4.10",
+									"penalty-value": "0.500"
+								}
+							]
+						},
+						{
+							"openroadm-operational-mode-id": "OR-W-400G-oFEC-124Gbd_type2",
+							"baud-rate": "124.1",
+							"line-rate": "422.6",
+							"modulation-format": "dp-qpsk",
+							"min-TX-osnr": "37.000",
+							"TX-OOB-osnr": {
+								"WR-openroadm-operational-mode-id": "MW-WR-core-type2",
+								"min-OOB-osnr-multi-channel-value": "36.000"
+							},
+							"output-power-range": {
+								"WR-openroadm-operational-mode-id": "MW-WR-core-type2",
+								"min-output-power": "-5.000",
+								"max-output-power": "0.000"
+							},
+							"min-RX-osnr-tolerance": "20.000",
+							"min-input-power-at-RX-osnr": "-15.000",
+							"max-input-power": "1.000",
+							"channel-width": "148.92000",
+							"fec-type": "org-openroadm-common-types:ofec",
+							"min-roll-off": "0.05",
+							"max-roll-off": "0.20",
+							"penalties": [
+								{
+									"parameter-and-unit": "CD-ps/nm",
+									"up-to-boundary": "4000",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "CD-ps/nm",
+									"up-to-boundary": "24000",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "1.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "2.00",
+									"penalty-value": "1.000"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "4.00",
+									"penalty-value": "2.500"
+								},
+								{
+									"parameter-and-unit": "PMD-ps",
+									"up-to-boundary": "10.00",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "PMD-ps",
+									"up-to-boundary": "25.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "power-dBm",
+									"up-to-boundary": "-15",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "power-dBm",
+									"up-to-boundary": "-18.00",
+									"penalty-value": "1.000"
+								},
+								{
+									"parameter-and-unit": "cross-talk-total-power-dB",
+									"up-to-boundary": "15.00",
+									"penalty-value": "0.300"
+								},
+								{
+									"parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+									"up-to-boundary": "4.10",
+									"penalty-value": "0.500"
+								}
+							]
+						},
+						{
+							"openroadm-operational-mode-id": "OR-W-400G-oFEC-118Gbd_type2",
+							"baud-rate": "118.2",
+							"line-rate": "422.6",
+							"modulation-format": "dp-qpsk",
+							"min-TX-osnr": "37.000",
+							"TX-OOB-osnr": {
+								"WR-openroadm-operational-mode-id": "MW-WR-core-type2",
+								"min-OOB-osnr-multi-channel-value": "36.000"
+							},
+							"output-power-range": {
+								"WR-openroadm-operational-mode-id": "MW-WR-core-type2",
+								"min-output-power": "-5.000",
+								"max-output-power": "0.000"
+							},
+							"min-RX-osnr-tolerance": "20.000",
+							"min-input-power-at-RX-osnr": "-15.000",
+							"max-input-power": "1.000",
+							"channel-width": "141.84000",
+							"fec-type": "org-openroadm-common-types:ofec",
+							"min-roll-off": "0.05",
+							"max-roll-off": "0.20",
+							"penalties": [
+								{
+									"parameter-and-unit": "CD-ps/nm",
+									"up-to-boundary": "4000",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "CD-ps/nm",
+									"up-to-boundary": "24000",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "1.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "2.00",
+									"penalty-value": "1.000"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "4.00",
+									"penalty-value": "2.500"
+								},
+								{
+									"parameter-and-unit": "PMD-ps",
+									"up-to-boundary": "10.00",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "PMD-ps",
+									"up-to-boundary": "25.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "power-dBm",
+									"up-to-boundary": "-15",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "power-dBm",
+									"up-to-boundary": "-18.00",
+									"penalty-value": "1.000"
+								},
+								{
+									"parameter-and-unit": "cross-talk-total-power-dB",
+									"up-to-boundary": "15.00",
+									"penalty-value": "0.300"
+								},
+								{
+									"parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+									"up-to-boundary": "4.10",
+									"penalty-value": "0.500"
+								}
+							]
+						},
+						{
+							"openroadm-operational-mode-id": "OR-W-800G-oFEC-124Gbd",
+							"baud-rate": "124.1",
+							"line-rate": "845.1",
+							"modulation-format": "dp-qam16",
+							"min-TX-osnr": "37.000",
+							"TX-OOB-osnr": {
+								"WR-openroadm-operational-mode-id": "MW-WR-core",
+								"min-OOB-osnr-multi-channel-value": "36.000"
+							},
+							"output-power-range": {
+								"WR-openroadm-operational-mode-id": "MW-WR-core",
+								"min-output-power": "-5.000",
+								"max-output-power": "0.000"
+							},
+							"min-RX-osnr-tolerance": "27.200",
+							"min-input-power-at-RX-osnr": "-11.000",
+							"max-input-power": "1.000",
+							"channel-width": "148.92000",
+							"fec-type": "org-openroadm-common-types:ofec",
+							"min-roll-off": "0.05",
+							"max-roll-off": "0.20",
+							"penalties": [
+								{
+									"parameter-and-unit": "CD-ps/nm",
+									"up-to-boundary": "4000",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "CD-ps/nm",
+									"up-to-boundary": "12000",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "1.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "2.00",
+									"penalty-value": "1.000"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "4.00",
+									"penalty-value": "2.500"
+								},
+								{
+									"parameter-and-unit": "PMD-ps",
+									"up-to-boundary": "10.00",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "PMD-ps",
+									"up-to-boundary": "20.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "power-dBm",
+									"up-to-boundary": "-11.00",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "power-dBm",
+									"up-to-boundary": "-14.00",
+									"penalty-value": "1.000"
+								},
+								{
+									"parameter-and-unit": "cross-talk-total-power-dB",
+									"up-to-boundary": "13.00",
+									"penalty-value": "0.300"
+								},
+								{
+									"parameter-and-unit": "cross-talk-total-power-dB",
+									"up-to-boundary": "15.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+									"up-to-boundary": "4.10",
+									"penalty-value": "0.500"
+								}
+							]
+						},
+						{
+							"openroadm-operational-mode-id": "OR-W-800G-oFEC-118Gbd",
+							"baud-rate": "118.2",
+							"line-rate": "845.1",
+							"modulation-format": "dp-qam16",
+							"min-TX-osnr": "37.000",
+							"TX-OOB-osnr": {
+								"WR-openroadm-operational-mode-id": "MW-WR-core",
+								"min-OOB-osnr-multi-channel-value": "36.000"
+							},
+							"output-power-range": {
+								"WR-openroadm-operational-mode-id": "MW-WR-core",
+								"min-output-power": "-5.000",
+								"max-output-power": "0.000"
+							},
+							"min-RX-osnr-tolerance": "27.000",
+							"min-input-power-at-RX-osnr": "-11.000",
+							"max-input-power": "1.000",
+							"channel-width": "141.84000",
+							"fec-type": "org-openroadm-common-types:ofec",
+							"min-roll-off": "0.05",
+							"max-roll-off": "0.20",
+							"penalties": [
+								{
+									"parameter-and-unit": "CD-ps/nm",
+									"up-to-boundary": "4000",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "CD-ps/nm",
+									"up-to-boundary": "12000",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "1.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "2.00",
+									"penalty-value": "1.000"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "4.00",
+									"penalty-value": "2.500"
+								},
+								{
+									"parameter-and-unit": "PMD-ps",
+									"up-to-boundary": "10.00",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "PMD-ps",
+									"up-to-boundary": "20.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "power-dBm",
+									"up-to-boundary": "-11.00",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "power-dBm",
+									"up-to-boundary": "-14.00",
+									"penalty-value": "1.000"
+								},
+								{
+									"parameter-and-unit": "cross-talk-total-power-dB",
+									"up-to-boundary": "13.00",
+									"penalty-value": "0.300"
+								},
+								{
+									"parameter-and-unit": "cross-talk-total-power-dB",
+									"up-to-boundary": "15.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+									"up-to-boundary": "4.10",
+									"penalty-value": "0.500"
+								}
+							]
+						},
+						{
+							"openroadm-operational-mode-id": "OR-W-800G-oFEC-124Gbd_type2",
+							"baud-rate": "124.1",
+							"line-rate": "845.1",
+							"modulation-format": "dp-qam16",
+							"min-TX-osnr": "37.000",
+							"TX-OOB-osnr": {
+								"WR-openroadm-operational-mode-id": "MW-WR-core-type2",
+								"min-OOB-osnr-multi-channel-value": "36.000"
+							},
+							"output-power-range": {
+								"WR-openroadm-operational-mode-id": "MW-WR-core-type2",
+								"min-output-power": "-5.000",
+								"max-output-power": "0.000"
+							},
+							"min-RX-osnr-tolerance": "27.200",
+							"min-input-power-at-RX-osnr": "-11.000",
+							"max-input-power": "1.000",
+							"channel-width": "148.92000",
+							"fec-type": "org-openroadm-common-types:ofec",
+							"min-roll-off": "0.05",
+							"max-roll-off": "0.20",
+							"penalties": [
+								{
+									"parameter-and-unit": "CD-ps/nm",
+									"up-to-boundary": "4000",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "CD-ps/nm",
+									"up-to-boundary": "12000",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "1.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "2.00",
+									"penalty-value": "1.000"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "4.00",
+									"penalty-value": "2.500"
+								},
+								{
+									"parameter-and-unit": "PMD-ps",
+									"up-to-boundary": "10.00",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "PMD-ps",
+									"up-to-boundary": "20.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "power-dBm",
+									"up-to-boundary": "-11.00",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "power-dBm",
+									"up-to-boundary": "-14.00",
+									"penalty-value": "1.000"
+								},
+								{
+									"parameter-and-unit": "cross-talk-total-power-dB",
+									"up-to-boundary": "13.00",
+									"penalty-value": "0.300"
+								},
+								{
+									"parameter-and-unit": "cross-talk-total-power-dB",
+									"up-to-boundary": "15.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+									"up-to-boundary": "4.10",
+									"penalty-value": "0.500"
+								}
+							]
+						},
+						{
+							"openroadm-operational-mode-id": "OR-W-800G-oFEC-118Gbd_type2",
+							"baud-rate": "118.2",
+							"line-rate": "845.1",
+							"modulation-format": "dp-qam16",
+							"min-TX-osnr": "37.000",
+							"TX-OOB-osnr": {
+								"WR-openroadm-operational-mode-id": "MW-WR-core-type2",
+								"min-OOB-osnr-multi-channel-value": "36.000"
+							},
+							"output-power-range": {
+								"WR-openroadm-operational-mode-id": "MW-WR-core-type2",
+								"min-output-power": "-5.000",
+								"max-output-power": "0.000"
+							},
+							"min-RX-osnr-tolerance": "27.000",
+							"min-input-power-at-RX-osnr": "-11.000",
+							"max-input-power": "1.000",
+							"channel-width": "141.84000",
+							"fec-type": "org-openroadm-common-types:ofec",
+							"min-roll-off": "0.05",
+							"max-roll-off": "0.20",
+							"penalties": [
+								{
+									"parameter-and-unit": "CD-ps/nm",
+									"up-to-boundary": "4000",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "CD-ps/nm",
+									"up-to-boundary": "12000",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "1.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "2.00",
+									"penalty-value": "1.000"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "4.00",
+									"penalty-value": "2.500"
+								},
+								{
+									"parameter-and-unit": "PMD-ps",
+									"up-to-boundary": "10.00",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "PMD-ps",
+									"up-to-boundary": "20.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "power-dBm",
+									"up-to-boundary": "-11.00",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "power-dBm",
+									"up-to-boundary": "-14.00",
+									"penalty-value": "1.000"
+								},
+								{
+									"parameter-and-unit": "cross-talk-total-power-dB",
+									"up-to-boundary": "13.00",
+									"penalty-value": "0.300"
+								},
+								{
+									"parameter-and-unit": "cross-talk-total-power-dB",
+									"up-to-boundary": "15.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+									"up-to-boundary": "4.10",
+									"penalty-value": "0.500"
+								}
+							]
+						},
+						{
+							"openroadm-operational-mode-id": "OR-W-600G-oFEC-124Gbd",
+							"baud-rate": "124.7",
+							"line-rate": "633.9",
+							"modulation-format": "pcs-dp-qam16",
+							"min-TX-osnr": "37.000",
+							"TX-OOB-osnr": {
+								"WR-openroadm-operational-mode-id": "MW-WR-core",
+								"min-OOB-osnr-multi-channel-value": "36.000"
+							},
+							"output-power-range": {
+								"WR-openroadm-operational-mode-id": "MW-WR-core",
+								"min-output-power": "-5.000",
+								"max-output-power": "0.000"
+							},
+							"min-RX-osnr-tolerance": "99.999",
+							"min-input-power-at-RX-osnr": "-11.000",
+							"max-input-power": "1.000",
+							"channel-width": "149.64000",
+							"fec-type": "org-openroadm-common-types:ofec",
+							"min-roll-off": "0.05",
+							"max-roll-off": "0.20",
+							"penalties": [
+								{
+									"parameter-and-unit": "CD-ps/nm",
+									"up-to-boundary": "4000",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "CD-ps/nm",
+									"up-to-boundary": "22000",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "1.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "2.00",
+									"penalty-value": "1.000"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "4.00",
+									"penalty-value": "2.500"
+								},
+								{
+									"parameter-and-unit": "PMD-ps",
+									"up-to-boundary": "10.00",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "PMD-ps",
+									"up-to-boundary": "25.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "power-dBm",
+									"up-to-boundary": "-11.00",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "power-dBm",
+									"up-to-boundary": "-18.00",
+									"penalty-value": "1.000"
+								},
+								{
+									"parameter-and-unit": "cross-talk-total-power-dB",
+									"up-to-boundary": "15.00",
+									"penalty-value": "0.300"
+								},
+								{
+									"parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+									"up-to-boundary": "4.10",
+									"penalty-value": "0.500"
+								}
+							]
+						},
+						{
+							"openroadm-operational-mode-id": "OR-W-600G-oFEC-118Gbd",
+							"baud-rate": "118.8",
+							"line-rate": "633.9",
+							"modulation-format": "pcs-dp-qam16",
+							"min-TX-osnr": "37.000",
+							"TX-OOB-osnr": {
+								"WR-openroadm-operational-mode-id": "MW-WR-core",
+								"min-OOB-osnr-multi-channel-value": "36.000"
+							},
+							"output-power-range": {
+								"WR-openroadm-operational-mode-id": "MW-WR-core",
+								"min-output-power": "-5.000",
+								"max-output-power": "0.000"
+							},
+							"min-RX-osnr-tolerance": "99.999",
+							"min-input-power-at-RX-osnr": "-11.000",
+							"max-input-power": "1.000",
+							"channel-width": "142.56000",
+							"fec-type": "org-openroadm-common-types:ofec",
+							"min-roll-off": "0.05",
+							"max-roll-off": "0.20",
+							"penalties": [
+								{
+									"parameter-and-unit": "CD-ps/nm",
+									"up-to-boundary": "4000",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "CD-ps/nm",
+									"up-to-boundary": "22000",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "1.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "2.00",
+									"penalty-value": "1.000"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "4.00",
+									"penalty-value": "2.500"
+								},
+								{
+									"parameter-and-unit": "PMD-ps",
+									"up-to-boundary": "10.00",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "PMD-ps",
+									"up-to-boundary": "25.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "power-dBm",
+									"up-to-boundary": "-11.00",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "power-dBm",
+									"up-to-boundary": "-18.00",
+									"penalty-value": "1.000"
+								},
+								{
+									"parameter-and-unit": "cross-talk-total-power-dB",
+									"up-to-boundary": "15.00",
+									"penalty-value": "0.300"
+								},
+								{
+									"parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+									"up-to-boundary": "4.10",
+									"penalty-value": "0.500"
+								}
+							]
+						},
+						{
+							"openroadm-operational-mode-id": "OR-W-800G-oFEC-131GbdE",
+							"baud-rate": "131.3",
+							"line-rate": "845.1",
+							"modulation-format": "pcs-dp-qam16",
+							"min-TX-osnr": "37.000",
+							"TX-OOB-osnr": {
+								"WR-openroadm-operational-mode-id": "MW-WR-core",
+								"min-OOB-osnr-multi-channel-value": "36.000"
+							},
+							"output-power-range": {
+								"WR-openroadm-operational-mode-id": "MW-WR-core",
+								"min-output-power": "-5.000",
+								"max-output-power": "0.000"
+							},
+							"min-RX-osnr-tolerance": "25.000",
+							"min-input-power-at-RX-osnr": "-11.000",
+							"max-input-power": "1.000",
+							"channel-width": "157.60800",
+							"fec-type": "org-openroadm-common-types:ofec",
+							"min-roll-off": "0.05",
+							"max-roll-off": "0.20",
+							"penalties": [
+								{
+									"parameter-and-unit": "CD-ps/nm",
+									"up-to-boundary": "4000",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "CD-ps/nm",
+									"up-to-boundary": "20000",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "1.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "2.00",
+									"penalty-value": "1.000"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "4.00",
+									"penalty-value": "2.500"
+								},
+								{
+									"parameter-and-unit": "PMD-ps",
+									"up-to-boundary": "10.00",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "PMD-ps",
+									"up-to-boundary": "20.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "power-dBm",
+									"up-to-boundary": "-11.00",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "power-dBm",
+									"up-to-boundary": "-14.00",
+									"penalty-value": "1.000"
+								},
+								{
+									"parameter-and-unit": "cross-talk-total-power-dB",
+									"up-to-boundary": "13.00",
+									"penalty-value": "0.300"
+								},
+								{
+									"parameter-and-unit": "cross-talk-total-power-dB",
+									"up-to-boundary": "15.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+									"up-to-boundary": "4.10",
+									"penalty-value": "0.500"
+								}
+							]
+						},
+						{
+							"openroadm-operational-mode-id": "OR-W-800G-oFEC-131GbdM",
+							"baud-rate": "131.4",
+							"line-rate": "845.1",
+							"modulation-format": "pcs-dp-qam16",
+							"min-TX-osnr": "37.000",
+							"TX-OOB-osnr": {
+								"WR-openroadm-operational-mode-id": "MW-WR-core",
+								"min-OOB-osnr-multi-channel-value": "36.000"
+							},
+							"output-power-range": {
+								"WR-openroadm-operational-mode-id": "MW-WR-core",
+								"min-output-power": "-5.000",
+								"max-output-power": "0.000"
+							},
+							"min-RX-osnr-tolerance": "26.000",
+							"min-input-power-at-RX-osnr": "-11.000",
+							"max-input-power": "1.000",
+							"channel-width": "157.62000",
+							"fec-type": "org-openroadm-common-types:ofec",
+							"min-roll-off": "0.05",
+							"max-roll-off": "0.20",
+							"penalties": [
+								{
+									"parameter-and-unit": "CD-ps/nm",
+									"up-to-boundary": "4000",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "CD-ps/nm",
+									"up-to-boundary": "20000",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "1.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "2.00",
+									"penalty-value": "1.000"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "4.00",
+									"penalty-value": "2.500"
+								},
+								{
+									"parameter-and-unit": "PMD-ps",
+									"up-to-boundary": "10.00",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "PMD-ps",
+									"up-to-boundary": "20.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "power-dBm",
+									"up-to-boundary": "-11.00",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "power-dBm",
+									"up-to-boundary": "-14.00",
+									"penalty-value": "1.000"
+								},
+								{
+									"parameter-and-unit": "cross-talk-total-power-dB",
+									"up-to-boundary": "13.00",
+									"penalty-value": "0.300"
+								},
+								{
+									"parameter-and-unit": "cross-talk-total-power-dB",
+									"up-to-boundary": "15.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+									"up-to-boundary": "4.10",
+									"penalty-value": "0.500"
+								}
+							]
+						},
+						{
+							"openroadm-operational-mode-id": "OR-W-600G-oFEC-124Gbd_type2",
+							"baud-rate": "124.7",
+							"line-rate": "633.9",
+							"modulation-format": "pcs-dp-qam16",
+							"min-TX-osnr": "37.000",
+							"TX-OOB-osnr": {
+								"WR-openroadm-operational-mode-id": "MW-WR-core-type2",
+								"min-OOB-osnr-multi-channel-value": "36.000"
+							},
+							"output-power-range": {
+								"WR-openroadm-operational-mode-id": "MW-WR-core-type2",
+								"min-output-power": "-5.000",
+								"max-output-power": "0.000"
+							},
+							"min-RX-osnr-tolerance": "99.999",
+							"min-input-power-at-RX-osnr": "-11.000",
+							"max-input-power": "1.000",
+							"channel-width": "149.64000",
+							"fec-type": "org-openroadm-common-types:ofec",
+							"min-roll-off": "0.05",
+							"max-roll-off": "0.20",
+							"penalties": [
+								{
+									"parameter-and-unit": "CD-ps/nm",
+									"up-to-boundary": "4000",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "CD-ps/nm",
+									"up-to-boundary": "22000",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "1.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "2.00",
+									"penalty-value": "1.000"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "4.00",
+									"penalty-value": "2.500"
+								},
+								{
+									"parameter-and-unit": "PMD-ps",
+									"up-to-boundary": "10.00",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "PMD-ps",
+									"up-to-boundary": "25.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "power-dBm",
+									"up-to-boundary": "-11.00",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "power-dBm",
+									"up-to-boundary": "-18.00",
+									"penalty-value": "1.000"
+								},
+								{
+									"parameter-and-unit": "cross-talk-total-power-dB",
+									"up-to-boundary": "15.00",
+									"penalty-value": "0.300"
+								},
+								{
+									"parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+									"up-to-boundary": "4.10",
+									"penalty-value": "0.500"
+								}
+							]
+						},
+						{
+							"openroadm-operational-mode-id": "OR-W-600G-oFEC-118Gbd_type2",
+							"baud-rate": "118.8",
+							"line-rate": "633.9",
+							"modulation-format": "pcs-dp-qam16",
+							"min-TX-osnr": "37.000",
+							"TX-OOB-osnr": {
+								"WR-openroadm-operational-mode-id": "MW-WR-core-type2",
+								"min-OOB-osnr-multi-channel-value": "36.000"
+							},
+							"output-power-range": {
+								"WR-openroadm-operational-mode-id": "MW-WR-core-type2",
+								"min-output-power": "-5.000",
+								"max-output-power": "0.000"
+							},
+							"min-RX-osnr-tolerance": "99.999",
+							"min-input-power-at-RX-osnr": "-11.000",
+							"max-input-power": "1.000",
+							"channel-width": "142.56000",
+							"fec-type": "org-openroadm-common-types:ofec",
+							"min-roll-off": "0.05",
+							"max-roll-off": "0.20",
+							"penalties": [
+								{
+									"parameter-and-unit": "CD-ps/nm",
+									"up-to-boundary": "4000",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "CD-ps/nm",
+									"up-to-boundary": "22000",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "1.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "2.00",
+									"penalty-value": "1.000"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "4.00",
+									"penalty-value": "2.500"
+								},
+								{
+									"parameter-and-unit": "PMD-ps",
+									"up-to-boundary": "10.00",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "PMD-ps",
+									"up-to-boundary": "25.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "power-dBm",
+									"up-to-boundary": "-11.00",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "power-dBm",
+									"up-to-boundary": "-18.00",
+									"penalty-value": "1.000"
+								},
+								{
+									"parameter-and-unit": "cross-talk-total-power-dB",
+									"up-to-boundary": "15.00",
+									"penalty-value": "0.300"
+								},
+								{
+									"parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+									"up-to-boundary": "4.10",
+									"penalty-value": "0.500"
+								}
+							]
+						},
+						{
+							"openroadm-operational-mode-id": "OR-W-800G-oFEC-131GbdE_type2",
+							"baud-rate": "131.3",
+							"line-rate": "845.1",
+							"modulation-format": "pcs-dp-qam16",
+							"min-TX-osnr": "37.000",
+							"TX-OOB-osnr": {
+								"WR-openroadm-operational-mode-id": "MW-WR-core-type2",
+								"min-OOB-osnr-multi-channel-value": "36.000"
+							},
+							"output-power-range": {
+								"WR-openroadm-operational-mode-id": "MW-WR-core-type2",
+								"min-output-power": "-5.000",
+								"max-output-power": "0.000"
+							},
+							"min-RX-osnr-tolerance": "25.000",
+							"min-input-power-at-RX-osnr": "-11.000",
+							"max-input-power": "1.000",
+							"channel-width": "157.60800",
+							"fec-type": "org-openroadm-common-types:ofec",
+							"min-roll-off": "0.05",
+							"max-roll-off": "0.20",
+							"penalties": [
+								{
+									"parameter-and-unit": "CD-ps/nm",
+									"up-to-boundary": "4000",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "CD-ps/nm",
+									"up-to-boundary": "20000",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "1.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "2.00",
+									"penalty-value": "1.000"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "4.00",
+									"penalty-value": "2.500"
+								},
+								{
+									"parameter-and-unit": "PMD-ps",
+									"up-to-boundary": "10.00",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "PMD-ps",
+									"up-to-boundary": "20.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "power-dBm",
+									"up-to-boundary": "-11.00",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "power-dBm",
+									"up-to-boundary": "-14.00",
+									"penalty-value": "1.000"
+								},
+								{
+									"parameter-and-unit": "cross-talk-total-power-dB",
+									"up-to-boundary": "13.00",
+									"penalty-value": "0.300"
+								},
+								{
+									"parameter-and-unit": "cross-talk-total-power-dB",
+									"up-to-boundary": "15.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+									"up-to-boundary": "4.10",
+									"penalty-value": "0.500"
+								}
+							]
+						},
+						{
+							"openroadm-operational-mode-id": "OR-W-800G-oFEC-131GbdM_type2",
+							"baud-rate": "131.4",
+							"line-rate": "845.1",
+							"modulation-format": "pcs-dp-qam16",
+							"min-TX-osnr": "37.000",
+							"TX-OOB-osnr": {
+								"WR-openroadm-operational-mode-id": "MW-WR-core-type2",
+								"min-OOB-osnr-multi-channel-value": "36.000"
+							},
+							"output-power-range": {
+								"WR-openroadm-operational-mode-id": "MW-WR-core-type2",
+								"min-output-power": "-5.000",
+								"max-output-power": "0.000"
+							},
+							"min-RX-osnr-tolerance": "26.000",
+							"min-input-power-at-RX-osnr": "-11.000",
+							"max-input-power": "1.000",
+							"channel-width": "157.62000",
+							"fec-type": "org-openroadm-common-types:ofec",
+							"min-roll-off": "0.05",
+							"max-roll-off": "0.20",
+							"penalties": [
+								{
+									"parameter-and-unit": "CD-ps/nm",
+									"up-to-boundary": "4000",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "CD-ps/nm",
+									"up-to-boundary": "20000",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "1.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "2.00",
+									"penalty-value": "1.000"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "4.00",
+									"penalty-value": "2.500"
+								},
+								{
+									"parameter-and-unit": "PMD-ps",
+									"up-to-boundary": "10.00",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "PMD-ps",
+									"up-to-boundary": "20.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "power-dBm",
+									"up-to-boundary": "-11.00",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "power-dBm",
+									"up-to-boundary": "-14.00",
+									"penalty-value": "1.000"
+								},
+								{
+									"parameter-and-unit": "cross-talk-total-power-dB",
+									"up-to-boundary": "13.00",
+									"penalty-value": "0.300"
+								},
+								{
+									"parameter-and-unit": "cross-talk-total-power-dB",
+									"up-to-boundary": "15.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+									"up-to-boundary": "4.10",
+									"penalty-value": "0.500"
+								}
+							]
+						}
+                    ]
+                },
+                "roadms": {
+                    "Express": {
+                        "openroadm-operational-mode": {
+                            "openroadm-operational-mode-id": "MW-MW-core",
+                            "per-channel-Pin-min": "-21.000",
+                            "per-channel-Pin-max": "-9.000",
+                            "max-introduced-pdl": "1.500",
+                            "max-introduced-dgd": "3.00",
+                            "max-introduced-cd": "25.00",
+                            "osnr-polynomial-fit": {
+                                "A": "-0.00059520",
+                                "B": "-0.06250000",
+                                "C": "-1.07100000",
+                                "D": "27.99000000"
+                            },
+                            "mask-power-vs-pin": [
+                                {
+                                    "lower-boundary": "0",
+                                    "upper-boundary": "6",
+                                    "C": "1.00000000",
+                                    "D": "-9.00000000",
+                                    "fiber-type": "smf"
+                                },
+                                {
+                                    "lower-boundary": "6",
+                                    "upper-boundary": "8",
+                                    "C": "-0.00000000",
+                                    "D": "-3.00000000",
+                                    "fiber-type": "smf"
+                                },
+                                {
+                                    "lower-boundary": "8",
+                                    "upper-boundary": "23",
+                                    "C": "0.33333334",
+                                    "D": "-5.66666667",
+                                    "fiber-type": "smf"
+                                },
+                                {
+                                    "lower-boundary": "23",
+                                    "upper-boundary": "27",
+                                    "C": "0.00000000",
+                                    "D": "2.00000000",
+                                    "fiber-type": "smf"
+                                }
+                            ]
+                        }
+                    },
+	                "Add": {
+	                    "openroadm-operational-mode": [
+		                    {
+		                        "openroadm-operational-mode-id": "MW-WR-core",
+		                        "max-channel-number": "16",
+		                        "incremental-osnr": "33.000",
+		                        "per-channel-Pin-min": "-6.000",
+		                        "per-channel-Pin-max": "3.000",
+		                        "max-introduced-pdl": "1.500",
+		                        "max-introduced-dgd": "3.00",
+		                        "max-introduced-cd": "25.00",
+		                        "mask-power-vs-pin": [
+		                            {
+		                                "lower-boundary": "0",
+		                                "upper-boundary": "6",
+		                                "C": "1.00000000",
+		                                "D": "-9.00000000",
+		                                "fiber-type": "smf"
+		                            },
+		                            {
+		                                "lower-boundary": "6",
+		                                "upper-boundary": "8",
+		                                "C": "-0.00000000",
+		                                "D": "-3.00000000",
+		                                "fiber-type": "smf"
+		                            },
+		                            {
+		                                "lower-boundary": "8",
+		                                "upper-boundary": "23",
+		                                "C": "0.33333334",
+		                                "D": "-5.66666667",
+		                                "fiber-type": "smf"
+		                            },
+		                            {
+		                                "lower-boundary": "23",
+		                                "upper-boundary": "27",
+		                                "C": "0.00000000",
+		                                "D": "2.00000000",
+		                                "fiber-type": "smf"
+		                            }
+		                        ]
+		                    },
+		                    {
+		                        "openroadm-operational-mode-id": "MW-WR-core-type2",
+		                        "max-channel-number": "4",
+		                        "incremental-osnr": "33.000",
+		                        "per-channel-Pin-min": "-6.000",
+		                        "per-channel-Pin-max": "3.000",
+		                        "max-introduced-pdl": "1.500",
+		                        "max-introduced-dgd": "3.00",
+		                        "max-introduced-cd": "25.00",
+		                        "mask-power-vs-pin": [
+		                            {
+		                                "lower-boundary": "0",
+		                                "upper-boundary": "6",
+		                                "C": "1.00000000",
+		                                "D": "-9.00000000",
+		                                "fiber-type": "smf"
+		                            },
+		                            {
+		                                "lower-boundary": "6",
+		                                "upper-boundary": "8",
+		                                "C": "-0.00000000",
+		                                "D": "-3.00000000",
+		                                "fiber-type": "smf"
+		                            },
+		                            {
+		                                "lower-boundary": "8",
+		                                "upper-boundary": "23",
+		                                "C": "0.33333334",
+		                                "D": "-5.66666667",
+		                                "fiber-type": "smf"
+		                            },
+		                            {
+		                                "lower-boundary": "23",
+		                                "upper-boundary": "27",
+		                                "C": "0.00000000",
+		                                "D": "2.00000000",
+		                                "fiber-type": "smf"
+		                            }
+		                        ]
+		                    }
+	                    ]
+	                },
+                    "Drop": {
+                        "openroadm-operational-mode": {
+                            "openroadm-operational-mode-id": "MW-WR-core",
+                            "per-channel-Pin-min": "-25.000",
+                            "per-channel-Pin-max": "-9.000",
+                            "max-introduced-pdl": "1.500",
+                            "max-introduced-dgd": "3.00",
+                            "max-introduced-cd": "25.00",
+                            "osnr-polynomial-fit": {
+                                "A": "-0.00059520",
+                                "B": "-0.06250000",
+                                "C": "-1.07100000",
+                                "D": "27.99000000"
+                            },
+                            "per-channel-Pout-min": "-22.000",
+                            "per-channel-Pout-max": "1.000"
+                        }
+                    }
+                },
+                "amplifiers": {
+                    "Amplifier": {
+                        "openroadm-operational-mode": [
+                            {
+                                "openroadm-operational-mode-id": "MWi-standard",
+                                "per-channel-Pin-min": "-31.000",
+                                "per-channel-Pin-max": "-9.000",
+                                "max-introduced-pdl": "0.70",
+                                "max-introduced-dgd": "3.00",
+                                "max-introduced-cd": "0.00",
+                                "osnr-polynomial-fit": {
+                                    "A": "-0.00059520",
+                                    "B": "-0.06250000",
+                                    "C": "-1.07100000",
+                                    "D": "28.99000000"
+                                },
+								 "mask-power-vs-pin": [
+									{
+										"lower-boundary": "0",
+										"upper-boundary": "6",
+										"C": "1.00000000",
+										"D": "-9.00000000",
+										"fiber-type": "smf"
+									},
+									{
+										"lower-boundary": "6",
+										"upper-boundary": "8",
+										"C": "-0.00000000",
+										"D": "-3.00000000",
+										"fiber-type": "smf"
+									},
+									{
+										"lower-boundary": "8",
+										"upper-boundary": "23",
+										"C": "0.33333334",
+										"D": "-5.66666667",
+										"fiber-type": "smf"
+									},
+									{
+										"lower-boundary": "23",
+										"upper-boundary": "31",
+										"C": "0.00000000",
+										"D": "2.00000000",
+										"fiber-type": "smf"
+									}
+								],
+								"min-gain": "0.000",
+								"max-gain": "27.000",
+								"max-extended-gain": "31.000",
+								 "mask-gain-ripple-vs-tilt": [
+                                    {
+                                        "lower-boundary": "-4",
+                                        "upper-boundary": "-1",
+                                        "C": "-0.50",
+                                        "D": "1.00"
+                                    },
+                                    {
+                                        "lower-boundary": "-1",
+                                        "upper-boundary": "0",
+                                        "C": "0.50",
+                                        "D": "2.00"
+                                    }
+                                ]
+                            },
+                            {
+                                "openroadm-operational-mode-id": "MWi-low-noise",
+                                "per-channel-Pin-min": "-31.000",
+                                "per-channel-Pin-max": "-9.000",
+                                "max-introduced-pdl": "0.700",
+                                "max-introduced-dgd": "3.00",
+                                "max-introduced-cd": "0.00",
+                                "osnr-polynomial-fit": {
+                                    "A": "-0.00081040",
+                                    "B": "-0.06221000",
+                                    "C": "-0.58890000",
+                                    "D": "37.62000000"
+                                },
+								 "mask-power-vs-pin": [
+									{
+										"lower-boundary": "0",
+										"upper-boundary": "6",
+										"C": "1.00000000",
+										"D": "-9.00000000",
+										"fiber-type": "smf"
+									},
+									{
+										"lower-boundary": "6",
+										"upper-boundary": "8",
+										"C": "-0.00000000",
+										"D": "-3.00000000",
+										"fiber-type": "smf"
+									},
+									{
+										"lower-boundary": "8",
+										"upper-boundary": "23",
+										"C": "0.33333334",
+										"D": "-5.66666667",
+										"fiber-type": "smf"
+									},
+									{
+										"lower-boundary": "23",
+										"upper-boundary": "31",
+										"C": "0.00000000",
+										"D": "2.00000000",
+										"fiber-type": "smf"
+									}
+								],
+								"min-gain": "0.000",
+								"max-gain": "27.000",
+								"max-extended-gain": "31.000",
+								 "mask-gain-ripple-vs-tilt": [
+                                    {
+                                        "lower-boundary": "-4",
+                                        "upper-boundary": "-1",
+                                        "C": "-0.50",
+                                        "D": "1.00"
+                                    },
+                                    {
+                                        "lower-boundary": "-1",
+                                        "upper-boundary": "0",
+                                        "C": "0.50",
+                                        "D": "2.00"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+}


### PR DESCRIPTION
Release 15.0 models

- RPC for optical rebalancing
- Add in catalog channel number to Add-Spec & new Spec Json files
- Enhance service models (feasibility) to include regenerator
- Enhance service model to globally restrict add/drop banks
- Remove IANA-AFN-SAFI (deprecated) as external dependency
- Addition of OSC PORT container in degree
- And other minor changes
