### PR TITLE
Release 13.1.1

### DIFF
--- a/External/iana-routing-types.yang
+++ b/External/iana-routing-types.yang
@@ -1,0 +1,644 @@
+module iana-routing-types {
+  namespace "urn:ietf:params:xml:ns:yang:iana-routing-types";
+  prefix iana-rt-types;
+
+  organization
+    "IANA";
+  contact
+    "Internet Assigned Numbers Authority
+
+     Postal: ICANN
+             12025 Waterfront Drive, Suite 300
+             Los Angeles, CA  90094-2536
+             United States of America
+     Tel:    +1 310 301 5800
+     <mailto:iana&iana.org>";
+
+  description
+    "This module contains a collection of YANG data types
+     considered defined by IANA and used for routing
+     protocols.
+
+     Copyright (c) 2017 IETF Trust and the persons
+     identified as authors of the code.  All rights reserved.
+
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject
+     to the license terms contained in, the Simplified BSD License
+     set forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+     (https://trustee.ietf.org/license-info).
+
+     This version of this YANG module is part of RFC 8294; see
+     the RFC itself for full legal notices.";
+
+   revision 2022-08-19 {
+     description "Added SAFI value 85.";
+  }
+
+   revision 2022-04-13 {
+     description "Added SAFI values 83 and 84.";
+  }
+
+   revision 2022-02-11 {
+     description "Added SAFI value 80.";
+  }
+
+   revision 2021-10-19 {
+     description "Added Address Family Number value 16399.";
+  }
+
+   revision 2021-09-08 {
+     description "Added SAFI value 79.";
+  }
+
+   revision 2021-05-26 {
+     description "Added ‘OBSOLETE’ to description field for SAFI value 7.";
+  }
+  
+   revision 2021-05-18 {
+     description "Added Address Family Number value 31, 
+                  SAFI value 9.";
+  }
+  
+   revision 2021-03-23 {
+     description "Added SAFI value 78.";
+  }
+
+   revision 2020-12-31 {
+     description "Non-backwards-compatible change of SAFI names
+                  (SAFI values 133, 134).";
+     reference
+       "RFC 8955: Dissemination of Flow Specification Rules.";
+  }
+
+   revision 2020-11-19 {
+     description "Added SAFI value 77.";
+  }
+
+   revision 2020-07-02 {
+     description "Added SAFI value 76.";
+  }
+  
+   revision 2020-05-12 {
+     description "Added Address Family Number value 16398, 
+                  SAFI value 75.";
+  }
+
+   revision 2019-11-04 {
+     description "Added Address Family Number value 16397.";
+  }
+
+   revision 2018-10-29 {
+     description "Added SAFI value 74.";
+  }
+
+   revision 2017-12-04 {
+     description "Initial revision.";
+     reference
+       "RFC 8294: Common YANG Data Types for the Routing Area.
+        Section 4.";
+  }
+
+
+
+
+  /*** Collection of IANA types related to routing ***/
+  /*** IANA Address Family enumeration ***/
+
+  typedef address-family {
+    type enumeration {
+      enum ipv4 {
+        value 1;
+        description
+          "IPv4 Address Family.";
+      }
+
+      enum ipv6 {
+        value 2;
+        description
+          "IPv6 Address Family.";
+      }
+
+      enum nsap {
+        value 3;
+        description
+          "OSI Network Service Access Point (NSAP) Address Family.";
+      }
+
+      enum hdlc {
+        value 4;
+        description
+          "High-Level Data Link Control (HDLC) Address Family.";
+      }
+
+      enum bbn1822 {
+        value 5;
+        description
+          "Bolt, Beranek, and Newman Report 1822 (BBN 1822)
+           Address Family.";
+      }
+
+      enum ieee802 {
+        value 6;
+        description
+          "IEEE 802 Committee Address Family
+           (aka Media Access Control (MAC) address).";
+      }
+
+      enum e163 {
+        value 7;
+        description
+          "ITU-T E.163 Address Family.";
+      }
+      enum e164 {
+        value 8;
+        description
+          "ITU-T E.164 (Switched Multimegabit Data Service (SMDS),
+           Frame Relay, ATM) Address Family.";
+      }
+
+      enum f69 {
+        value 9;
+        description
+          "ITU-T F.69 (Telex) Address Family.";
+      }
+
+      enum x121 {
+        value 10;
+        description
+          "ITU-T X.121 (X.25, Frame Relay) Address Family.";
+      }
+
+      enum ipx {
+        value 11;
+        description
+          "Novell Internetwork Packet Exchange (IPX)
+           Address Family.";
+      }
+
+      enum appletalk {
+        value 12;
+        description
+          "Apple AppleTalk Address Family.";
+      }
+
+      enum decnet-iv {
+        value 13;
+        description
+          "Digital Equipment DECnet Phase IV Address Family.";
+      }
+
+      enum vines {
+        value 14;
+        description
+          "Banyan Vines Address Family.";
+      }
+
+
+
+
+
+      enum e164-nsap {
+        value 15;
+        description
+          "ITU-T E.164 with NSAP sub-address Address Family.";
+      }
+
+      enum dns {
+        value 16;
+        description
+          "Domain Name System (DNS) Address Family.";
+      }
+
+      enum distinguished-name {
+        value 17;
+        description
+          "Distinguished Name Address Family.";
+      }
+
+      enum as-num {
+        value 18;
+        description
+          "Autonomous System (AS) Number Address Family.";
+      }
+
+      enum xtp-v4 {
+        value 19;
+        description
+          "Xpress Transport Protocol (XTP) over IPv4
+           Address Family.";
+      }
+
+      enum xtp-v6 {
+        value 20;
+        description
+          "XTP over IPv6 Address Family.";
+      }
+
+      enum xtp-native {
+        value 21;
+        description
+          "XTP native mode Address Family.";
+      }
+
+      enum fc-port {
+        value 22;
+        description
+          "Fibre Channel (FC) World-Wide Port Name Address Family.";
+      }
+      enum fc-node {
+        value 23;
+        description
+          "FC World-Wide Node Name Address Family.";
+      }
+
+      enum gwid {
+        value 24;
+        description
+          "ATM Gateway Identifier (GWID) Number Address Family.";
+      }
+
+      enum l2vpn {
+        value 25;
+        description
+          "Layer 2 VPN (L2VPN) Address Family.";
+      }
+
+      enum mpls-tp-section-eid {
+        value 26;
+        description
+          "MPLS Transport Profile (MPLS-TP) Section Endpoint
+           Identifier Address Family.";
+      }
+
+      enum mpls-tp-lsp-eid {
+        value 27;
+        description
+          "MPLS-TP Label Switched Path (LSP) Endpoint Identifier
+           Address Family.";
+      }
+
+      enum mpls-tp-pwe-eid {
+        value 28;
+        description
+          "MPLS-TP Pseudowire Endpoint Identifier Address Family.";
+      }
+
+      enum mt-v4 {
+        value 29;
+        description
+          "Multi-Topology IPv4 Address Family.";
+      }
+
+
+
+
+
+      enum mt-v6 {
+        value 30;
+        description
+          "Multi-Topology IPv6 Address Family.";
+      }
+
+      enum bgp-sfc {
+        value 31;
+        description
+          "BGP SFC Address Family.";
+        reference
+          "RFC 9015: BGP Control Plane for the Network Service Header in Service Function Chaining.";
+      }
+
+      enum eigrp-common-sf {
+        value 16384;
+        description
+          "Enhanced Interior Gateway Routing Protocol (EIGRP)
+           Common Service Family Address Family.";
+      }
+
+      enum eigrp-v4-sf {
+        value 16385;
+        description
+          "EIGRP IPv4 Service Family Address Family.";
+      }
+
+      enum eigrp-v6-sf {
+        value 16386;
+        description
+          "EIGRP IPv6 Service Family Address Family.";
+      }
+
+      enum lcaf {
+        value 16387;
+        description
+          "Locator/ID Separation Protocol (LISP)
+           Canonical Address Format (LCAF) Address Family.";
+      }
+
+      enum bgp-ls {
+        value 16388;
+        description
+          "Border Gateway Protocol - Link State (BGP-LS)
+           Address Family.";
+      }
+
+      enum mac-48 {
+        value 16389;
+        description
+          "IEEE 48-bit MAC Address Family.";
+      }
+
+
+
+
+      enum mac-64 {
+        value 16390;
+        description
+          "IEEE 64-bit MAC Address Family.";
+      }
+
+      enum trill-oui {
+        value 16391;
+        description
+          "Transparent Interconnection of Lots of Links (TRILL)
+           IEEE Organizationally Unique Identifier (OUI)
+           Address Family.";
+      }
+
+      enum trill-mac-24 {
+        value 16392;
+        description
+          "TRILL final 3 octets of 48-bit MAC Address Family.";
+      }
+
+      enum trill-mac-40 {
+        value 16393;
+        description
+          "TRILL final 5 octets of 64-bit MAC Address Family.";
+      }
+
+      enum ipv6-64 {
+        value 16394;
+        description
+          "First 8 octets (64 bits) of IPv6 address
+           Address Family.";
+      }
+
+      enum trill-rbridge-port-id {
+        value 16395;
+        description
+          "TRILL Routing Bridge (RBridge) Port ID Address Family.";
+      }
+
+      enum trill-nickname {
+        value 16396;
+        description
+          "TRILL Nickname Address Family.";
+      }
+
+      enum universally-unique-identifier {
+        value 16397;
+        description
+          "Universally Unique Identifier (UUID).";
+      }
+
+      enum routing-policy {
+        value 16398;
+        description
+          "Routing Policy Address Family.";
+      }
+
+      enum mpls-namespaces {
+        value 16399;
+        description
+          "MPLS Namespaces Address Family.";
+      }
+
+    }
+
+
+
+    description
+      "Enumeration containing all the IANA-defined
+       Address Families.";
+
+  }
+
+  /*** Subsequent Address Family Identifiers (SAFIs) ***/
+  /*** for multiprotocol BGP enumeration ***/
+
+  typedef bgp-safi {
+    type enumeration {
+      enum unicast-safi {
+        value 1;
+        description
+          "Unicast SAFI.";
+      }
+
+      enum multicast-safi {
+        value 2;
+        description
+          "Multicast SAFI.";
+      }
+
+      enum labeled-unicast-safi {
+        value 4;
+        description
+          "Labeled Unicast SAFI.";
+      }
+
+      enum multicast-vpn-safi {
+        value 5;
+        description
+          "Multicast VPN SAFI.";
+      }
+
+      enum pseudowire-safi {
+        value 6;
+        description
+          "Multi-segment Pseudowire VPN SAFI.";
+      }
+
+      enum tunnel-encap-safi {
+        value 7;
+        description
+          "Tunnel Encap SAFI (OBSOLETE).";
+      }
+
+
+      enum mcast-vpls-safi {
+        value 8;
+        description
+          "Multicast Virtual Private LAN Service (VPLS) SAFI.";
+      }
+
+      enum bgp-sfc-safi {
+        value 9;
+        description
+          "BGP SFC SAFI.";
+        reference
+          "RFC 9015: BGP Control Plane for the Network Service Header in Service Function Chaining.";
+      }
+
+      enum tunnel-safi {
+        value 64;
+        description
+          "Tunnel SAFI.";
+      }
+
+      enum vpls-safi {
+        value 65;
+        description
+          "VPLS SAFI.";
+      }
+
+      enum mdt-safi {
+        value 66;
+        description
+          "Multicast Distribution Tree (MDT) SAFI.";
+      }
+
+      enum v4-over-v6-safi {
+        value 67;
+        description
+          "IPv4 over IPv6 SAFI.";
+      }
+
+      enum v6-over-v4-safi {
+        value 68;
+        description
+          "IPv6 over IPv4 SAFI.";
+      }
+
+      enum l1-vpn-auto-discovery-safi {
+        value 69;
+        description
+          "Layer 1 VPN Auto-Discovery SAFI.";
+      }
+
+      enum evpn-safi {
+        value 70;
+        description
+          "Ethernet VPN (EVPN) SAFI.";
+      }
+
+      enum bgp-ls-safi {
+        value 71;
+        description
+          "BGP-LS SAFI.";
+      }
+
+      enum bgp-ls-vpn-safi {
+        value 72;
+        description
+          "BGP-LS VPN SAFI.";
+      }
+
+      enum sr-te-safi {
+        value 73;
+        description
+          "Segment Routing - Traffic Engineering (SR-TE) SAFI.";
+      }
+
+      enum sd-wan-capabilities-safi {
+        value 74;
+        description
+          "SD-WAN Capabilities SAFI.";
+      }
+
+      enum routing-policy-safi {
+        value 75;
+        description
+          "Routing Policy SAFI.";
+      }
+	  
+      enum classful-transport-safi {
+        value 76;
+        description
+          "Classful-Transport SAFI.";
+      }
+
+      enum tunneled-traffic-flowspec-safi {
+        value 77;
+        description
+          "Tunneled Traffic Flowspec SAFI.";
+      }
+
+      enum mcast-tree-safi {
+        value 78;
+        description
+          "MCAST-TREE SAFI.";
+      }
+
+      enum bgp-dps-safi {
+        value 79;
+        description
+          "BGP-DPS (Dynamic Path Selection) SAFI.";
+      }
+
+      enum bgp-ls-spf-safi {
+        value 80;
+        description
+          "BGP-LS-SPF SAFI.";
+      }
+
+      enum bgp-car-safi {
+        value 83;
+        description
+          "BGP CAR SAFI.";
+      }
+
+      enum bgp-vpn-car-safi {
+        value 84;
+        description
+          "BGP VPN CAR SAFI.";
+      }
+
+      enum bgp-mup-safi {
+        value 85;
+        description
+          "BGP-MUP SAFI.";
+      }
+
+      enum labeled-vpn-safi {
+        value 128;
+        description
+          "MPLS Labeled VPN SAFI.";
+      }
+
+      enum multicast-mpls-vpn-safi {
+        value 129;
+        description
+          "Multicast for BGP/MPLS IP VPN SAFI.";
+      }
+
+      enum route-target-safi {
+        value 132;
+        description
+          "Route Target SAFI.";
+      }
+
+      enum flow-spec-safi {
+        value 133;
+        description
+          "Dissemination of Flow Specification rules SAFI.";
+      }
+
+      enum l3vpn-flow-spec-safi {
+        value 134;
+        description
+          "L3VPN Dissemination of Flow Specification rules SAFI.";
+      }
+
+      enum vpn-auto-discovery-safi {
+        value 140;
+        description
+          "VPN Auto-Discovery SAFI.";
+      }
+    }
+    description
+      "Enumeration for BGP SAFI.";
+    reference
+      "RFC 4760: Multiprotocol Extensions for BGP-4.";
+  }
+}

--- a/model/Common/org-openroadm-alarm.yang
+++ b/model/Common/org-openroadm-alarm.yang
@@ -8,7 +8,7 @@ module org-openroadm-alarm {
   }
   import org-openroadm-resource {
     prefix org-openroadm-resource;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-probable-cause {
     prefix org-openroadm-probable-cause;
@@ -48,6 +48,10 @@ module org-openroadm-alarm {
      ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
      POSSIBILITY OF SUCH DAMAGE.";
 
+  revision 2025-01-10 {
+    description
+      "Version 13.1.1";
+  }
   revision 2023-05-26 {
     description
       "Version 13.1";

--- a/model/Common/org-openroadm-common-attributes.yang
+++ b/model/Common/org-openroadm-common-attributes.yang
@@ -4,7 +4,7 @@ module org-openroadm-common-attributes {
 
   import org-openroadm-otn-common-types {
     prefix org-openroadm-otn-common-types;
-    revision-date 2021-09-24;
+    revision-date 2025-01-10;
   }
 
   organization
@@ -40,6 +40,10 @@ module org-openroadm-common-attributes {
       ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
       POSSIBILITY OF SUCH DAMAGE";
 
+  revision 2025-01-10 {
+    description
+      "Version 13.1.1";
+  }
   revision 2021-09-24 {
     description
       "Version 10.0";

--- a/model/Common/org-openroadm-common-optical-channel-types.yang
+++ b/model/Common/org-openroadm-common-optical-channel-types.yang
@@ -35,6 +35,10 @@ module org-openroadm-common-optical-channel-types {
       ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
       POSSIBILITY OF SUCH DAMAGE";
 
+  revision 2025-01-10 {
+    description
+      "Version 13.1.1";
+  }
   revision 2023-05-26 {
     description
       "Version 13.1";
@@ -154,6 +158,174 @@ module org-openroadm-common-optical-channel-types {
     base foic-identity;
     description
       "Applicable to the FlexO type defined in G.Sup58";
+  }
+
+  identity R3200G-otsi {
+    base otsi-rate-identity;
+    description
+      "Applicable instance for otsi rate identity";
+  }
+
+  identity R3100G-otsi {
+    base otsi-rate-identity;
+    description
+      "Applicable instance for otsi rate identity";
+  }
+
+  identity R3000G-otsi {
+    base otsi-rate-identity;
+    description
+      "Applicable instance for otsi rate identity";
+  }
+
+  identity R2900G-otsi {
+    base otsi-rate-identity;
+    description
+      "Applicable instance for otsi rate identity";
+  }
+
+  identity R2800G-otsi {
+    base otsi-rate-identity;
+    description
+      "Applicable instance for otsi rate identity";
+  }
+
+  identity R2700G-otsi {
+    base otsi-rate-identity;
+    description
+      "Applicable instance for otsi rate identity";
+  }
+
+  identity R2600G-otsi {
+    base otsi-rate-identity;
+    description
+      "Applicable instance for otsi rate identity";
+  }
+
+  identity R2500G-otsi {
+    base otsi-rate-identity;
+    description
+      "Applicable instance for otsi rate identity";
+  }
+
+  identity R2400G-otsi {
+    base otsi-rate-identity;
+    description
+      "Applicable instance for otsi rate identity";
+  }
+
+  identity R2300G-otsi {
+    base otsi-rate-identity;
+    description
+      "Applicable instance for otsi rate identity";
+  }
+
+  identity R2200G-otsi {
+    base otsi-rate-identity;
+    description
+      "Applicable instance for otsi rate identity";
+  }
+
+  identity R2100G-otsi {
+    base otsi-rate-identity;
+    description
+      "Applicable instance for otsi rate identity";
+  }
+
+  identity R2000G-otsi {
+    base otsi-rate-identity;
+    description
+      "Applicable instance for otsi rate identity";
+  }
+
+  identity R1900G-otsi {
+    base otsi-rate-identity;
+    description
+      "Applicable instance for otsi rate identity";
+  }
+
+  identity R1800G-otsi {
+    base otsi-rate-identity;
+    description
+      "Applicable instance for otsi rate identity";
+  }
+
+  identity R1700G-otsi {
+    base otsi-rate-identity;
+    description
+      "Applicable instance for otsi rate identity";
+  }
+
+  identity R1600G-otsi {
+    base otsi-rate-identity;
+    description
+      "Applicable instance for otsi rate identity";
+  }
+
+  identity R1500G-otsi {
+    base otsi-rate-identity;
+    description
+      "Applicable instance for otsi rate identity";
+  }
+
+  identity R1400G-otsi {
+    base otsi-rate-identity;
+    description
+      "Applicable instance for otsi rate identity";
+  }
+
+  identity R1300G-otsi {
+    base otsi-rate-identity;
+    description
+      "Applicable instance for otsi rate identity";
+  }
+
+  identity R1200G-otsi {
+    base otsi-rate-identity;
+    description
+      "Applicable instance for otsi rate identity";
+  }
+
+  identity R1100G-otsi {
+    base otsi-rate-identity;
+    description
+      "Applicable instance for otsi rate identity";
+  }
+
+  identity R1000G-otsi {
+    base otsi-rate-identity;
+    description
+      "Applicable instance for otsi rate identity";
+  }
+
+  identity R900G-otsi {
+    base otsi-rate-identity;
+    description
+      "Applicable instance for otsi rate identity";
+  }
+
+  identity R800G-otsi {
+    base otsi-rate-identity;
+    description
+      "Applicable instance for otsi rate identity";
+  }
+
+  identity R700G-otsi {
+    base otsi-rate-identity;
+    description
+      "Applicable instance for otsi rate identity";
+  }
+
+  identity R600G-otsi {
+    base otsi-rate-identity;
+    description
+      "Applicable instance for otsi rate identity";
+  }
+
+  identity R500G-otsi {
+    base otsi-rate-identity;
+    description
+      "Applicable instance for otsi rate identity";
   }
 
   identity R400G-otsi {
@@ -337,5 +509,4 @@ module org-openroadm-common-optical-channel-types {
       config false;
     }
   }
-
 }

--- a/model/Common/org-openroadm-common-phy-codes.yang
+++ b/model/Common/org-openroadm-common-phy-codes.yang
@@ -35,6 +35,10 @@ module org-openroadm-common-phy-codes {
       ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
       POSSIBILITY OF SUCH DAMAGE";
 
+  revision 2025-01-10 {
+    description
+      "Version 13.1.1";
+  }
   revision 2022-05-27 {
     description
       "Version 11.1";
@@ -261,6 +265,9 @@ module org-openroadm-common-phy-codes {
     base client-phy-code-identity;
   }
   identity ethernet-100G-ER1-40 {
+    base client-phy-code-identity;
+  }
+  identity ethernet-400G-ER4-30 {
     base client-phy-code-identity;
   }
   identity ethernet-400G-FR4 {

--- a/model/Common/org-openroadm-common-types.yang
+++ b/model/Common/org-openroadm-common-types.yang
@@ -35,6 +35,10 @@ module org-openroadm-common-types {
       ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
       POSSIBILITY OF SUCH DAMAGE";
 
+  revision 2025-01-10 {
+    description
+      "Version 13.1.1";
+  }
   revision 2023-05-26 {
     description
       "Version 13.1";
@@ -342,6 +346,13 @@ module org-openroadm-common-types {
         value 28;
         description
           "value for 13.1";
+      }
+      enum 13.1.1 {
+        value 35;
+        description
+          "value for 13.1.1. Gap in enums values is due to the  fact other versions
+          that exist between the release of 13.1 and 13.1.1. Those include 14.0 (29),
+          14.1 (30), 15.0 (31), 15.1 (32), 16.0 (33), 16.1 (34)";
       }
     }
     description

--- a/model/Common/org-openroadm-manifest-file.yang
+++ b/model/Common/org-openroadm-manifest-file.yang
@@ -10,7 +10,7 @@ module org-openroadm-manifest-file {
 
   import org-openroadm-common-types {
     prefix org-openroadm-common-types;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
 
   organization
@@ -60,6 +60,10 @@ module org-openroadm-manifest-file {
      Section 4.e of the Trust Legal Provisions and are provided without warranty as
      described in the Simplified BSD License.";
 
+  revision 2025-01-10 {
+    description
+      "Version 13.1.1";
+  }
   revision 2023-05-26 {
     description
       "Version 13.1";

--- a/model/Common/org-openroadm-otn-common-types.yang
+++ b/model/Common/org-openroadm-otn-common-types.yang
@@ -49,6 +49,10 @@ module org-openroadm-otn-common-types {
      Section 4.e of the Trust Legal Provisions and are provided without warranty as
      described in the Simplified BSD License.";
 
+  revision 2025-01-10 {
+    description
+      "Version 13.1.1";
+  }
   revision 2021-09-24 {
     description
       "Version 10.0";
@@ -213,6 +217,12 @@ module org-openroadm-otn-common-types {
     base ODUflex-cbr-identity;
     description
       "ODUFlex for CBR client signals 400G (G.709 17.13.2)";
+  }
+
+  identity ODUflex-cbr-800G {
+    base ODUflex-cbr-identity;
+    description
+      "ODUFlex for CBR client signals 800G (G.709 17.14)";
   }
 
   identity ODUflex-imp {

--- a/model/Common/org-openroadm-pm.yang
+++ b/model/Common/org-openroadm-pm.yang
@@ -8,7 +8,7 @@ module org-openroadm-pm {
   }
   import org-openroadm-common-types {
     prefix org-openroadm-common-types;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-common-alarm-pm-types {
     prefix org-openroadm-common-alarm-pm-types;
@@ -60,6 +60,10 @@ module org-openroadm-pm {
       ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
       POSSIBILITY OF SUCH DAMAGE";
 
+  revision 2025-01-10 {
+    description
+      "Version 13.1.1";
+  }
   revision 2023-05-26 {
     description
       "Version 13.1";

--- a/model/Common/org-openroadm-pm.yang
+++ b/model/Common/org-openroadm-pm.yang
@@ -16,7 +16,7 @@ module org-openroadm-pm {
   }
   import org-openroadm-resource {
     prefix org-openroadm-resource;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-resource-types {
     prefix org-openroadm-resource-types;

--- a/model/Common/org-openroadm-pm.yang
+++ b/model/Common/org-openroadm-pm.yang
@@ -20,7 +20,7 @@ module org-openroadm-pm {
   }
   import org-openroadm-resource-types {
     prefix org-openroadm-resource-types;
-    revision-date 2022-03-25;
+    revision-date 2025-01-10;
   }
   import org-openroadm-pm-types {
     prefix org-openroadm-pm-types;

--- a/model/Common/org-openroadm-port-types.yang
+++ b/model/Common/org-openroadm-port-types.yang
@@ -267,11 +267,15 @@ module org-openroadm-port-types {
     base supported-if-capability;
   }
 
+  identity if-400GE-oduflexcbr {
+    base supported-if-capability;
+  }
+
   identity if-400GE-odufleximp {
     base supported-if-capability;
   }
 
-  identity if-400GE-oduflexcbr {
+  identity if-eth {
     base supported-if-capability;
   }
 

--- a/model/Common/org-openroadm-port-types.yang
+++ b/model/Common/org-openroadm-port-types.yang
@@ -40,6 +40,10 @@ module org-openroadm-port-types {
      ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
      POSSIBILITY OF SUCH DAMAGE.";
 
+  revision 2025-01-10 {
+    description
+      "Version 13.1.1";
+  }
   revision 2023-05-26 {
     description
       "Version 13.1";
@@ -271,6 +275,14 @@ module org-openroadm-port-types {
     base supported-if-capability;
   }
 
+  identity if-800GE {
+    base supported-if-capability;
+  }
+
+  identity if-800GE-oduflexcbr {
+    base supported-if-capability;
+  }
+
   identity supported-xpdr-capability {
     description
       "Base identity from which specific supported xponder are derived";
@@ -331,6 +343,8 @@ module org-openroadm-port-types {
 
   identity QSFP-DD {
     base pluggable-identifiers-identity;
+    reference
+       "QSFP-DD MSA, QSFP-DD/QSFP-DD800/QSFP-DD1600 Hardware Specification, Revision 7.1";
   }
 
   identity micro-QSFP {
@@ -379,6 +393,21 @@ module org-openroadm-port-types {
 
   identity QSFP56-DD {
     base pluggable-identifiers-identity;
+    status deprecated;
+    description
+        "Recommend to use QSFP-DD.";
+  }
+
+  identity QSFP-DD800 {
+    base pluggable-identifiers-identity;
+    reference
+       "QSFP-DD MSA, QSFP-DD/QSFP-DD800/QSFP-DD1600 Hardware Specification, Revision 7.1";
+  }
+
+  identity QSFP-DD1600 {
+    base pluggable-identifiers-identity;
+    reference
+       "QSFP-DD MSA, QSFP-DD/QSFP-DD800/QSFP-DD1600 Hardware Specification, Revision 7.1";
   }
 
   identity SFP-other {

--- a/model/Common/org-openroadm-port-types.yang
+++ b/model/Common/org-openroadm-port-types.yang
@@ -283,6 +283,30 @@ module org-openroadm-port-types {
     base supported-if-capability;
   }
 
+  identity if-otsi-otsig-regen {
+    base supported-if-capability;
+  }
+
+  identity if-otsi-otsig-uniregen {
+    base supported-if-capability;
+  }
+
+  identity if-otsi-otsig-eth-regen {
+    base supported-if-capability;
+  }
+
+  identity if-otsi-otsig-eth-uniregen {
+    base supported-if-capability;
+  }
+
+  identity if-otsi-otsig-otuc-regen {
+    base supported-if-capability;
+  }
+
+  identity if-otsi-otsig-otuc-uniregen {
+    base supported-if-capability;
+  }
+
   identity supported-xpdr-capability {
     description
       "Base identity from which specific supported xponder are derived";

--- a/model/Common/org-openroadm-resource-types.yang
+++ b/model/Common/org-openroadm-resource-types.yang
@@ -40,6 +40,10 @@ module org-openroadm-resource-types {
       ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
       POSSIBILITY OF SUCH DAMAGE";
 
+  revision 2025-01-10 {
+    description
+      "Version 13.1.1";
+  }
   revision 2022-03-25 {
     description
       "Version 11.0";
@@ -187,6 +191,16 @@ module org-openroadm-resource-types {
         value 20;
         description
           "circuit-pack-pg";
+      }
+      enum slot {
+        value 21;
+        description
+          "shelf slot";
+      }
+      enum cp-slot {
+        value 22;
+        description
+          "circuit pack cp-slot";
       }
     }
   }
@@ -409,6 +423,26 @@ module org-openroadm-resource-types {
       mandatory true;
       description
         "number of the xponder";
+    }
+  }
+
+  grouping slot-name {
+    leaf slot-name {
+      type string;
+      mandatory true;
+      description
+        "Slot-name identifier for a shelf slot. Unique within the context of a shelf.
+         Same as leafref value in model, if applicable.";
+    }
+  }
+
+  grouping cp-slot-name {
+    leaf slot-name {
+      type string;
+      mandatory true;
+      description
+        "Slot-name identifier for a circuit-pack cp-slot. Unique within the context of a circut-pack.
+         Same as leafref value in model, if applicable.";
     }
   }
 }

--- a/model/Common/org-openroadm-resource.yang
+++ b/model/Common/org-openroadm-resource.yang
@@ -16,7 +16,7 @@ module org-openroadm-resource {
   }
   import org-openroadm-resource-types {
     prefix org-openroadm-resource-types;
-    revision-date 2022-03-25;
+    revision-date 2025-01-10;
   }
   import org-openroadm-common-link-types {
     prefix org-openroadm-common-link-types;
@@ -560,6 +560,18 @@ module org-openroadm-resource {
         }
         case temp-service {
           uses org-openroadm-resource-types:temp-service-name;
+        }
+        case slot {
+          container slot {
+            uses org-openroadm-resource-types:shelf-name;
+            uses org-openroadm-resource-types:slot-name;
+          }
+        }
+        case cp-slot {
+          container cp-slot {
+            uses org-openroadm-resource-types:circuit-pack-name;
+            uses org-openroadm-resource-types:cp-slot-name;
+          }
         }
       }
     }

--- a/model/Common/org-openroadm-resource.yang
+++ b/model/Common/org-openroadm-resource.yang
@@ -8,11 +8,11 @@ module org-openroadm-resource {
   }
   import org-openroadm-otn-common-types {
     prefix org-openroadm-otn-common-types;
-    revision-date 2021-09-24;
+    revision-date 2025-01-10;
   }
   import org-openroadm-common-optical-channel-types {
     prefix org-openroadm-common-optical-channel-types;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-resource-types {
     prefix org-openroadm-resource-types;
@@ -56,6 +56,10 @@ module org-openroadm-resource {
       ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
       POSSIBILITY OF SUCH DAMAGE";
 
+  revision 2025-01-10 {
+    description
+      "Version 13.1.1";
+  }
   revision 2023-05-26 {
     description
       "Version 13.1";

--- a/model/Common/org-openroadm-tca.yang
+++ b/model/Common/org-openroadm-tca.yang
@@ -29,7 +29,7 @@ module org-openroadm-tca {
   }
   import org-openroadm-common-types {
     prefix org-openroadm-common-types;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-interfaces {
     prefix org-openroadm-interfaces;
@@ -69,6 +69,10 @@ module org-openroadm-tca {
       ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
       POSSIBILITY OF SUCH DAMAGE";
 
+  revision 2025-01-10 {
+    description
+      "Version 13.1.1";
+  }
   revision 2023-05-26 {
     description
       "Version 13.1";

--- a/model/Common/org-openroadm-tca.yang
+++ b/model/Common/org-openroadm-tca.yang
@@ -21,11 +21,11 @@ module org-openroadm-tca {
   }
   import org-openroadm-common-optical-channel-types {
     prefix org-openroadm-common-optical-channel-types;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-otn-common-types {
     prefix org-openroadm-otn-common-types;
-    revision-date 2021-09-24;
+    revision-date 2025-01-10;
   }
   import org-openroadm-common-types {
     prefix org-openroadm-common-types;

--- a/model/Common/org-openroadm-tca.yang
+++ b/model/Common/org-openroadm-tca.yang
@@ -17,7 +17,7 @@ module org-openroadm-tca {
   }
   import org-openroadm-resource-types {
     prefix org-openroadm-resource-types;
-    revision-date 2022-03-25;
+    revision-date 2025-01-10;
   }
   import org-openroadm-common-optical-channel-types {
     prefix org-openroadm-common-optical-channel-types;

--- a/model/Common/tree-view-common.txt
+++ b/model/Common/tree-view-common.txt
@@ -47,7 +47,15 @@ module: org-openroadm-alarm
         |  |     |  +--ro versioned-service-name    string
         |  |     |  +--ro version-number            uint64
         |  |     +--:(temp-service)
-        |  |        +--ro common-id                 string
+        |  |     |  +--ro common-id                 string
+        |  |     +--:(slot)
+        |  |     |  +--ro slot
+        |  |     |     +--ro shelf-name    string
+        |  |     |     +--ro slot-name     string
+        |  |     +--:(cp-slot)
+        |  |        +--ro cp-slot
+        |  |           +--ro circuit-pack-name    string
+        |  |           +--ro slot-name            string
         |  +--ro resourceType
         |     +--ro type         resource-type-enum
         |     +--ro extension?   string
@@ -111,7 +119,15 @@ module: org-openroadm-alarm
        |  |     |  +--ro versioned-service-name    string
        |  |     |  +--ro version-number            uint64
        |  |     +--:(temp-service)
-       |  |        +--ro common-id                 string
+       |  |     |  +--ro common-id                 string
+       |  |     +--:(slot)
+       |  |     |  +--ro slot
+       |  |     |     +--ro shelf-name    string
+       |  |     |     +--ro slot-name     string
+       |  |     +--:(cp-slot)
+       |  |        +--ro cp-slot
+       |  |           +--ro circuit-pack-name    string
+       |  |           +--ro slot-name            string
        |  +--ro resourceType
        |     +--ro type         resource-type-enum
        |     +--ro extension?   string
@@ -362,7 +378,15 @@ module: org-openroadm-pm
     |  |  |     |  +---w versioned-service-name    string
     |  |  |     |  +---w version-number            uint64
     |  |  |     +--:(temp-service)
-    |  |  |        +---w common-id                 string
+    |  |  |     |  +---w common-id                 string
+    |  |  |     +--:(slot)
+    |  |  |     |  +---w slot
+    |  |  |     |     +---w shelf-name    string
+    |  |  |     |     +---w slot-name     string
+    |  |  |     +--:(cp-slot)
+    |  |  |        +---w cp-slot
+    |  |  |           +---w circuit-pack-name    string
+    |  |  |           +---w slot-name            string
     |  |  +---w resourceType
     |  |  |  +---w type         resource-type-enum
     |  |  |  +---w extension?   string

--- a/model/Common/tree-view-common.txt
+++ b/model/Common/tree-view-common.txt
@@ -126,6 +126,7 @@ module: org-openroadm-alarm
        +--ro circuit-id?          string
        +--ro additional-detail?   string
        +--ro corrective-action?   string
+
 module: org-openroadm-ltp-template
   +--rw ltp-template
      +--rw vendor                    string
@@ -140,6 +141,7 @@ module: org-openroadm-ltp-template
            +--rw command-index        uint8
            +--rw netconf-operation    <anydata>
            +--rw sync-timeout?        uint16
+
 module: org-openroadm-manifest-file
   +--rw sw-manifest!
   |  +--rw vendor                  string
@@ -276,6 +278,7 @@ module: org-openroadm-manifest-file
            +--rw command-name    string
            +--rw timeout?        uint16
            +--rw is-async?       boolean
+
 module: org-openroadm-pm
   +--ro current-pm-list
   |  +--ro current-pm-entry* [pm-resource-type pm-resource-type-extension pm-resource-instance]
@@ -383,6 +386,7 @@ module: org-openroadm-pm
        +--ro pm-filename       string
        +--ro status            rpc-status
        +--ro status-message?   string
+
 module: org-openroadm-tca
   +--rw potential-tca-list
   |  +--rw tca-entry* [tca-resource-type tca-resource-type-extension tca-resource-instance]
@@ -466,6 +470,7 @@ module: org-openroadm-tca
        +--ro threshold-type                 threshold-enum
        +--ro pm-value                       org-openroadm-pm-types:pm-data-type
        +--ro raise-time                     yang:date-and-time
+
 module: org-openroadm-user-mgmt
 
   rpcs:

--- a/model/Device/org-openroadm-database.yang
+++ b/model/Device/org-openroadm-database.yang
@@ -4,7 +4,7 @@ module org-openroadm-database {
 
   import org-openroadm-common-types {
     prefix org-openroadm-common-types;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
 
   organization
@@ -40,6 +40,10 @@ module org-openroadm-database {
      ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
      POSSIBILITY OF SUCH DAMAGE.";
 
+  revision 2025-01-10 {
+    description
+      "Version 13.1.1";
+  }
   revision 2023-05-26 {
     description
       "Version 13.1";

--- a/model/Device/org-openroadm-de-operations.yang
+++ b/model/Device/org-openroadm-de-operations.yang
@@ -8,7 +8,7 @@ module org-openroadm-de-operations {
   }
   import org-openroadm-common-types {
     prefix org-openroadm-common-types;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
 
   organization
@@ -44,6 +44,10 @@ module org-openroadm-de-operations {
      ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
      POSSIBILITY OF SUCH DAMAGE.";
 
+  revision 2025-01-10 {
+    description
+      "Version 13.1.1";
+  }
   revision 2023-05-26 {
     description
       "Version 13.1";

--- a/model/Device/org-openroadm-de-operations.yang
+++ b/model/Device/org-openroadm-de-operations.yang
@@ -4,7 +4,7 @@ module org-openroadm-de-operations {
 
   import org-openroadm-resource {
     prefix org-openroadm-resource;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-common-types {
     prefix org-openroadm-common-types;

--- a/model/Device/org-openroadm-device.yang
+++ b/model/Device/org-openroadm-device.yang
@@ -807,6 +807,22 @@ module org-openroadm-device {
       description
         "Circuit-pack mode allowed. e.g. NORMAL or REGEN";
     }
+    list sub-circuit-pack-mode {
+      key "index";
+      description
+        "List of sub-circuit-pack in circuit-packs and the mode.";
+      leaf index {
+        type uint8;
+        description
+          "Sub circuit-pack index.";
+      }
+      leaf mode {
+        type string;
+        default "NORMAL";
+        description
+          "Sub circuit-pack mode allowed, e.g. NORMAL or REGEN";
+      }
+    }
     leaf shelf {
       type leafref {
         path "/org-openroadm-device/shelves/shelf-name";
@@ -2883,10 +2899,13 @@ module org-openroadm-device {
           description
             "Mux profile name";
         }
-        leaf network-eth-speed {
-          type uint32;
+        leaf network-otsi-group-rate {
+          type identityref {
+            base org-openroadm-common-optical-channel-types:otsi-rate-identity;
+          }
+          mandatory true;
           description
-            "Network ethernet speed types supported by the profile, unit mbps";
+            "Network OTSIG rate types supported by the profile";
         }
         uses mux-eth-grp;
       }

--- a/model/Device/org-openroadm-device.yang
+++ b/model/Device/org-openroadm-device.yang
@@ -351,6 +351,13 @@ module org-openroadm-device {
         "Common Language Location Identifier.";
     }
     uses org-openroadm-physical-types:node-info;
+    leaf oamp-interface-name {
+      type string;
+      config false;
+      description
+        "Assign the Ethernet interface name linked to the OAMP management port,
+         typically utilized for provisioning the primary IP address of the device.";
+    }
     leaf macAddress {
       type ietf-yang-types:mac-address;
       config false;

--- a/model/Device/org-openroadm-device.yang
+++ b/model/Device/org-openroadm-device.yang
@@ -92,7 +92,7 @@ module org-openroadm-device {
   }
   import org-openroadm-common-phy-codes {
     prefix org-openroadm-common-phy-codes;
-    revision-date 2022-05-27;
+    revision-date 2025-01-10;
   }
   import org-openroadm-pm-types {
     prefix org-openroadm-pm-types;

--- a/model/Device/org-openroadm-device.yang
+++ b/model/Device/org-openroadm-device.yang
@@ -44,7 +44,7 @@ module org-openroadm-device {
   }
   import org-openroadm-common-optical-channel-types {
     prefix org-openroadm-common-optical-channel-types;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-device-types {
     prefix org-openroadm-device-types;
@@ -64,7 +64,7 @@ module org-openroadm-device {
   }
   import org-openroadm-port-types {
     prefix org-openroadm-port-types;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-interfaces {
     prefix org-openroadm-interfaces;
@@ -84,11 +84,11 @@ module org-openroadm-device {
   }
   import org-openroadm-optical-operational-interfaces {
     prefix org-openroadm-optical-operational-interfaces;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-otn-common-types {
     prefix org-openroadm-otn-common-types;
-    revision-date 2021-09-24;
+    revision-date 2025-01-10;
   }
   import org-openroadm-common-phy-codes {
     prefix org-openroadm-common-phy-codes;

--- a/model/Device/org-openroadm-device.yang
+++ b/model/Device/org-openroadm-device.yang
@@ -16,7 +16,7 @@ module org-openroadm-device {
   }
   import org-openroadm-common-types {
     prefix org-openroadm-common-types;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-common-alarm-pm-types {
     prefix org-openroadm-common-alarm-pm-types;
@@ -72,7 +72,7 @@ module org-openroadm-device {
   }
   import org-openroadm-swdl {
     prefix org-openroadm-swdl;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-equipment-states-types {
     prefix org-openroadm-equipment-states-types;
@@ -145,6 +145,10 @@ module org-openroadm-device {
      Section 4.e of the Trust Legal Provisions and are provided without warranty as
      described in the Simplified BSD License.";
 
+  revision 2025-01-10 {
+    description
+      "Version 13.1.1";
+  }
   revision 2023-05-26 {
     description
       "Version 13.1";

--- a/model/Device/org-openroadm-device.yang
+++ b/model/Device/org-openroadm-device.yang
@@ -52,7 +52,7 @@ module org-openroadm-device {
   }
   import org-openroadm-resource-types {
     prefix org-openroadm-resource-types;
-    revision-date 2022-03-25;
+    revision-date 2025-01-10;
   }
   import org-openroadm-physical-types {
     prefix org-openroadm-physical-types;

--- a/model/Device/org-openroadm-device.yang
+++ b/model/Device/org-openroadm-device.yang
@@ -2066,6 +2066,16 @@ module org-openroadm-device {
          (G.709.3 Annex F (2020-12))
          G.798 15.3.5.1 (FlexO-n/OTUCni_A_So) source to insert PT code '0000 0010' (2021-01)";
     }
+    leaf eth-mixed {
+      type boolean;
+      description
+        "Announce whether mixed ETH interfaces are supported in NE.";
+    }
+    leaf-list eth-speed {
+      type uint32;
+      description
+        "List the supported ethernet speed. For example, in the case eth-mixed TRUE, eth-speed* = {100000, 200000, 400000, 800000}[Mbps].";
+    }
     choice otu-rate {
       description
         "To specify the supported rate in the case of OTUCn or NxOTU4";
@@ -2325,7 +2335,7 @@ module org-openroadm-device {
         "G.709.1 Amd.4 2023-03 clause 10.2.3.1";
     }
     leaf-list network-flexo-iid {
-      type uint16;
+      type uint8;
       description
         "Network FlexO instance id";
     }

--- a/model/Device/org-openroadm-dhcp.yang
+++ b/model/Device/org-openroadm-dhcp.yang
@@ -10,6 +10,10 @@ module org-openroadm-dhcp {
     prefix ietf-inet-types;
     revision-date 2013-07-15;
   }
+  import org-openroadm-common-state-types {
+    prefix org-openroadm-common-state-types;
+    revision-date 2019-11-29;
+  }
 
   organization
     "Open ROADM MSA";
@@ -140,6 +144,11 @@ module org-openroadm-dhcp {
 
   grouping dhcp-relay {
     container ipv4-dhcp-relay {
+      leaf lifecycle-state {
+        type org-openroadm-common-state-types:lifecycle-state;
+        description
+          "Lifecycle State of the ipv4-dhcp-relay. Whether it is planned or deployed, etc.";
+      }
       list ipv4-server-group {
         key "server-group-name";
         description
@@ -164,6 +173,11 @@ module org-openroadm-dhcp {
       }
     }
     container ipv6-dhcp-relay {
+      leaf lifecycle-state {
+        type org-openroadm-common-state-types:lifecycle-state;
+        description
+          "Lifecycle State of the ipv6-dhcp-relay. Whether it is planned or deployed, etc.";
+      }
       list ipv6-server-group {
         key "server-group-name";
         description

--- a/model/Device/org-openroadm-dhcp.yang
+++ b/model/Device/org-openroadm-dhcp.yang
@@ -4,7 +4,7 @@ module org-openroadm-dhcp {
 
   import org-openroadm-device {
     prefix org-openroadm-device;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import ietf-inet-types {
     prefix ietf-inet-types;
@@ -45,6 +45,10 @@ module org-openroadm-dhcp {
      ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
      POSSIBILITY OF SUCH DAMAGE.";
 
+  revision 2025-01-10 {
+    description
+      "Version 13.1.1";
+  }
   revision 2023-05-26 {
     description
       "Version 13.1";

--- a/model/Device/org-openroadm-ethernet-interfaces.yang
+++ b/model/Device/org-openroadm-ethernet-interfaces.yang
@@ -5,7 +5,7 @@ module org-openroadm-ethernet-interfaces {
 
   import org-openroadm-device {
     prefix org-openroadm-device;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-interfaces {
     prefix openROADM-if;
@@ -13,11 +13,11 @@ module org-openroadm-ethernet-interfaces {
   }
   import org-openroadm-common-types {
     prefix org-openroadm-common-types;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-maintenance-testsignal {
     prefix org-openroadm-maint-testsignal;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-maintenance-loopback {
     prefix org-openroadm-maint-loopback;
@@ -71,6 +71,10 @@ module org-openroadm-ethernet-interfaces {
      Section 4.e of the Trust Legal Provisions and are provided without warranty as
      described in the Simplified BSD License.";
 
+  revision 2025-01-10 {
+    description
+      "Version 13.1.1";
+  }
   revision 2023-05-26 {
     description
       "Version 13.1";

--- a/model/Device/org-openroadm-ethernet-interfaces.yang
+++ b/model/Device/org-openroadm-ethernet-interfaces.yang
@@ -191,36 +191,12 @@ module org-openroadm-ethernet-interfaces {
          Applies to both management and transport Ethernet.
          Optional, must be specified for transport Ethernet or when auto-negotiation is disabled.";
     }
-    typedef eth-function-type {
-      type enumeration {
-        enum ETH-TTP {
-          value 1;
-          description
-            "applicable to Ethernet PHY termination point";
-        }
-        enum ETH-CTP {
-          value 2;
-          description
-            "applicable to ethernet MAC switching/cross connect point";
-        }
-      }
-      description
-        "Defines the Ethernet TTP and CTP ";
-    }
-    leaf eth-function {
-      type eth-function-type;
-      default 'ETH-TTP';
-      description
-      "function of the ethernet interface";
-    }
     uses org-openroadm-common-types:fec-grouping {
-      when "./eth-function = 'ETH-TTP'";
       description
         "Forward Error Correction Choices.
          Applies to transport Ethernet. Mandatory for transport Ethernet.";
     }
     leaf egress-consequent-action {
-      when "../eth-function = 'ETH-TTP'";
       type enumeration {
         enum local-fault {
           value 1;
@@ -238,7 +214,6 @@ module org-openroadm-ethernet-interfaces {
         "Egress consequent action choices";
     }
     leaf duplex {
-      when "../eth-function = 'ETH-TTP'";
       type enumeration {
         enum half {
           value 0;
@@ -258,7 +233,6 @@ module org-openroadm-ethernet-interfaces {
          Optional, default full. Transport Ethernet only supports full.";
     }
     leaf auto-negotiation {
-      when "../eth-function = 'ETH-TTP'";
       type enumeration {
         enum enabled {
           value 1;
@@ -278,12 +252,10 @@ module org-openroadm-ethernet-interfaces {
          Optional, default enabled. Transport Ethernet only supports enabled.";
     }
     uses org-openroadm-common-types:enable-laser {
-      when "./eth-function = 'ETH-TTP'";
       description
         "Enable laser control.";
     }
     leaf curr-speed {
-      when "../eth-function = 'ETH-TTP'";
       type string;
       config false;
       description
@@ -291,7 +263,6 @@ module org-openroadm-ethernet-interfaces {
          Applies to both management and transport Ethernet.";
     }
     leaf curr-duplex {
-      when "../eth-function = 'ETH-TTP'";
       type string;
       config false;
       description
@@ -299,7 +270,6 @@ module org-openroadm-ethernet-interfaces {
          Applies to both management and transport Ethernet.";
     }
     leaf max-frame-size {
-      when "../eth-function = 'ETH-TTP'";
       type uint32;
       config false;
       description
@@ -307,7 +277,6 @@ module org-openroadm-ethernet-interfaces {
     }
     container subrate-eth-sla {
       presence "Explicit assignment of subrate ethernet allocation";
-      when "../eth-function = 'ETH-TTP'";
       description
         "SLA (Service Level Agreement) for subrate Ethernet.
          Applies to transport Ethernet.";
@@ -332,7 +301,6 @@ module org-openroadm-ethernet-interfaces {
          generation is not supported by this interface.";
     }
     container parent-flexo-allocation {
-      when "../eth-function = 'ETH-CTP'";
       presence "Explicit assignment of parent FlexO instance and trib-port allocation.";
       description
         "parent flexo-xe allocation";
@@ -346,7 +314,7 @@ module org-openroadm-ethernet-interfaces {
           "Assigned tributary port number in parent FlexO-xe";
       }
       leaf-list iid {
-        type uint16;
+        type uint8;
         min-elements 1;
         description
           "A list of FlexO instance identification (G.709.3, G.709.1 clause 9.2.3)";

--- a/model/Device/org-openroadm-fcc-interfaces.yang
+++ b/model/Device/org-openroadm-fcc-interfaces.yang
@@ -4,7 +4,7 @@ module org-openroadm-fcc-interfaces {
 
   import org-openroadm-device {
     prefix org-openroadm-device;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-interfaces {
     prefix openROADM-if;
@@ -58,6 +58,10 @@ module org-openroadm-fcc-interfaces {
      Section 4.e of the Trust Legal Provisions and are provided without warranty as
      described in the Simplified BSD License.";
 
+  revision 2025-01-10 {
+    description
+      "Version 13.1.1";
+  }
   revision 2023-05-26 {
     description
       "Version 13.1";

--- a/model/Device/org-openroadm-file-transfer.yang
+++ b/model/Device/org-openroadm-file-transfer.yang
@@ -8,7 +8,7 @@ module org-openroadm-file-transfer {
   }
   import org-openroadm-common-types {
     prefix org-openroadm-common-types;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import ietf-yang-types {
     prefix ietf-yang-types;
@@ -48,6 +48,10 @@ module org-openroadm-file-transfer {
      ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
      POSSIBILITY OF SUCH DAMAGE.";
 
+  revision 2025-01-10 {
+    description
+      "Version 13.1.1";
+  }
   revision 2023-05-26 {
     description
       "Version 13.1";

--- a/model/Device/org-openroadm-fwdl.yang
+++ b/model/Device/org-openroadm-fwdl.yang
@@ -4,7 +4,7 @@ module org-openroadm-fwdl {
 
   import org-openroadm-common-types {
     prefix org-openroadm-common-types;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
 
   organization
@@ -40,6 +40,10 @@ module org-openroadm-fwdl {
      ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
      POSSIBILITY OF SUCH DAMAGE.";
 
+  revision 2025-01-10 {
+    description
+      "Version 13.1.1";
+  }
   revision 2023-05-26 {
     description
       "Version 13.1";

--- a/model/Device/org-openroadm-gcc-interfaces.yang
+++ b/model/Device/org-openroadm-gcc-interfaces.yang
@@ -4,7 +4,7 @@ module org-openroadm-gcc-interfaces {
 
   import org-openroadm-device {
     prefix org-openroadm-device;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-interfaces {
     prefix openROADM-if;
@@ -58,6 +58,10 @@ module org-openroadm-gcc-interfaces {
      Section 4.e of the Trust Legal Provisions and are provided without warranty as
      described in the Simplified BSD License.";
 
+  revision 2025-01-10 {
+    description
+      "Version 13.1.1";
+  }
   revision 2023-05-26 {
     description
       "Version 13.1";

--- a/model/Device/org-openroadm-gnmi.yang
+++ b/model/Device/org-openroadm-gnmi.yang
@@ -15,6 +15,10 @@ module org-openroadm-gnmi {
     prefix inet;
     revision-date 2013-07-15;
   }
+  import org-openroadm-common-state-types {
+    prefix org-openroadm-common-state-types;
+    revision-date 2019-11-29;
+  }
 
   organization
     "Open ROADM MSA";
@@ -140,6 +144,11 @@ module org-openroadm-gnmi {
         default "false";
         description
           "Enable/Disable gNMI.";
+      }
+      leaf lifecycle-state {
+        type org-openroadm-common-state-types:lifecycle-state;
+        description
+          "Lifecycle State of gnmi. Whether it is planned or deployed, etc.";
       }
       leaf certificate-id {
         type leafref {

--- a/model/Device/org-openroadm-gnmi.yang
+++ b/model/Device/org-openroadm-gnmi.yang
@@ -5,11 +5,11 @@ module org-openroadm-gnmi {
 
   import org-openroadm-device {
     prefix org-openroadm-device;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-security {
     prefix org-openroadm-security;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import ietf-inet-types {
     prefix inet;
@@ -49,6 +49,10 @@ module org-openroadm-gnmi {
      ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
      POSSIBILITY OF SUCH DAMAGE.";
 
+  revision 2025-01-10 {
+    description
+      "Version 13.1.1";
+  }
   revision 2023-05-26 {
     description
       "Version 13.1";

--- a/model/Device/org-openroadm-ip.yang
+++ b/model/Device/org-openroadm-ip.yang
@@ -4,7 +4,7 @@ module org-openroadm-ip {
 
   import org-openroadm-device {
     prefix org-openroadm-device;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import ietf-inet-types {
     prefix inet;
@@ -39,6 +39,10 @@ module org-openroadm-ip {
      Section 4.c of the IETF Trust's Legal Provisions Relating
      to IETF Documents (http://trustee.ietf.org/license-info).";
 
+  revision 2025-01-10 {
+    description
+      "Version 13.1.1";
+  }
   revision 2023-05-26 {
     description
       "Version 13.1";

--- a/model/Device/org-openroadm-ip.yang
+++ b/model/Device/org-openroadm-ip.yang
@@ -586,12 +586,12 @@ module org-openroadm-ip {
           description
             "The length of the subnet prefix.";
         }
-      }
-      leaf origin {
-        type ip-address-origin;
-      }
-      leaf status {
-        type ipv6-address-status;
+        leaf origin {
+          type ip-address-origin;
+        }
+        leaf status {
+          type ipv6-address-status;
+        }
       }
     }
   }

--- a/model/Device/org-openroadm-ipv4-unicast-routing.yang
+++ b/model/Device/org-openroadm-ipv4-unicast-routing.yang
@@ -23,7 +23,7 @@ module org-openroadm-ipv4-unicast-routing {
     "This model defines Yang model for IPv4 unicast routing.
 
      This model reuses data items defined in the IETF YANG model for
-     interfaces described by RFC 8022.
+     interfaces described by draft-ietf-netmod-routing-cfg-19.
 
      Some attributes which are not required in Open ROADM MSA are removed.
      Yang file included are changed to fit into Open ROADM MSA yang structure.
@@ -127,7 +127,6 @@ module org-openroadm-ipv4-unicast-routing {
     description
       "This identity represents the IPv4 unicast address family.";
   }
-
   grouping ipv4-uni-grp {
     description
       "Grouping for IPv4";
@@ -137,7 +136,6 @@ module org-openroadm-ipv4-unicast-routing {
          consists of a list of routes.";
       list route {
         key "destination-prefix";
-        max-elements 32;
         ordered-by user;
         description
           "A user-ordered list of static routes.";
@@ -177,4 +175,39 @@ module org-openroadm-ipv4-unicast-routing {
        pseudo-protocol with data specific to IPv4 unicast.";
     uses ipv4-uni-grp;
   }
+
+  augment "/org-openroadm-device:org-openroadm-device/org-openroadm-routing:routing-state/"
+           + "org-openroadm-routing:routing-instance/org-openroadm-routing:ribs/org-openroadm-routing:rib/"
+           + "org-openroadm-routing:routes/org-openroadm-routing:route" {
+       when "../../org-openroadm-routing:address-family = 'org-openroadm-ipv4-unicast-routing:ipv4-unicast'" {
+         description
+           "This augment is valid only for IPv4 unicast.";
+       }
+       description
+         "This leaf augments an IPv4 unicast route.";
+       leaf destination-prefix {
+         type inet:ipv4-prefix;
+         description
+           "IPv4 destination prefix.";
+       }
+  }
+
+  augment "/org-openroadm-device:org-openroadm-device/org-openroadm-routing:routing-state/"
+           + "org-openroadm-routing:routing-instance/org-openroadm-routing:ribs/org-openroadm-routing:rib/"
+           + "org-openroadm-routing:routes/org-openroadm-routing:route/org-openroadm-routing:next-hop/"
+           + "org-openroadm-routing:next-hop-options/org-openroadm-routing:simple-next-hop" {
+       when "../../../org-openroadm-routing:address-family = 'org-openroadm-ipv4-unicast-routing:ipv4-unicast'" {
+         description
+           "This augment is valid only for IPv4 unicast.";
+       }
+       description
+         "This leaf augments the 'simple-next-hop' case of IPv4 unicast
+          routes.";
+       leaf next-hop-address {
+         type inet:ipv4-address;
+         description
+           "IPv4 address of the next-hop.";
+       }
+  }
+
 }

--- a/model/Device/org-openroadm-ipv4-unicast-routing.yang
+++ b/model/Device/org-openroadm-ipv4-unicast-routing.yang
@@ -4,7 +4,7 @@ module org-openroadm-ipv4-unicast-routing {
 
   import org-openroadm-routing {
     prefix org-openroadm-routing;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import ietf-inet-types {
     prefix inet;
@@ -12,7 +12,7 @@ module org-openroadm-ipv4-unicast-routing {
   }
   import org-openroadm-device {
     prefix org-openroadm-device;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
 
   organization
@@ -39,6 +39,10 @@ module org-openroadm-ipv4-unicast-routing {
      Section 4.c of the IETF Trust's Legal Provisions Relating
      to IETF Documents (http://trustee.ietf.org/license-info).";
 
+  revision 2025-01-10 {
+    description
+      "Version 13.1.1";
+  }
   revision 2023-05-26 {
     description
       "Version 13.1";

--- a/model/Device/org-openroadm-ipv6-unicast-routing.yang
+++ b/model/Device/org-openroadm-ipv6-unicast-routing.yang
@@ -23,7 +23,7 @@ module org-openroadm-ipv6-unicast-routing {
     "This model defines Yang model for IPv6 unicast routing.
 
      This model reuses data items defined in the IETF YANG model for
-     interfaces described by RFC 8022.
+     interfaces described by draft-ietf-netmod-routing-cfg-19.
 
      Some attributes which are not required in Open ROADM MSA are removed.
      Yang file included are changed to fit into Open ROADM MSA yang structure.
@@ -172,8 +172,41 @@ module org-openroadm-ipv6-unicast-routing {
 
   augment "/org-openroadm-device:org-openroadm-device/org-openroadm-routing:routing/org-openroadm-routing:routing-instance/org-openroadm-routing:routing-protocols/org-openroadm-routing:routing-protocol/org-openroadm-routing:static-routes" {
     description
-      "This augment defines the configuration of the 'static'
-       pseudo-protocol with data specific to IPv6 unicast.";
+      "This augment defines the configuration of the 'static',
+      pseudo-protocol with data specific to IPv6 unicast.";
     uses ipv6-uni-grp;
+  }
+
+  augment "/org-openroadm-device:org-openroadm-device/org-openroadm-routing:routing-state/"
+           + "org-openroadm-routing:routing-instance/org-openroadm-routing:ribs/org-openroadm-routing:rib/"
+           + "org-openroadm-routing:routes/org-openroadm-routing:route" {
+       when "../../org-openroadm-routing:address-family = 'org-openroadm-ipv6-unicast-routing:ipv6-unicast'" {
+         description
+           "This augment is valid only for IPv6 unicast.";
+       }
+       description
+         "This leaf augments an IPv6 unicast route.";
+       leaf destination-prefix {
+         type inet:ipv6-prefix;
+         description
+           "IPv6 destination prefix.";
+       }
+  }
+
+  augment "/org-openroadm-device:org-openroadm-device/org-openroadm-routing:routing-state/"
+           + "org-openroadm-routing:routing-instance/org-openroadm-routing:ribs/org-openroadm-routing:rib/"
+           + "org-openroadm-routing:routes/org-openroadm-routing:route/org-openroadm-routing:next-hop/"
+           + "org-openroadm-routing:next-hop-options/org-openroadm-routing:simple-next-hop" {
+       when "../../../org-openroadm-routing:address-family = 'org-openroadm-ipv6-unicast-routing:ipv6-unicast'" {
+         description
+           "This augment is valid only for IPv6 unicast.";
+       }
+       description
+         "This leaf augments the 'simple-next-hop' case of IPv6 unicast routes.";
+       leaf next-hop-address {
+         type inet:ipv6-address;
+         description
+           "IPv6 address of the next-hop.";
+       }
   }
 }

--- a/model/Device/org-openroadm-ipv6-unicast-routing.yang
+++ b/model/Device/org-openroadm-ipv6-unicast-routing.yang
@@ -4,7 +4,7 @@ module org-openroadm-ipv6-unicast-routing {
 
   import org-openroadm-routing {
     prefix org-openroadm-routing;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import ietf-inet-types {
     prefix inet;
@@ -12,7 +12,7 @@ module org-openroadm-ipv6-unicast-routing {
   }
   import org-openroadm-device {
     prefix org-openroadm-device;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
 
   organization
@@ -39,6 +39,10 @@ module org-openroadm-ipv6-unicast-routing {
      Section 4.c of the IETF Trust's Legal Provisions Relating
      to IETF Documents (http://trustee.ietf.org/license-info).";
 
+  revision 2025-01-10 {
+    description
+      "Version 13.1.1";
+  }
   revision 2023-05-26 {
     description
       "Version 13.1";

--- a/model/Device/org-openroadm-lldp.yang
+++ b/model/Device/org-openroadm-lldp.yang
@@ -16,7 +16,7 @@ module org-openroadm-lldp {
   }
   import org-openroadm-resource-types {
     prefix org-openroadm-resource-types;
-    revision-date 2022-03-25;
+    revision-date 2025-01-10;
   }
   import ietf-yang-types {
     prefix yang;

--- a/model/Device/org-openroadm-lldp.yang
+++ b/model/Device/org-openroadm-lldp.yang
@@ -22,6 +22,10 @@ module org-openroadm-lldp {
     prefix yang;
     revision-date 2013-07-15;
   }
+  import org-openroadm-common-state-types {
+    prefix org-openroadm-common-state-types;
+    revision-date 2019-11-29;
+  }
 
   organization
     "Open ROADM MSA";
@@ -295,6 +299,11 @@ module org-openroadm-lldp {
     container lldp {
       description
         "LLDP configurable and retrievable";
+      leaf lifecycle-state {
+        type org-openroadm-common-state-types:lifecycle-state;
+        description
+          "Lifecycle State of lldp. Whether it is planned or deployed, etc.";
+      }
       container global-config {
         description
           "LLDP global configurations";

--- a/model/Device/org-openroadm-lldp.yang
+++ b/model/Device/org-openroadm-lldp.yang
@@ -10,9 +10,9 @@ module org-openroadm-lldp {
     prefix org-openroadm-device;
     revision-date 2025-01-10;
   }
-  import iana-afn-safi {
-    prefix ianaaf;
-    revision-date 2013-07-04;
+  import iana-routing-types {
+    prefix iana-rt-types;
+    revision-date 2022-08-19;
   }
   import org-openroadm-resource-types {
     prefix org-openroadm-resource-types;
@@ -178,7 +178,7 @@ module org-openroadm-lldp {
         "remote neighbour system name";
     }
     leaf remoteMgmtAddressSubType {
-      type ianaaf:address-family;
+      type iana-rt-types:address-family;
       description
         "remote neighbour Management Address Subtype Enumeration";
     }

--- a/model/Device/org-openroadm-lldp.yang
+++ b/model/Device/org-openroadm-lldp.yang
@@ -8,7 +8,7 @@ module org-openroadm-lldp {
   }
   import org-openroadm-device {
     prefix org-openroadm-device;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import iana-afn-safi {
     prefix ianaaf;
@@ -56,6 +56,10 @@ module org-openroadm-lldp {
      ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
      POSSIBILITY OF SUCH DAMAGE.";
 
+  revision 2025-01-10 {
+    description
+      "Version 13.1.1";
+  }
   revision 2023-05-26 {
     description
       "Version 13.1";

--- a/model/Device/org-openroadm-maintenance-testsignal.yang
+++ b/model/Device/org-openroadm-maintenance-testsignal.yang
@@ -5,7 +5,7 @@ module org-openroadm-maintenance-testsignal {
 
   import org-openroadm-common-types {
     prefix org-openroadm-common-types;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
 
   organization
@@ -41,6 +41,10 @@ module org-openroadm-maintenance-testsignal {
      ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
      POSSIBILITY OF SUCH DAMAGE.";
 
+  revision 2025-01-10 {
+    description
+      "Version 13.1.1";
+  }
   revision 2023-05-26 {
     description
       "Version 13.1";

--- a/model/Device/org-openroadm-media-channel-interfaces.yang
+++ b/model/Device/org-openroadm-media-channel-interfaces.yang
@@ -12,7 +12,7 @@ module org-openroadm-media-channel-interfaces {
   }
   import org-openroadm-common-optical-channel-types {
     prefix org-openroadm-common-optical-channel-types;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
 
   organization

--- a/model/Device/org-openroadm-media-channel-interfaces.yang
+++ b/model/Device/org-openroadm-media-channel-interfaces.yang
@@ -4,7 +4,7 @@ module org-openroadm-media-channel-interfaces {
 
   import org-openroadm-device {
     prefix org-openroadm-device;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-interfaces {
     prefix openROADM-if;
@@ -62,6 +62,10 @@ module org-openroadm-media-channel-interfaces {
      Section 4.e of the Trust Legal Provisions and are provided without warranty as
      described in the Simplified BSD License.";
 
+  revision 2025-01-10 {
+    description
+      "Version 13.1.1";
+  }
   revision 2023-05-26 {
     description
       "Version 13.1";

--- a/model/Device/org-openroadm-network-media-channel-interfaces.yang
+++ b/model/Device/org-openroadm-network-media-channel-interfaces.yang
@@ -4,7 +4,7 @@ module org-openroadm-network-media-channel-interfaces {
 
   import org-openroadm-device {
     prefix org-openroadm-device;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-interfaces {
     prefix openROADM-if;
@@ -62,6 +62,10 @@ module org-openroadm-network-media-channel-interfaces {
      Section 4.e of the Trust Legal Provisions and are provided without warranty as
      described in the Simplified BSD License.";
 
+  revision 2025-01-10 {
+    description
+      "Version 13.1.1";
+  }
   revision 2023-05-26 {
     description
       "Version 13.1";

--- a/model/Device/org-openroadm-network-media-channel-interfaces.yang
+++ b/model/Device/org-openroadm-network-media-channel-interfaces.yang
@@ -12,7 +12,7 @@ module org-openroadm-network-media-channel-interfaces {
   }
   import org-openroadm-common-optical-channel-types {
     prefix org-openroadm-common-optical-channel-types;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
 
   organization

--- a/model/Device/org-openroadm-optical-channel-interfaces.yang
+++ b/model/Device/org-openroadm-optical-channel-interfaces.yang
@@ -16,11 +16,11 @@ module org-openroadm-optical-channel-interfaces {
   }
   import org-openroadm-common-optical-channel-types {
     prefix org-openroadm-common-optical-channel-types;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-optical-operational-interfaces {
     prefix org-openroadm-optical-operational-interfaces;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-common-types {
     prefix org-openroadm-common-types;

--- a/model/Device/org-openroadm-optical-channel-interfaces.yang
+++ b/model/Device/org-openroadm-optical-channel-interfaces.yang
@@ -4,7 +4,7 @@ module org-openroadm-optical-channel-interfaces {
 
   import org-openroadm-device {
     prefix org-openroadm-device;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-interfaces {
     prefix openROADM-if;
@@ -24,7 +24,7 @@ module org-openroadm-optical-channel-interfaces {
   }
   import org-openroadm-common-types {
     prefix org-openroadm-common-types;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
 
   organization
@@ -74,6 +74,10 @@ module org-openroadm-optical-channel-interfaces {
      Section 4.e of the Trust Legal Provisions and are provided without warranty as
      described in the Simplified BSD License.";
 
+  revision 2025-01-10 {
+    description
+      "Version 13.1.1";
+  }
   revision 2023-05-26 {
     description
       "Version 13.1";

--- a/model/Device/org-openroadm-optical-operational-interfaces.yang
+++ b/model/Device/org-openroadm-optical-operational-interfaces.yang
@@ -4,7 +4,7 @@ module org-openroadm-optical-operational-interfaces {
 
   import org-openroadm-common-optical-channel-types {
     prefix org-openroadm-common-optical-channel-types;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
 
   organization
@@ -54,6 +54,10 @@ module org-openroadm-optical-operational-interfaces {
      Section 4.e of the Trust Legal Provisions and are provided without warranty as
      described in the Simplified BSD License.";
 
+  revision 2025-01-10 {
+    description
+      "Version 13.1.1";
+  }
   revision 2023-05-26 {
     description
       "Version 13.1";

--- a/model/Device/org-openroadm-optical-transport-interfaces.yang
+++ b/model/Device/org-openroadm-optical-transport-interfaces.yang
@@ -4,7 +4,7 @@ module org-openroadm-optical-transport-interfaces {
 
   import org-openroadm-device {
     prefix org-openroadm-device;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-interfaces {
     prefix openROADM-if;
@@ -63,6 +63,10 @@ module org-openroadm-optical-transport-interfaces {
      Section 4.e of the Trust Legal Provisions and are provided without warranty as
      described in the Simplified BSD License.";
 
+  revision 2025-01-10 {
+    description
+      "Version 13.1.1";
+  }
   revision 2023-05-26 {
     description
       "Version 13.1";

--- a/model/Device/org-openroadm-optical-tributary-signal-interfaces.yang
+++ b/model/Device/org-openroadm-optical-tributary-signal-interfaces.yang
@@ -12,7 +12,7 @@ module org-openroadm-optical-tributary-signal-interfaces {
   }
   import org-openroadm-common-types {
     prefix org-openroadm-common-types;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-optical-operational-interfaces {
     prefix org-openroadm-optical-operational-interfaces;
@@ -20,7 +20,7 @@ module org-openroadm-optical-tributary-signal-interfaces {
   }
   import org-openroadm-device {
     prefix org-openroadm-device;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-interfaces {
     prefix openROADM-if;
@@ -78,6 +78,10 @@ module org-openroadm-optical-tributary-signal-interfaces {
      Section 4.e of the Trust Legal Provisions and are provided without warranty as
      described in the Simplified BSD License.";
 
+  revision 2025-01-10 {
+    description
+      "Version 13.1.1";
+  }
   revision 2023-05-26 {
     description
       "Version 13.1";

--- a/model/Device/org-openroadm-optical-tributary-signal-interfaces.yang
+++ b/model/Device/org-openroadm-optical-tributary-signal-interfaces.yang
@@ -8,7 +8,7 @@ module org-openroadm-optical-tributary-signal-interfaces {
   }
   import org-openroadm-common-optical-channel-types {
     prefix org-openroadm-common-optical-channel-types;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-common-types {
     prefix org-openroadm-common-types;
@@ -16,7 +16,7 @@ module org-openroadm-optical-tributary-signal-interfaces {
   }
   import org-openroadm-optical-operational-interfaces {
     prefix org-openroadm-optical-operational-interfaces;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-device {
     prefix org-openroadm-device;
@@ -28,7 +28,7 @@ module org-openroadm-optical-tributary-signal-interfaces {
   }
   import org-openroadm-otn-common-types {
     prefix org-openroadm-otn-common-types;
-    revision-date 2021-09-24;
+    revision-date 2025-01-10;
   }
 
   organization

--- a/model/Device/org-openroadm-optical-tributary-signal-interfaces.yang
+++ b/model/Device/org-openroadm-optical-tributary-signal-interfaces.yang
@@ -262,6 +262,16 @@ module org-openroadm-optical-tributary-signal-interfaces {
         description
           "A list of FlexO instance identification (G.709.1 clause 9.2.3)";
       }
+      leaf payload-id {
+        type org-openroadm-otn-common-types:flexo-payload-type-def;
+        description
+          "Payload type PT (Section 9.2.6.2, G.709.1 2020-12). For example, applicable to OIF 800ZR (0x40) (ITU-T)";
+      }
+      leaf flexo-mode {
+        type string;
+        description
+          "Generic line mapping application beyond ITU-T: 1. OIF 400ZR, 2. Industry OpenZR+ MSA (400ZR+)";
+      }
       leaf-list accepted-group-id {
         type uint32;
         config false;

--- a/model/Device/org-openroadm-ospf.yang
+++ b/model/Device/org-openroadm-ospf.yang
@@ -12,11 +12,11 @@ module org-openroadm-ospf {
   }
   import org-openroadm-device {
     prefix org-openroadm-device;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-routing {
     prefix org-openroadm-routing;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-key-chain {
     prefix org-openroadm-key-chain;
@@ -47,6 +47,10 @@ module org-openroadm-ospf {
      Section 4.c of the IETF Trust's Legal Provisions Relating
      to IETF Documents (http://trustee.ietf.org/license-info).";
 
+  revision 2025-01-10 {
+    description
+      "Version 13.1.1";
+  }
   revision 2023-05-26 {
     description
       "Version 13.1";

--- a/model/Device/org-openroadm-otn-common.yang
+++ b/model/Device/org-openroadm-otn-common.yang
@@ -4,7 +4,7 @@ module org-openroadm-otn-common {
 
   import org-openroadm-resource-types {
     prefix org-openroadm-resource-types;
-    revision-date 2022-03-25;
+    revision-date 2025-01-10;
   }
   import org-openroadm-otn-common-types {
     prefix org-openroadm-otn-common-types;

--- a/model/Device/org-openroadm-otn-common.yang
+++ b/model/Device/org-openroadm-otn-common.yang
@@ -8,11 +8,11 @@ module org-openroadm-otn-common {
   }
   import org-openroadm-otn-common-types {
     prefix org-openroadm-otn-common-types;
-    revision-date 2021-09-24;
+    revision-date 2025-01-10;
   }
   import org-openroadm-common-attributes {
     prefix org-openroadm-common-attributes;
-    revision-date 2021-09-24;
+    revision-date 2025-01-10;
   }
 
   organization
@@ -62,6 +62,10 @@ module org-openroadm-otn-common {
      Section 4.e of the Trust Legal Provisions and are provided without warranty as
      described in the Simplified BSD License.";
 
+  revision 2025-01-10 {
+    description
+      "Version 13.1.1";
+  }
   revision 2022-03-25 {
     description
       "Version 11.0";

--- a/model/Device/org-openroadm-otn-odu-interfaces.yang
+++ b/model/Device/org-openroadm-otn-odu-interfaces.yang
@@ -17,15 +17,15 @@ module org-openroadm-otn-odu-interfaces {
   }
   import org-openroadm-otn-common {
     prefix org-openroadm-otn-common;
-    revision-date 2022-03-25;
+    revision-date 2025-01-10;
   }
   import org-openroadm-otn-common-types {
     prefix org-openroadm-otn-common-types;
-    revision-date 2021-09-24;
+    revision-date 2025-01-10;
   }
   import org-openroadm-common-attributes {
     prefix org-openroadm-common-attributes;
-    revision-date 2021-09-24;
+    revision-date 2025-01-10;
   }
 
   organization

--- a/model/Device/org-openroadm-otn-odu-interfaces.yang
+++ b/model/Device/org-openroadm-otn-odu-interfaces.yang
@@ -5,7 +5,7 @@ module org-openroadm-otn-odu-interfaces {
 
   import org-openroadm-device {
     prefix org-openroadm-device;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-interfaces {
     prefix openROADM-if;
@@ -13,7 +13,7 @@ module org-openroadm-otn-odu-interfaces {
   }
   import org-openroadm-maintenance-testsignal {
     prefix org-openroadm-maint-testsignal;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-otn-common {
     prefix org-openroadm-otn-common;
@@ -75,6 +75,10 @@ module org-openroadm-otn-odu-interfaces {
      Section 4.e of the Trust Legal Provisions and are provided without warranty as
      described in the Simplified BSD License.";
 
+  revision 2025-01-10 {
+    description
+      "Version 13.1.1";
+  }
   revision 2023-05-26 {
     description
       "Version 13.1";

--- a/model/Device/org-openroadm-otn-otu-interfaces.yang
+++ b/model/Device/org-openroadm-otn-otu-interfaces.yang
@@ -16,15 +16,15 @@ module org-openroadm-otn-otu-interfaces {
   }
   import org-openroadm-otn-common {
     prefix org-openroadm-otn-common;
-    revision-date 2022-03-25;
+    revision-date 2025-01-10;
   }
   import org-openroadm-otn-common-types {
     prefix org-openroadm-otn-common-types;
-    revision-date 2021-09-24;
+    revision-date 2025-01-10;
   }
   import org-openroadm-common-attributes {
     prefix org-openroadm-common-attributes;
-    revision-date 2021-09-24;
+    revision-date 2025-01-10;
   }
   import org-openroadm-common-types {
     prefix org-openroadm-common-types;

--- a/model/Device/org-openroadm-otn-otu-interfaces.yang
+++ b/model/Device/org-openroadm-otn-otu-interfaces.yang
@@ -4,7 +4,7 @@ module org-openroadm-otn-otu-interfaces {
 
   import org-openroadm-device {
     prefix org-openroadm-device;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-interfaces {
     prefix openROADM-if;
@@ -28,7 +28,7 @@ module org-openroadm-otn-otu-interfaces {
   }
   import org-openroadm-common-types {
     prefix org-openroadm-common-types;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
 
   organization
@@ -78,6 +78,10 @@ module org-openroadm-otn-otu-interfaces {
      Section 4.e of the Trust Legal Provisions and are provided without warranty as
      described in the Simplified BSD License.";
 
+  revision 2025-01-10 {
+    description
+      "Version 13.1.1";
+  }
   revision 2023-05-26 {
     description
       "Version 13.1";

--- a/model/Device/org-openroadm-otsi-group-interfaces.yang
+++ b/model/Device/org-openroadm-otsi-group-interfaces.yang
@@ -5,7 +5,7 @@ module org-openroadm-otsi-group-interfaces {
 
   import org-openroadm-device {
     prefix org-openroadm-device;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-interfaces {
     prefix openROADM-if;
@@ -22,7 +22,7 @@ module org-openroadm-otsi-group-interfaces {
 
   import org-openroadm-maintenance-testsignal {
     prefix org-openroadm-maint-testsignal;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-maintenance-loopback {
     prefix org-openroadm-maint-loopback;
@@ -76,6 +76,10 @@ module org-openroadm-otsi-group-interfaces {
      Section 4.e of the Trust Legal Provisions and are provided without warranty as
      described in the Simplified BSD License.";
 
+  revision 2025-01-10 {
+    description
+      "Version 13.1.1";
+  }
   revision 2023-05-26 {
     description
       "Version 13.1";

--- a/model/Device/org-openroadm-otsi-group-interfaces.yang
+++ b/model/Device/org-openroadm-otsi-group-interfaces.yang
@@ -13,11 +13,11 @@ module org-openroadm-otsi-group-interfaces {
   }
   import org-openroadm-common-optical-channel-types {
     prefix org-openroadm-common-optical-channel-types;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-otn-common-types {
     prefix org-openroadm-otn-common-types;
-    revision-date 2021-09-24;
+    revision-date 2025-01-10;
   }
 
   import org-openroadm-maintenance-testsignal {

--- a/model/Device/org-openroadm-pluggable-optics-holder-capability.yang
+++ b/model/Device/org-openroadm-pluggable-optics-holder-capability.yang
@@ -12,7 +12,7 @@ module org-openroadm-pluggable-optics-holder-capability {
   }
   import org-openroadm-port-types {
     prefix org-openroadm-port-types;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
 
   organization

--- a/model/Device/org-openroadm-pluggable-optics-holder-capability.yang
+++ b/model/Device/org-openroadm-pluggable-optics-holder-capability.yang
@@ -4,11 +4,11 @@ module org-openroadm-pluggable-optics-holder-capability {
 
   import org-openroadm-device {
     prefix org-openroadm-device;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-port-capability {
     prefix org-openroadm-port-capability;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-port-types {
     prefix org-openroadm-port-types;
@@ -62,6 +62,10 @@ module org-openroadm-pluggable-optics-holder-capability {
      Section 4.e of the Trust Legal Provisions and are provided without warranty as
      described in the Simplified BSD License.";
 
+  revision 2025-01-10 {
+    description
+      "Version 13.1.1";
+  }
   revision 2023-05-26 {
     description
       "Version 13.1";

--- a/model/Device/org-openroadm-port-capability.yang
+++ b/model/Device/org-openroadm-port-capability.yang
@@ -4,7 +4,7 @@ module org-openroadm-port-capability {
 
   import org-openroadm-device {
     prefix org-openroadm-device;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-port-types {
     prefix org-openroadm-port-types;
@@ -58,6 +58,10 @@ module org-openroadm-port-capability {
      Section 4.e of the Trust Legal Provisions and are provided without warranty as
      described in the Simplified BSD License.";
 
+  revision 2025-01-10 {
+    description
+      "Version 13.1.1";
+  }
   revision 2023-05-26 {
     description
       "Version 13.1";

--- a/model/Device/org-openroadm-port-capability.yang
+++ b/model/Device/org-openroadm-port-capability.yang
@@ -10,6 +10,10 @@ module org-openroadm-port-capability {
     prefix org-openroadm-port-types;
     revision-date 2025-01-10;
   }
+  import org-openroadm-common-state-types {
+    prefix org-openroadm-common-state-types;
+    revision-date 2019-11-29;
+  }
 
   organization
     "Open ROADM MSA";
@@ -202,7 +206,14 @@ module org-openroadm-port-capability {
       }
       config false;
       description
-        "Optical operation capabilities handled through specific operation modes leaf list";
+        "Optical operational modes supported.
+
+           The optical-operational-mode is configured on the OCH and OTSI interfaces.
+           When an Open ROADM standard optical operational mode is advertised, this indicates
+           that the mode is supported and can be provisioned using the provision-mode = explicit
+           or profile.
+           When a bookended optical operational mode is advertised, this indicates that the mode
+           is supported and can be provisioned using the provisioned-mode = profile.";
     }
   }
 
@@ -398,6 +409,11 @@ module org-openroadm-port-capability {
         key "port-sharing-id";
         leaf port-sharing-id {
           type uint16;
+        }
+        leaf lifecycle-state {
+          type org-openroadm-common-state-types:lifecycle-state;
+          description
+            "Lifecycle State of the port bandwidth sharing. Whether it is planned or deployed, etc.";
         }
         leaf provisioned-port-config {
           type uint16;

--- a/model/Device/org-openroadm-port-capability.yang
+++ b/model/Device/org-openroadm-port-capability.yang
@@ -8,7 +8,7 @@ module org-openroadm-port-capability {
   }
   import org-openroadm-port-types {
     prefix org-openroadm-port-types;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
 
   organization

--- a/model/Device/org-openroadm-prot-equipment-aps.yang
+++ b/model/Device/org-openroadm-prot-equipment-aps.yang
@@ -4,11 +4,11 @@ module org-openroadm-prot-equipment-aps {
 
   import org-openroadm-device {
     prefix org-openroadm-device;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-common-types {
     prefix org-openroadm-common-types;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
 
   organization
@@ -58,6 +58,10 @@ module org-openroadm-prot-equipment-aps {
      Section 4.e of the Trust Legal Provisions and are provided without warranty as
      described in the Simplified BSD License.";
 
+  revision 2025-01-10 {
+    description
+      "Version 13.1.1";
+  }
   revision 2023-05-26 {
     description
       "Version 13.1";

--- a/model/Device/org-openroadm-prot-equipment-aps.yang
+++ b/model/Device/org-openroadm-prot-equipment-aps.yang
@@ -10,6 +10,10 @@ module org-openroadm-prot-equipment-aps {
     prefix org-openroadm-common-types;
     revision-date 2025-01-10;
   }
+  import org-openroadm-common-state-types {
+    prefix org-openroadm-common-state-types;
+    revision-date 2019-11-29;
+  }
 
   organization
     "Open ROADM MSA";
@@ -87,7 +91,6 @@ module org-openroadm-prot-equipment-aps {
       "Version 11.0";
   }
 
-
   typedef prot-architecture-type {
     type enumeration {
       enum one-for-one {
@@ -100,7 +103,6 @@ module org-openroadm-prot-equipment-aps {
     description
       "Protection architecture, 1:1 or 1:n";
   }
-
 
   typedef pg-service-state-type {
     type enumeration {
@@ -136,7 +138,6 @@ module org-openroadm-prot-equipment-aps {
            the PG cannot provide full service.";
   }
 
-
   typedef pg-redundancy-state-type {
     type enumeration {
       enum redundancy-available {
@@ -161,7 +162,6 @@ module org-openroadm-prot-equipment-aps {
            is not (yet) available.";
   }
 
-
   typedef pg-lockout-state-type {
     type enumeration {
       enum clear {
@@ -176,7 +176,6 @@ module org-openroadm-prot-equipment-aps {
        'clear' means that none of the members are locked out.
        'locked' means that one or more members are in a 'locked' state.";
   }
-
 
   typedef pg-member-state-type {
     type enumeration {
@@ -208,7 +207,6 @@ module org-openroadm-prot-equipment-aps {
            circuit-pack itself.";
   }
 
-
   typedef pg-member-switch-request-type {
     type enumeration {
       enum no-request {
@@ -228,7 +226,6 @@ module org-openroadm-prot-equipment-aps {
       "Describes the switch request on a PG member.";
   }
 
-
   grouping circuit-pack-grps {
     list circuit-pack-pg {
       key "name";
@@ -242,6 +239,11 @@ module org-openroadm-prot-equipment-aps {
         type string;
         description
           "The circuit-pack PG name";
+      }
+      leaf lifecycle-state {
+        type org-openroadm-common-state-types:lifecycle-state;
+        description
+          "Lifecycle State of the circuit-pack protection group. Whether it is planned or deployed, etc.";
       }
       leaf prot-architecture {
         type prot-architecture-type;
@@ -313,7 +315,6 @@ module org-openroadm-prot-equipment-aps {
     }
   }
 
-
   rpc circuit-pack-protection-switch {
     description
       "Exercise a protection switch command on a pg-cp-descriptor";
@@ -345,7 +346,7 @@ module org-openroadm-prot-equipment-aps {
             value 2;
             description
               "remove the member from active service,
-              and if persistent, set switch request to 'manual'";
+               and if persistent, set switch request to 'manual'";
           }
           enum release {
             value 3;
@@ -361,9 +362,7 @@ module org-openroadm-prot-equipment-aps {
     }
   }
 
-
   augment "/org-openroadm-device:org-openroadm-device/org-openroadm-device:protection-grps" {
     uses circuit-pack-grps;
   }
-
 }

--- a/model/Device/org-openroadm-prot-otn-linear-aps.yang
+++ b/model/Device/org-openroadm-prot-otn-linear-aps.yang
@@ -4,11 +4,11 @@ module org-openroadm-prot-otn-linear-aps {
 
   import org-openroadm-device {
     prefix org-openroadm-device;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-common-types {
     prefix org-openroadm-common-types;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
 
   organization
@@ -58,6 +58,10 @@ module org-openroadm-prot-otn-linear-aps {
      Section 4.e of the Trust Legal Provisions and are provided without warranty as
      described in the Simplified BSD License.";
 
+  revision 2025-01-10 {
+    description
+      "Version 13.1.1";
+  }
   revision 2023-05-26 {
     description
       "Version 13.1";

--- a/model/Device/org-openroadm-prot-otn-linear-aps.yang
+++ b/model/Device/org-openroadm-prot-otn-linear-aps.yang
@@ -10,6 +10,10 @@ module org-openroadm-prot-otn-linear-aps {
     prefix org-openroadm-common-types;
     revision-date 2025-01-10;
   }
+  import org-openroadm-common-state-types {
+    prefix org-openroadm-common-state-types;
+    revision-date 2019-11-29;
+  }
 
   organization
     "Open ROADM MSA";
@@ -445,6 +449,11 @@ module org-openroadm-prot-otn-linear-aps {
         description
           "The odu-sncp-protection-group name";
       }
+      leaf lifecycle-state {
+        type org-openroadm-common-state-types:lifecycle-state;
+        description
+          "Lifecycle State of the odu sncp protection group. Whether it is planned or deployed, etc.";
+      }
       leaf level {
         type protection-level-type;
         must "current() = 'path' or current() = 'line'" {
@@ -488,6 +497,11 @@ module org-openroadm-prot-otn-linear-aps {
         type string;
         description
           "The client-sncp-protection-group name";
+      }
+      leaf lifecycle-state {
+        type org-openroadm-common-state-types:lifecycle-state;
+        description
+          "Lifecycle State of the client sncp protection group. Whether it is planned or deployed, etc.";
       }
       uses generic-sncp-pg;
     }

--- a/model/Device/org-openroadm-routing.yang
+++ b/model/Device/org-openroadm-routing.yang
@@ -8,7 +8,7 @@ module org-openroadm-routing {
   }
   import org-openroadm-device {
     prefix org-openroadm-device;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
 
   organization
@@ -35,6 +35,10 @@ module org-openroadm-routing {
      Section 4.c of the IETF Trust's Legal Provisions Relating
      to IETF Documents (http://trustee.ietf.org/license-info).";
 
+  revision 2025-01-10 {
+    description
+      "Version 13.1.1";
+  }
   revision 2023-05-26 {
     description
       "Version 13.1";

--- a/model/Device/org-openroadm-routing.yang
+++ b/model/Device/org-openroadm-routing.yang
@@ -19,7 +19,7 @@ module org-openroadm-routing {
     "This model defines Yang model for routing.
 
      This model reuses data items defined in the IETF YANG model for
-     interfaces described by RFC 8022.
+     interfaces described by draft-ietf-netmod-routing-cfg-19.
 
      Some attributes which are not required in Open ROADM MSA are removed.
      Yang file included are changed to fit into Open ROADM MSA yang structure.
@@ -314,6 +314,38 @@ module org-openroadm-routing {
       }
     }
   }
+   grouping next-hop-state-content {
+    description
+      "Generic parameters of next-hops in state data.";
+    choice next-hop-options {
+      mandatory "true";
+      description
+        "Options for next-hops in state data.
+
+         It is expected that other cases will be added through
+         augments from other modules, e.g., for ECMP or recursive
+         next-hops.";
+      case simple-next-hop {
+        description
+          "Simple next-hop is specified as an outgoing interface,
+           next-hop address or both.
+
+           Address-family-specific modules are expected to provide
+           'next-hop-address' leaf via augmentation.";
+        leaf outgoing-interface {
+          type leafref {
+            path "/org-openroadm-device:org-openroadm-device/org-openroadm-routing:routing-state/"
+               + "org-openroadm-routing:routing-instance/org-openroadm-routing:interfaces/org-openroadm-routing:interface";
+          }
+          description
+            "Name of the outgoing interface.";
+        }
+      }
+      case special-next-hop {
+        uses special-next-hop-group;
+      }
+    }
+  }
 
   grouping route-metadata {
     description
@@ -534,6 +566,17 @@ module org-openroadm-routing {
              It may be either configured or assigned algorithmically by
              the implementation.";
         }
+        container interfaces {
+          description
+            "Network layer interfaces belonging to the routing
+             instance.";
+          leaf-list interface {
+            type org-openroadm-device:interface-ref;
+            description
+              "Each entry is a reference to the name of a configured
+               network layer interface.";
+          }
+        }
         container routing-protocols {
           description
             "Container for the list of routing protocol instances.";
@@ -568,7 +611,6 @@ module org-openroadm-routing {
             "Container for RIBs.";
           list rib {
             key "name";
-            min-elements 1;
             description
               "Each entry represents a RIB identified by the 'name'
                key. All routes in a RIB MUST belong to the same address
@@ -598,6 +640,26 @@ module org-openroadm-routing {
             container routes {
               description
                 "Current content of the RIB.";
+              list route {
+                 description
+                   "A RIB route entry. This data node MUST be augmented
+                    with information specific for routes of each address
+                    family.";
+                 leaf route-preference {
+                   type route-preference;
+                   description
+                     "This route attribute, also known as administrative
+                      distance, allows for selecting the preferred route
+                      among routes with the same destination prefix. A
+                      smaller value means a more preferred route.";
+                 }
+                 container next-hop {
+                   description
+                     "Route's next-hop attribute.";
+                   uses next-hop-state-content;
+                 }
+                 uses route-metadata;
+              }
             }
           }
         }

--- a/model/Device/org-openroadm-routing.yang
+++ b/model/Device/org-openroadm-routing.yang
@@ -10,6 +10,10 @@ module org-openroadm-routing {
     prefix org-openroadm-device;
     revision-date 2025-01-10;
   }
+  import org-openroadm-common-state-types {
+    prefix org-openroadm-common-state-types;
+    revision-date 2019-11-29;
+  }
 
   organization
     "Open ROADM MSA";
@@ -383,6 +387,11 @@ module org-openroadm-routing {
         key "name";
         description
           "Configuration of a routing instance.";
+        leaf lifecycle-state {
+          type org-openroadm-common-state-types:lifecycle-state;
+          description
+            "Lifecycle State of the routing instance. Whether it is planned or deployed, etc.";
+        }
         leaf name {
           type string;
           description
@@ -443,6 +452,11 @@ module org-openroadm-routing {
             description
               "Each entry contains configuration of a routing protocol
                instance.";
+            leaf lifecycle-state {
+              type org-openroadm-common-state-types:lifecycle-state;
+              description
+                "Lifecycle State of the routing protocol. Whether it is planned or deployed, etc.";
+            }
             leaf type {
               type identityref {
                 base routing-protocol;

--- a/model/Device/org-openroadm-rstp.yang
+++ b/model/Device/org-openroadm-rstp.yang
@@ -8,7 +8,7 @@ module org-openroadm-rstp {
   }
   import org-openroadm-resource-types {
     prefix org-openroadm-resource-types;
-    revision-date 2022-03-25;
+    revision-date 2025-01-10;
   }
 
   organization

--- a/model/Device/org-openroadm-rstp.yang
+++ b/model/Device/org-openroadm-rstp.yang
@@ -4,7 +4,7 @@ module org-openroadm-rstp {
 
   import org-openroadm-device {
     prefix org-openroadm-device;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-resource-types {
     prefix org-openroadm-resource-types;
@@ -45,6 +45,10 @@ module org-openroadm-rstp {
      ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
      POSSIBILITY OF SUCH DAMAGE.";
 
+  revision 2025-01-10 {
+    description
+      "Version 13.1.1";
+  }
   revision 2023-05-26 {
     description
       "Version 13.1";

--- a/model/Device/org-openroadm-rstp.yang
+++ b/model/Device/org-openroadm-rstp.yang
@@ -10,6 +10,10 @@ module org-openroadm-rstp {
     prefix org-openroadm-resource-types;
     revision-date 2025-01-10;
   }
+  import org-openroadm-common-state-types {
+    prefix org-openroadm-common-state-types;
+    revision-date 2019-11-29;
+  }
 
   organization
     "Open ROADM MSA";
@@ -369,6 +373,11 @@ module org-openroadm-rstp {
     container rstp {
       description
         "Open ROADM RSTP top level";
+      leaf lifecycle-state {
+        type org-openroadm-common-state-types:lifecycle-state;
+        description
+          "Lifecycle State of rstp. Whether it is planned or deployed, etc.";
+      }
       leaf max-bridge-instances {
         type uint32;
         config false;

--- a/model/Device/org-openroadm-security.yang
+++ b/model/Device/org-openroadm-security.yang
@@ -5,11 +5,11 @@ module org-openroadm-security {
 
   import org-openroadm-device {
     prefix org-openroadm-device;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-common-types {
     prefix org-openroadm-common-types;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
 
   organization
@@ -45,6 +45,10 @@ module org-openroadm-security {
      ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
      POSSIBILITY OF SUCH DAMAGE.";
 
+  revision 2025-01-10 {
+    description
+      "Version 13.1.1";
+  }
   revision 2023-05-26 {
     description
       "Version 13.1";

--- a/model/Device/org-openroadm-swdl.yang
+++ b/model/Device/org-openroadm-swdl.yang
@@ -8,7 +8,7 @@ module org-openroadm-swdl {
   }
   import org-openroadm-common-types {
     prefix org-openroadm-common-types;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
 
   organization
@@ -44,6 +44,10 @@ module org-openroadm-swdl {
      ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
      POSSIBILITY OF SUCH DAMAGE.";
 
+  revision 2025-01-10 {
+    description
+      "Version 13.1.1";
+  }
   revision 2023-05-26 {
     description
       "Version 13.1";

--- a/model/Device/tree-view-device.txt
+++ b/model/Device/tree-view-device.txt
@@ -353,6 +353,9 @@ module: org-openroadm-device
      |  |  +--ro extension?   string
      |  +--rw equipment-state?             org-openroadm-equipment-states-types:states
      |  +--rw circuit-pack-mode?           string
+     |  +--rw sub-circuit-pack-mode* [index]
+     |  |  +--rw index    uint8
+     |  |  +--rw mode?    string
      |  +--rw shelf                        -> /org-openroadm-device/shelves/shelf-name
      |  +--rw slot                         string
      |  +--rw subSlot?                     string
@@ -1183,7 +1186,7 @@ module: org-openroadm-device
      |  +--ro network-ho-odu-opucn-trib-slots*   org-openroadm-otn-common-types:opucn-trib-slot-def
      +--ro muxp-eth-profile* [profile-name]
      |  +--ro profile-name                      string
-     |  +--ro network-eth-speed?                uint32
+     |  +--ro network-otsi-group-rate           identityref
      |  +--ro network-flexo-trib-port-number    uint16
      |  +--ro network-flexo-iid*                uint16
      +--ro otsi-profile* [profile-name]

--- a/model/Device/tree-view-device.txt
+++ b/model/Device/tree-view-device.txt
@@ -513,7 +513,6 @@ module: org-openroadm-device
      |  |  +--ro org-openroadm-prot-otn-linear-aps:protection-profile-name*   -> /org-openroadm-device:org-openroadm-device/protection-profiles/org-openroadm-prot-otn-linear-aps:protection-profile/profile-name
      |  +--rw org-openroadm-eth-interfaces:ethernet
      |  |  +--rw org-openroadm-eth-interfaces:speed?                          uint32
-     |  |  +--rw org-openroadm-eth-interfaces:eth-function?                   eth-function-type
      |  |  +--rw org-openroadm-eth-interfaces:fec?                            identityref
      |  |  +--rw org-openroadm-eth-interfaces:egress-consequent-action?       enumeration
      |  |  +--rw org-openroadm-eth-interfaces:duplex?                         enumeration
@@ -530,7 +529,7 @@ module: org-openroadm-device
      |  |  +--ro org-openroadm-eth-interfaces:no-maint-testsignal-function?   empty
      |  |  +--rw org-openroadm-eth-interfaces:parent-flexo-allocation!
      |  |  |  +--rw org-openroadm-eth-interfaces:trib-port-number    uint16
-     |  |  |  +--rw org-openroadm-eth-interfaces:iid*                uint16
+     |  |  |  +--rw org-openroadm-eth-interfaces:iid*                uint8
      |  |  +--rw org-openroadm-eth-interfaces:maint-testsignal
      |  |  |  +---x org-openroadm-eth-interfaces:clear-diagnostics
      |  |  |  |  +---w org-openroadm-eth-interfaces:input
@@ -657,6 +656,8 @@ module: org-openroadm-device
      |  |  +--rw org-openroadm-optical-tributary-signal-interfaces:flexo!
      |  |     +--rw org-openroadm-optical-tributary-signal-interfaces:foic-type?             identityref
      |  |     +--rw org-openroadm-optical-tributary-signal-interfaces:iid*                   uint8
+     |  |     +--rw org-openroadm-optical-tributary-signal-interfaces:payload-id?            org-openroadm-otn-common-types:flexo-payload-type-def
+     |  |     +--rw org-openroadm-optical-tributary-signal-interfaces:flexo-mode?            string
      |  |     +--ro org-openroadm-optical-tributary-signal-interfaces:accepted-group-id*     uint32
      |  |     +--ro org-openroadm-optical-tributary-signal-interfaces:accepted-iid*          uint8
      |  |     +--ro org-openroadm-optical-tributary-signal-interfaces:accepted-payload-id*   org-openroadm-otn-common-types:flexo-payload-type-def
@@ -1126,6 +1127,8 @@ module: org-openroadm-device
      |  +--ro profile-name                          string
      |  +--ro if-cap-type?                          identityref
      |  +--ro flexo-payload-type?                   org-openroadm-otn-common-types:flexo-payload-type-def
+     |  +--ro eth-mixed?                            boolean
+     |  +--ro eth-speed*                            uint32
      |  +--ro (otu-rate)?
      |  |  +--:(otucn)
      |  |  |  +--ro otucn-n-rate?                   uint16
@@ -1188,7 +1191,7 @@ module: org-openroadm-device
      |  +--ro profile-name                      string
      |  +--ro network-otsi-group-rate           identityref
      |  +--ro network-flexo-trib-port-number    uint16
-     |  +--ro network-flexo-iid*                uint16
+     |  +--ro network-flexo-iid*                uint8
      +--ro otsi-profile* [profile-name]
      |  +--ro profile-name                 string
      |  +--ro otsi-rate                    identityref

--- a/model/Device/tree-view-device.txt
+++ b/model/Device/tree-view-device.txt
@@ -820,6 +820,7 @@ module: org-openroadm-device
      +--rw protection-grps
      |  +--rw org-openroadm-prot-equipment-aps:circuit-pack-pg* [name]
      |  |  +--rw org-openroadm-prot-equipment-aps:name                 string
+     |  |  +--rw org-openroadm-prot-equipment-aps:lifecycle-state?     org-openroadm-common-state-types:lifecycle-state
      |  |  +--rw org-openroadm-prot-equipment-aps:prot-architecture    prot-architecture-type
      |  |  +--ro org-openroadm-prot-equipment-aps:service-state        pg-service-state-type
      |  |  +--ro org-openroadm-prot-equipment-aps:redundancy-state     pg-redundancy-state-type
@@ -832,6 +833,7 @@ module: org-openroadm-device
      |  |     +--ro org-openroadm-prot-equipment-aps:member-active      boolean
      |  +--rw org-openroadm-prot-otn-linear-aps:odu-sncp-pg* [name]
      |  |  +--rw org-openroadm-prot-otn-linear-aps:name                   string
+     |  |  +--rw org-openroadm-prot-otn-linear-aps:lifecycle-state?       org-openroadm-common-state-types:lifecycle-state
      |  |  +--rw org-openroadm-prot-otn-linear-aps:level                  protection-level-type
      |  |  +--rw org-openroadm-prot-otn-linear-aps:prot-type?             identityref
      |  |  +--rw org-openroadm-prot-otn-linear-aps:mode                   protection-mode-type
@@ -849,6 +851,7 @@ module: org-openroadm-device
      |  |  +--ro org-openroadm-prot-otn-linear-aps:request-state?         request-state-type
      |  +--rw org-openroadm-prot-otn-linear-aps:client-sncp-pg* [name]
      |     +--rw org-openroadm-prot-otn-linear-aps:name                   string
+     |     +--rw org-openroadm-prot-otn-linear-aps:lifecycle-state?       org-openroadm-common-state-types:lifecycle-state
      |     +--rw org-openroadm-prot-otn-linear-aps:switching-direction?   switching-direction-type
      |     +--rw org-openroadm-prot-otn-linear-aps:revertive?             boolean
      |     +--rw org-openroadm-prot-otn-linear-aps:sd-enable?             boolean
@@ -872,20 +875,24 @@ module: org-openroadm-device
      +--rw protocols
      |  +--rw lifecycle-state?                      org-openroadm-common-state-types:lifecycle-state
      |  +--rw org-openroadm-dhcp:ipv4-dhcp-relay
+     |  |  +--rw org-openroadm-dhcp:lifecycle-state?     org-openroadm-common-state-types:lifecycle-state
      |  |  +--rw org-openroadm-dhcp:ipv4-server-group* [server-group-name]
      |  |     +--rw org-openroadm-dhcp:server-group-name    string
      |  |     +--rw org-openroadm-dhcp:interface-name*      -> /org-openroadm-device:org-openroadm-device/interface/name
      |  |     +--rw org-openroadm-dhcp:server-address*      ietf-inet-types:ipv4-address
      |  +--rw org-openroadm-dhcp:ipv6-dhcp-relay
+     |  |  +--rw org-openroadm-dhcp:lifecycle-state?     org-openroadm-common-state-types:lifecycle-state
      |  |  +--rw org-openroadm-dhcp:ipv6-server-group* [server-group-name]
      |  |     +--rw org-openroadm-dhcp:server-group-name    string
      |  |     +--rw org-openroadm-dhcp:interface-name*      -> /org-openroadm-device:org-openroadm-device/interface/name
      |  |     +--rw org-openroadm-dhcp:server-address*      ietf-inet-types:ipv6-address
      |  +--rw org-openroadm-gnmi:gnmi
-     |  |  +--rw org-openroadm-gnmi:enabled?          boolean
-     |  |  +--rw org-openroadm-gnmi:certificate-id?   -> /org-openroadm-device:org-openroadm-device/org-openroadm-security:security/certificate/certificate-id
-     |  |  +--rw org-openroadm-gnmi:port?             inet:port-number
+     |  |  +--rw org-openroadm-gnmi:enabled?           boolean
+     |  |  +--rw org-openroadm-gnmi:lifecycle-state?   org-openroadm-common-state-types:lifecycle-state
+     |  |  +--rw org-openroadm-gnmi:certificate-id?    -> /org-openroadm-device:org-openroadm-device/org-openroadm-security:security/certificate/certificate-id
+     |  |  +--rw org-openroadm-gnmi:port?              inet:port-number
      |  +--rw org-openroadm-lldp:lldp
+     |  |  +--rw org-openroadm-lldp:lifecycle-state?   org-openroadm-common-state-types:lifecycle-state
      |  |  +--rw org-openroadm-lldp:global-config
      |  |  |  +--rw org-openroadm-lldp:adminStatus?           enumeration
      |  |  |  +--rw org-openroadm-lldp:msgTxInterval?         uint16
@@ -904,6 +911,7 @@ module: org-openroadm-device
      |  |        +--ro org-openroadm-lldp:remoteChassisIdSubType?     enumeration
      |  |        +--ro org-openroadm-lldp:remoteChassisId?            string
      |  +--rw org-openroadm-rstp:rstp
+     |     +--rw org-openroadm-rstp:lifecycle-state?        org-openroadm-common-state-types:lifecycle-state
      |     +--ro org-openroadm-rstp:max-bridge-instances?   uint32
      |     +--rw org-openroadm-rstp:rstp-bridge-instance* [bridge-name]
      |        +--rw org-openroadm-rstp:bridge-name    string
@@ -1205,6 +1213,7 @@ module: org-openroadm-device
      |     +--ro org-openroadm-security:information?         string
      +--rw org-openroadm-routing:routing
      |  +--rw org-openroadm-routing:routing-instance* [name]
+     |     +--rw org-openroadm-routing:lifecycle-state?     org-openroadm-common-state-types:lifecycle-state
      |     +--rw org-openroadm-routing:name                 string
      |     +--rw org-openroadm-routing:type?                identityref
      |     +--rw org-openroadm-routing:enabled?             boolean
@@ -1214,9 +1223,10 @@ module: org-openroadm-device
      |     |  +--rw org-openroadm-routing:interface*   org-openroadm-device:interface-ref
      |     +--rw org-openroadm-routing:routing-protocols
      |     |  +--rw org-openroadm-routing:routing-protocol* [type name]
-     |     |     +--rw org-openroadm-routing:type             identityref
-     |     |     +--rw org-openroadm-routing:name             string
-     |     |     +--rw org-openroadm-routing:description?     string
+     |     |     +--rw org-openroadm-routing:lifecycle-state?   org-openroadm-common-state-types:lifecycle-state
+     |     |     +--rw org-openroadm-routing:type               identityref
+     |     |     +--rw org-openroadm-routing:name               string
+     |     |     +--rw org-openroadm-routing:description?       string
      |     |     +--rw org-openroadm-routing:static-routes
      |     |     |  +--rw org-openroadm-ipv4-unicast-routing:ipv4
      |     |     |  |  +--rw org-openroadm-ipv4-unicast-routing:route* [destination-prefix]
@@ -1764,6 +1774,7 @@ module: org-openroadm-device
      +--rw org-openroadm-port-capability:provisioned-port-grp
         +--rw org-openroadm-port-capability:port-bandwidth-sharing* [port-sharing-id]
            +--rw org-openroadm-port-capability:port-sharing-id            uint16
+           +--rw org-openroadm-port-capability:lifecycle-state?           org-openroadm-common-state-types:lifecycle-state
            +--rw org-openroadm-port-capability:provisioned-port-config?   uint16
 
   rpcs:

--- a/model/Device/tree-view-device.txt
+++ b/model/Device/tree-view-device.txt
@@ -89,6 +89,7 @@ module: openconfig-telemetry
                     +--ro state
                        +--ro path?             string
                        +--ro exclude-filter?   string
+
 module: org-openroadm-database
 
   rpcs:
@@ -133,6 +134,7 @@ module: org-openroadm-database
        +--ro db-active-notification-type?   org-openroadm-common-types:activate-notification-type
        +--ro status                         rpc-status
        +--ro status-message?                string
+
 module: org-openroadm-de-operations
 
   rpcs:
@@ -241,6 +243,7 @@ module: org-openroadm-de-operations
        +--ro resourceType
           +--ro type         resource-type-enum
           +--ro extension?   string
+
 module: org-openroadm-device
   +--rw org-openroadm-device
      +--rw info
@@ -1308,6 +1311,8 @@ module: org-openroadm-device
      |     +--ro org-openroadm-routing:name                 string
      |     +--ro org-openroadm-routing:type?                identityref
      |     +--ro org-openroadm-routing:router-id?           yang:dotted-quad
+     |     +--ro org-openroadm-routing:interfaces
+     |     |  +--ro org-openroadm-routing:interface*   org-openroadm-device:interface-ref
      |     +--ro org-openroadm-routing:routing-protocols
      |     |  +--ro org-openroadm-routing:routing-protocol* [type name]
      |     |     +--ro org-openroadm-routing:type    identityref
@@ -1700,6 +1705,21 @@ module: org-openroadm-device
      |           +--ro org-openroadm-routing:address-family    identityref
      |           +--ro org-openroadm-routing:default-rib?      boolean {multiple-ribs}?
      |           +--ro org-openroadm-routing:routes
+     |              +--ro org-openroadm-routing:route* []
+     |                 +--ro org-openroadm-routing:route-preference?                  route-preference
+     |                 +--ro org-openroadm-routing:next-hop
+     |                 |  +--ro (org-openroadm-routing:next-hop-options)
+     |                 |     +--:(org-openroadm-routing:simple-next-hop)
+     |                 |     |  +--ro org-openroadm-routing:outgoing-interface?              -> /org-openroadm-device:org-openroadm-device/org-openroadm-routing:routing-state/routing-instance/interfaces/interface
+     |                 |     |  +--ro org-openroadm-ipv4-unicast-routing:next-hop-address?   inet:ipv4-address
+     |                 |     |  +--ro org-openroadm-ipv6-unicast-routing:next-hop-address?   inet:ipv6-address
+     |                 |     +--:(org-openroadm-routing:special-next-hop)
+     |                 |        +--ro org-openroadm-routing:special-next-hop?                enumeration
+     |                 +--ro org-openroadm-routing:source-protocol                    identityref
+     |                 +--ro org-openroadm-routing:active?                            empty
+     |                 +--ro org-openroadm-routing:last-updated?                      yang:date-and-time
+     |                 +--ro org-openroadm-ipv4-unicast-routing:destination-prefix?   inet:ipv4-prefix
+     |                 +--ro org-openroadm-ipv6-unicast-routing:destination-prefix?   inet:ipv6-prefix
      +--ro org-openroadm-port-capability:port-group-restriction
      |  +--ro org-openroadm-port-capability:port-bandwidth-sharing* [port-sharing-id]
      |     +--ro org-openroadm-port-capability:port-sharing-id                 uint16
@@ -1859,6 +1879,7 @@ module: org-openroadm-device
        +--ro edit* []
           +--ro target?      instance-identifier
           +--ro operation?   ietf-nc:edit-operation-type
+
 module: org-openroadm-file-transfer
 
   rpcs:
@@ -1895,6 +1916,7 @@ module: org-openroadm-file-transfer
        +--ro progress
           +--ro bytes-transferred?     uint64
           +--ro percentage-complete?   uint8
+
 module: org-openroadm-fwdl
 
   rpcs:
@@ -1905,6 +1927,7 @@ module: org-openroadm-fwdl
        +--ro output
           +--ro status            rpc-status
           +--ro status-message?   string
+
 module: org-openroadm-key-chain
   +--rw key-chains
   |  +--rw key-chain-list* [name]
@@ -1929,6 +1952,7 @@ module: org-openroadm-key-chain
               +--ro (algorithm)?
                  +--:(md5)
                     +--ro md5?   empty
+
 module: org-openroadm-lldp
 
   notifications:
@@ -1945,6 +1969,7 @@ module: org-openroadm-lldp
        |  +--ro remoteChassisIdSubType?     enumeration
        |  +--ro remoteChassisId?            string
        +--ro event-time?          yang:date-and-time
+
 module: org-openroadm-ospf
 
   notifications:
@@ -2061,6 +2086,7 @@ module: org-openroadm-ospf
        +--ro status?                  restart-status-type
        +--ro restart-interval?        uint16
        +--ro exit-reason?             restart-exit-reason-type
+
 module: org-openroadm-otn-common
 
   notifications:
@@ -2074,6 +2100,7 @@ module: org-openroadm-otn-common
           +--ro accepted-sapi?       string
           +--ro accepted-dapi?       string
           +--ro accepted-operator?   string
+
 module: org-openroadm-prot-equipment-aps
 
   rpcs:
@@ -2085,6 +2112,7 @@ module: org-openroadm-prot-equipment-aps
        +--ro output
           +--ro status            rpc-status
           +--ro status-message?   string
+
 module: org-openroadm-prot-otn-linear-aps
 
   rpcs:
@@ -2109,6 +2137,7 @@ module: org-openroadm-prot-otn-linear-aps
     +---n odu-sncp-pg-switch-event
        +--ro switch-status?      enumeration
        +--ro odu-sncp-pg-name?   string
+
 module: org-openroadm-rstp
 
   notifications:
@@ -2116,6 +2145,7 @@ module: org-openroadm-rstp
     |  +--ro node-id?   org-openroadm-common-node-types:node-id-type
     +---n rstp-new-root
        +--ro node-id?   org-openroadm-common-node-types:node-id-type
+
 module: org-openroadm-swdl
 
   rpcs:
@@ -2147,6 +2177,7 @@ module: org-openroadm-swdl
        +--ro sw-active-notification-type?   org-openroadm-common-types:activate-notification-type
        +--ro status                         rpc-status
        +--ro status-message?                string
+
 module: org-openroadm-syslog
   +--rw syslog
      +--ro local-syslog-filename    string
@@ -2172,3 +2203,4 @@ module: org-openroadm-syslog
                           +--rw facility             union
                           +--rw severity             severity
                           +--rw severity-operator?   enumeration {selector-sevop-config}?
+

--- a/model/Device/tree-view-device.txt
+++ b/model/Device/tree-view-device.txt
@@ -881,7 +881,7 @@ module: org-openroadm-device
      |  |     +--ro org-openroadm-lldp:if-name* [ifName]
      |  |        +--ro org-openroadm-lldp:ifName                      string
      |  |        +--ro org-openroadm-lldp:remoteSysName?              string
-     |  |        +--ro org-openroadm-lldp:remoteMgmtAddressSubType?   ianaaf:address-family
+     |  |        +--ro org-openroadm-lldp:remoteMgmtAddressSubType?   iana-rt-types:address-family
      |  |        +--ro org-openroadm-lldp:remoteMgmtAddress?          inet:ip-address
      |  |        +--ro org-openroadm-lldp:remotePortIdSubType?        enumeration
      |  |        +--ro org-openroadm-lldp:remotePortId?               string
@@ -1963,7 +1963,7 @@ module: org-openroadm-lldp
        +--ro resource?            string
        +--ro nbr-info
        |  +--ro remoteSysName?              string
-       |  +--ro remoteMgmtAddressSubType?   ianaaf:address-family
+       |  +--ro remoteMgmtAddressSubType?   iana-rt-types:address-family
        |  +--ro remoteMgmtAddress?          inet:ip-address
        |  +--ro remotePortIdSubType?        enumeration
        |  +--ro remotePortId?               string

--- a/model/Device/tree-view-device.txt
+++ b/model/Device/tree-view-device.txt
@@ -184,7 +184,15 @@ module: org-openroadm-de-operations
        |  |     |  +---w versioned-service-name    string
        |  |     |  +---w version-number            uint64
        |  |     +--:(temp-service)
-       |  |        +---w common-id                 string
+       |  |     |  +---w common-id                 string
+       |  |     +--:(slot)
+       |  |     |  +---w slot
+       |  |     |     +---w shelf-name    string
+       |  |     |     +---w slot-name     string
+       |  |     +--:(cp-slot)
+       |  |        +---w cp-slot
+       |  |           +---w circuit-pack-name    string
+       |  |           +---w slot-name            string
        |  +---w resourceType
        |  |  +---w type         resource-type-enum
        |  |  +---w extension?   string
@@ -239,7 +247,15 @@ module: org-openroadm-de-operations
        |     |  +--ro versioned-service-name    string
        |     |  +--ro version-number            uint64
        |     +--:(temp-service)
-       |        +--ro common-id                 string
+       |     |  +--ro common-id                 string
+       |     +--:(slot)
+       |     |  +--ro slot
+       |     |     +--ro shelf-name    string
+       |     |     +--ro slot-name     string
+       |     +--:(cp-slot)
+       |        +--ro cp-slot
+       |           +--ro circuit-pack-name    string
+       |           +--ro slot-name            string
        +--ro resourceType
           +--ro type         resource-type-enum
           +--ro extension?   string

--- a/model/Device/tree-view-device.txt
+++ b/model/Device/tree-view-device.txt
@@ -255,6 +255,7 @@ module: org-openroadm-device
      |  +--ro vendor                              string
      |  +--ro model                               string
      |  +--ro serial-id                           string
+     |  +--ro oamp-interface-name?                string
      |  +--ro macAddress?                         ietf-yang-types:mac-address
      |  +--ro softwareVersion?                    string
      |  +--ro software-build?                     string

--- a/model/Device/tree-view-device.txt
+++ b/model/Device/tree-view-device.txt
@@ -583,10 +583,10 @@ module: org-openroadm-device
      |  |  +--ro org-openroadm-ip:forwarding?   boolean
      |  |  +--ro org-openroadm-ip:mtu?          uint32
      |  |  +--ro org-openroadm-ip:address* [ip]
-     |  |  |  +--ro org-openroadm-ip:ip               inet:ipv6-address-no-zone
-     |  |  |  +--ro org-openroadm-ip:prefix-length    uint8
-     |  |  +--ro org-openroadm-ip:origin?       ip-address-origin
-     |  |  +--ro org-openroadm-ip:status?       ipv6-address-status
+     |  |     +--ro org-openroadm-ip:ip               inet:ipv6-address-no-zone
+     |  |     +--ro org-openroadm-ip:prefix-length    uint8
+     |  |     +--ro org-openroadm-ip:origin?          ip-address-origin
+     |  |     +--ro org-openroadm-ip:status?          ipv6-address-status
      |  +--rw org-openroadm-media-channel-interfaces:mc-ttp
      |  |  +--rw org-openroadm-media-channel-interfaces:min-freq?      org-openroadm-common-optical-channel-types:frequency-THz
      |  |  +--rw org-openroadm-media-channel-interfaces:max-freq?      org-openroadm-common-optical-channel-types:frequency-THz

--- a/model/Network/org-openroadm-common-network.yang
+++ b/model/Network/org-openroadm-common-network.yang
@@ -13,7 +13,7 @@ module org-openroadm-common-network {
   }
   import org-openroadm-network-types {
     prefix org-openroadm-network-types;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-common-state-types {
     prefix org-openroadm-common-state-types;
@@ -59,6 +59,10 @@ module org-openroadm-common-network {
      ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
      POSSIBILITY OF SUCH DAMAGE.";
 
+  revision 2025-01-10 {
+    description
+      "Version 13.1.1";
+  }
   revision 2023-05-26 {
     description
       "Version 13.1";

--- a/model/Network/org-openroadm-degree.yang
+++ b/model/Network/org-openroadm-degree.yang
@@ -9,7 +9,7 @@ module org-openroadm-degree {
   }
   import org-openroadm-network-types {
     prefix org-openroadm-network-types;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
 
   organization
@@ -46,6 +46,10 @@ module org-openroadm-degree {
      ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
      POSSIBILITY OF SUCH DAMAGE.";
 
+  revision 2025-01-10 {
+    description
+      "Version 13.1.1";
+  }
   revision 2023-05-26 {
     description
       "Version 13.1";

--- a/model/Network/org-openroadm-external-pluggable.yang
+++ b/model/Network/org-openroadm-external-pluggable.yang
@@ -13,7 +13,7 @@ module org-openroadm-external-pluggable {
   }
   import org-openroadm-common-optical-channel-types {
     prefix org-openroadm-common-optical-channel-types;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
 
   organization
@@ -50,6 +50,10 @@ module org-openroadm-external-pluggable {
      ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
      POSSIBILITY OF SUCH DAMAGE.";
 
+  revision 2025-01-10 {
+    description
+      "Version 13.1.1";
+  }
   revision 2023-05-26 {
     description
       "Version 13.1";

--- a/model/Network/org-openroadm-link.yang
+++ b/model/Network/org-openroadm-link.yang
@@ -25,11 +25,11 @@ module org-openroadm-link {
   }
   import org-openroadm-network-types {
     prefix org-openroadm-network-types;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-common-network {
     prefix cnet;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
 
   organization
@@ -66,6 +66,10 @@ module org-openroadm-link {
      ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
      POSSIBILITY OF SUCH DAMAGE.";
 
+  revision 2025-01-10 {
+    description
+      "Version 13.1.1";
+  }
   revision 2023-05-26 {
     description
       "Version 13.1";

--- a/model/Network/org-openroadm-network-topology-types.yang
+++ b/model/Network/org-openroadm-network-topology-types.yang
@@ -17,7 +17,7 @@ module org-openroadm-network-topology-types {
   }
   import org-openroadm-port-types {
     prefix org-openroadm-port-types;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
 
   organization
@@ -51,6 +51,10 @@ module org-openroadm-network-topology-types {
      ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
      POSSIBILITY OF SUCH DAMAGE.";
 
+  revision 2025-01-10 {
+    description
+      "Version 13.1.1";
+  }
   revision 2023-05-26 {
     description
       "Version 13.1";

--- a/model/Network/org-openroadm-network-topology.yang
+++ b/model/Network/org-openroadm-network-topology.yang
@@ -13,7 +13,7 @@ module org-openroadm-network-topology {
   }
   import org-openroadm-network-types {
     prefix org-openroadm-network-types;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-srg {
     prefix srg;
@@ -21,11 +21,11 @@ module org-openroadm-network-topology {
   }
   import org-openroadm-degree {
     prefix dgr;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-xponder {
     prefix xpdr;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-external-pluggable {
     prefix plg;
@@ -33,11 +33,11 @@ module org-openroadm-network-topology {
   }
   import org-openroadm-link {
     prefix link;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-common-network {
     prefix cnet;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
 
   organization
@@ -73,6 +73,10 @@ module org-openroadm-network-topology {
      ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
      POSSIBILITY OF SUCH DAMAGE.";
 
+  revision 2025-01-10 {
+    description
+      "Version 13.1.1";
+  }
   revision 2023-05-26 {
     description
       "Version 13.1";

--- a/model/Network/org-openroadm-network-topology.yang
+++ b/model/Network/org-openroadm-network-topology.yang
@@ -17,7 +17,7 @@ module org-openroadm-network-topology {
   }
   import org-openroadm-srg {
     prefix srg;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-degree {
     prefix dgr;
@@ -29,7 +29,7 @@ module org-openroadm-network-topology {
   }
   import org-openroadm-external-pluggable {
     prefix plg;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-link {
     prefix link;

--- a/model/Network/org-openroadm-network-types.yang
+++ b/model/Network/org-openroadm-network-types.yang
@@ -9,11 +9,11 @@ module org-openroadm-network-types {
   }
   import org-openroadm-common-optical-channel-types {
     prefix org-openroadm-common-optical-channel-types;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-port-types {
     prefix org-openroadm-port-types;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-common-types {
     prefix org-openroadm-common-types;

--- a/model/Network/org-openroadm-network-types.yang
+++ b/model/Network/org-openroadm-network-types.yang
@@ -17,7 +17,7 @@ module org-openroadm-network-types {
   }
   import org-openroadm-common-types {
     prefix org-openroadm-common-types;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-common-node-types {
     prefix org-openroadm-common-node-types;
@@ -55,6 +55,10 @@ module org-openroadm-network-types {
      ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
      POSSIBILITY OF SUCH DAMAGE.";
 
+  revision 2025-01-10 {
+    description
+      "Version 13.1.1";
+  }
   revision 2023-05-26 {
     description
       "Version 13.1";

--- a/model/Network/org-openroadm-network.yang
+++ b/model/Network/org-openroadm-network.yang
@@ -9,7 +9,7 @@ module org-openroadm-network {
   }
   import org-openroadm-network-types {
     prefix nt;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-roadm {
     prefix roadm;
@@ -21,7 +21,7 @@ module org-openroadm-network {
   }
   import org-openroadm-xponder {
     prefix xpdr;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import ietf-inet-types {
     prefix inet;
@@ -29,11 +29,11 @@ module org-openroadm-network {
   }
   import org-openroadm-common-types {
     prefix org-openroadm-common-types;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-common-network {
     prefix cnet;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
 
   organization
@@ -67,6 +67,10 @@ module org-openroadm-network {
      ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
      POSSIBILITY OF SUCH DAMAGE.";
 
+  revision 2025-01-10 {
+    description
+      "Version 13.1.1";
+  }
   revision 2023-05-26 {
     description
       "Version 13.1";

--- a/model/Network/org-openroadm-network.yang
+++ b/model/Network/org-openroadm-network.yang
@@ -17,7 +17,7 @@ module org-openroadm-network {
   }
   import org-openroadm-external-pluggable {
     prefix plg;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-xponder {
     prefix xpdr;

--- a/model/Network/org-openroadm-otn-network-topology.yang
+++ b/model/Network/org-openroadm-otn-network-topology.yang
@@ -13,7 +13,7 @@ module org-openroadm-otn-network-topology {
   }
   import org-openroadm-network-types {
     prefix org-openroadm-network-types;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-network-topology-types {
     prefix org-openroadm-network-topology-types;
@@ -21,11 +21,11 @@ module org-openroadm-otn-network-topology {
   }
   import org-openroadm-xponder {
     prefix xpdr;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-common-network {
     prefix cnet;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
 
   organization
@@ -61,6 +61,10 @@ module org-openroadm-otn-network-topology {
      ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
      POSSIBILITY OF SUCH DAMAGE.";
 
+  revision 2025-01-10 {
+    description
+      "Version 13.1.1";
+  }
   revision 2023-05-26 {
     description
       "Version 13.1";

--- a/model/Network/org-openroadm-otn-network-topology.yang
+++ b/model/Network/org-openroadm-otn-network-topology.yang
@@ -17,7 +17,7 @@ module org-openroadm-otn-network-topology {
   }
   import org-openroadm-network-topology-types {
     prefix org-openroadm-network-topology-types;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-xponder {
     prefix xpdr;

--- a/model/Network/org-openroadm-srg.yang
+++ b/model/Network/org-openroadm-srg.yang
@@ -5,7 +5,7 @@ module org-openroadm-srg {
 
   import org-openroadm-common-optical-channel-types {
     prefix org-openroadm-common-optical-channel-types;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
 
   organization
@@ -41,6 +41,10 @@ module org-openroadm-srg {
      ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
      POSSIBILITY OF SUCH DAMAGE.";
 
+  revision 2025-01-10 {
+    description
+      "Version 13.1.1";
+  }
   revision 2023-05-26 {
     description
       "Version 13.1";

--- a/model/Network/org-openroadm-xponder.yang
+++ b/model/Network/org-openroadm-xponder.yang
@@ -5,7 +5,7 @@ module org-openroadm-xponder {
 
   import org-openroadm-network-types {
     prefix org-openroadm-network-types;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-common-equipment-types {
     prefix org-openroadm-common-equipment-types;
@@ -61,6 +61,10 @@ module org-openroadm-xponder {
      ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
      POSSIBILITY OF SUCH DAMAGE.";
 
+  revision 2025-01-10 {
+    description
+      "Version 13.1.1";
+  }
   revision 2023-05-26 {
     description
       "Version 13.1";

--- a/model/Network/org-openroadm-xponder.yang
+++ b/model/Network/org-openroadm-xponder.yang
@@ -17,11 +17,11 @@ module org-openroadm-xponder {
   }
   import org-openroadm-common-optical-channel-types {
     prefix org-openroadm-common-optical-channel-types;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-otn-common-types {
     prefix org-openroadm-otn-common-types;
-    revision-date 2021-09-24;
+    revision-date 2025-01-10;
   }
   import org-openroadm-service-format {
     prefix org-openroadm-service-format;

--- a/model/Network/tree-view-network-full.txt
+++ b/model/Network/tree-view-network-full.txt
@@ -3,11 +3,11 @@ module: ietf-network
      +--rw network* [network-id]
         +--rw network-id            network-id
         +--rw network-types
-        |  +--rw cn:clli-network!
         |  +--rw cnet:openroadm-common-network!
-        |     +--rw topo:openroadm-topology!
-        |     +--rw net:openroadm-network!
-        |     +--rw otn-topo:otn-topology!
+        |  |  +--rw net:openroadm-network!
+        |  |  +--rw topo:openroadm-topology!
+        |  |  +--rw otn-topo:otn-topology!
+        |  +--rw cn:clli-network!
         +--rw supporting-network* [network-ref]
         |  +--rw network-ref    -> /networks/network/network-id
         +--rw node* [node-id]
@@ -184,36 +184,6 @@ module: ietf-network
         |  +--rw cnet:lifecycle-state?            org-openroadm-common-state-types:lifecycle-state
         |  +--rw cnet:operational-state?          org-openroadm-common-state-types:state
         |  +--rw cnet:administrative-state?       org-openroadm-equipment-states-types:admin-states
-        |  +--rw topo:srg-attributes
-        |  |  +--rw topo:srg-number?                    uint16
-        |  |  +--rw topo:max-pp?                        uint32
-        |  |  +--rw topo:current-provisioned-pp?        uint32
-        |  |  +--rw topo:wavelength-duplication?        org-openroadm-common-optical-channel-types:wavelength-duplication-type
-        |  |  +--rw topo:supported-operational-modes*   string
-        |  |  +--rw topo:avail-freq-maps* [map-name]
-        |  |  |  +--rw topo:map-name                string
-        |  |  |  +--rw topo:start-edge-freq?        org-openroadm-common-optical-channel-types:frequency-THz
-        |  |  |  +--rw topo:freq-map-granularity?   org-openroadm-common-optical-channel-types:frequency-GHz
-        |  |  |  +--rw topo:effective-bits?         uint16
-        |  |  |  +--rw topo:freq-map?               binary
-        |  |  +--rw topo:type-variety?                  string
-        |  +--rw topo:degree-attributes
-        |  |  +--rw topo:degree-number?                    uint16
-        |  |  +--rw topo:max-wavelengths?                  uint32
-        |  |  +--rw topo:ingress-span-loss-aging-margin?   org-openroadm-common-link-types:ratio-dB
-        |  |  +--rw topo:eol-max-load-pIn?                 org-openroadm-common-link-types:power-dBm
-        |  |  +--rw topo:egress-average-channel-power?     org-openroadm-common-link-types:power-dBm
-        |  |  +--rw topo:supported-operational-modes*      string
-        |  |  +--rw topo:avail-freq-maps* [map-name]
-        |  |  |  +--rw topo:map-name                string
-        |  |  |  +--rw topo:start-edge-freq?        org-openroadm-common-optical-channel-types:frequency-THz
-        |  |  |  +--rw topo:freq-map-granularity?   org-openroadm-common-optical-channel-types:frequency-GHz
-        |  |  |  +--rw topo:effective-bits?         uint16
-        |  |  |  +--rw topo:freq-map?               binary
-        |  |  +--rw topo:type-variety?                     string
-        |  +--rw topo:xpdr-attributes
-        |  |  +--rw topo:xpdr-number?   uint16
-        |  |  +--rw topo:recolor?       boolean
         |  +--rw net:software-version?            string
         |  +--rw net:openroadm-version?           org-openroadm-common-types:openroadm-version-type
         |  +--rw net:vendor?                      string
@@ -257,6 +227,37 @@ module: ietf-network
         |  |     +--rw net:id            uint16
         |  |     +--rw net:start-date?   yang:date-and-time
         |  |     +--rw net:end-date?     yang:date-and-time
+        |  +--rw cn:clli?                         string
+        |  +--rw topo:srg-attributes
+        |  |  +--rw topo:srg-number?                    uint16
+        |  |  +--rw topo:max-pp?                        uint32
+        |  |  +--rw topo:current-provisioned-pp?        uint32
+        |  |  +--rw topo:wavelength-duplication?        org-openroadm-common-optical-channel-types:wavelength-duplication-type
+        |  |  +--rw topo:supported-operational-modes*   string
+        |  |  +--rw topo:avail-freq-maps* [map-name]
+        |  |  |  +--rw topo:map-name                string
+        |  |  |  +--rw topo:start-edge-freq?        org-openroadm-common-optical-channel-types:frequency-THz
+        |  |  |  +--rw topo:freq-map-granularity?   org-openroadm-common-optical-channel-types:frequency-GHz
+        |  |  |  +--rw topo:effective-bits?         uint16
+        |  |  |  +--rw topo:freq-map?               binary
+        |  |  +--rw topo:type-variety?                  string
+        |  +--rw topo:degree-attributes
+        |  |  +--rw topo:degree-number?                    uint16
+        |  |  +--rw topo:max-wavelengths?                  uint32
+        |  |  +--rw topo:ingress-span-loss-aging-margin?   org-openroadm-common-link-types:ratio-dB
+        |  |  +--rw topo:eol-max-load-pIn?                 org-openroadm-common-link-types:power-dBm
+        |  |  +--rw topo:egress-average-channel-power?     org-openroadm-common-link-types:power-dBm
+        |  |  +--rw topo:supported-operational-modes*      string
+        |  |  +--rw topo:avail-freq-maps* [map-name]
+        |  |  |  +--rw topo:map-name                string
+        |  |  |  +--rw topo:start-edge-freq?        org-openroadm-common-optical-channel-types:frequency-THz
+        |  |  |  +--rw topo:freq-map-granularity?   org-openroadm-common-optical-channel-types:frequency-GHz
+        |  |  |  +--rw topo:effective-bits?         uint16
+        |  |  |  +--rw topo:freq-map?               binary
+        |  |  +--rw topo:type-variety?                     string
+        |  +--rw topo:xpdr-attributes
+        |  |  +--rw topo:xpdr-number?   uint16
+        |  |  +--rw topo:recolor?       boolean
         |  +--rw otn-topo:tp-bandwidth-sharing
         |  |  +--rw otn-topo:tp-bandwidth-sharing* [tp-sharing-id]
         |  |     +--rw otn-topo:tp-sharing-id         uint16
@@ -372,3 +373,4 @@ module: ietf-network
            +--rw cnet:SRLG-name?     string
            +--rw cnet:SRLG-type?     org-openroadm-common-types:SRLG-type
            +--rw cnet:SRLG-length?   decimal64
+

--- a/model/Network/tree-view-network-full.txt
+++ b/model/Network/tree-view-network-full.txt
@@ -15,6 +15,7 @@ module: ietf-network
         |  +--rw supporting-node* [network-ref node-ref]
         |  |  +--rw network-ref    -> ../../../supporting-network/network-ref
         |  |  +--rw node-ref       -> /networks/network/node/node-id
+        |  +--rw cn:clli?                         string
         |  +--rw nt:termination-point* [tp-id]
         |  |  +--rw nt:tp-id                                       tp-id
         |  |  +--rw nt:supporting-termination-point* [network-ref node-ref tp-ref]
@@ -178,7 +179,6 @@ module: ietf-network
         |  |     +--rw otn-topo:service-format?                  org-openroadm-service-format:service-format
         |  |     +--rw otn-topo:service-rate?                    uint32
         |  |     +--rw otn-topo:other-service-format-and-rate?   string
-        |  +--rw cn:clli?                         string
         |  +--rw cnet:node-type?                  org-openroadm-network-types:openroadm-node-type
         |  +--rw cnet:node-subtype?               org-openroadm-common-node-types:node-subtypes
         |  +--rw cnet:lifecycle-state?            org-openroadm-common-state-types:lifecycle-state

--- a/model/Network/tree-view-network-full.txt
+++ b/model/Network/tree-view-network-full.txt
@@ -3,11 +3,11 @@ module: ietf-network
      +--rw network* [network-id]
         +--rw network-id            network-id
         +--rw network-types
-        |  +--rw cnet:openroadm-common-network!
-        |  |  +--rw net:openroadm-network!
-        |  |  +--rw topo:openroadm-topology!
-        |  |  +--rw otn-topo:otn-topology!
         |  +--rw cn:clli-network!
+        |  +--rw cnet:openroadm-common-network!
+        |     +--rw topo:openroadm-topology!
+        |     +--rw net:openroadm-network!
+        |     +--rw otn-topo:otn-topology!
         +--rw supporting-network* [network-ref]
         |  +--rw network-ref    -> /networks/network/network-id
         +--rw node* [node-id]
@@ -15,6 +15,7 @@ module: ietf-network
         |  +--rw supporting-node* [network-ref node-ref]
         |  |  +--rw network-ref    -> ../../../supporting-network/network-ref
         |  |  +--rw node-ref       -> /networks/network/node/node-id
+        |  +--rw cn:clli?                         string
         |  +--rw nt:termination-point* [tp-id]
         |  |  +--rw nt:tp-id                                       tp-id
         |  |  +--rw nt:supporting-termination-point* [network-ref node-ref tp-ref]
@@ -178,12 +179,41 @@ module: ietf-network
         |  |     +--rw otn-topo:service-format?                  org-openroadm-service-format:service-format
         |  |     +--rw otn-topo:service-rate?                    uint32
         |  |     +--rw otn-topo:other-service-format-and-rate?   string
-        |  +--rw cn:clli?                         string
         |  +--rw cnet:node-type?                  org-openroadm-network-types:openroadm-node-type
         |  +--rw cnet:node-subtype?               org-openroadm-common-node-types:node-subtypes
         |  +--rw cnet:lifecycle-state?            org-openroadm-common-state-types:lifecycle-state
         |  +--rw cnet:operational-state?          org-openroadm-common-state-types:state
         |  +--rw cnet:administrative-state?       org-openroadm-equipment-states-types:admin-states
+        |  +--rw topo:srg-attributes
+        |  |  +--rw topo:srg-number?                    uint16
+        |  |  +--rw topo:max-pp?                        uint32
+        |  |  +--rw topo:current-provisioned-pp?        uint32
+        |  |  +--rw topo:wavelength-duplication?        org-openroadm-common-optical-channel-types:wavelength-duplication-type
+        |  |  +--rw topo:supported-operational-modes*   string
+        |  |  +--rw topo:avail-freq-maps* [map-name]
+        |  |  |  +--rw topo:map-name                string
+        |  |  |  +--rw topo:start-edge-freq?        org-openroadm-common-optical-channel-types:frequency-THz
+        |  |  |  +--rw topo:freq-map-granularity?   org-openroadm-common-optical-channel-types:frequency-GHz
+        |  |  |  +--rw topo:effective-bits?         uint16
+        |  |  |  +--rw topo:freq-map?               binary
+        |  |  +--rw topo:type-variety?                  string
+        |  +--rw topo:degree-attributes
+        |  |  +--rw topo:degree-number?                    uint16
+        |  |  +--rw topo:max-wavelengths?                  uint32
+        |  |  +--rw topo:ingress-span-loss-aging-margin?   org-openroadm-common-link-types:ratio-dB
+        |  |  +--rw topo:eol-max-load-pIn?                 org-openroadm-common-link-types:power-dBm
+        |  |  +--rw topo:egress-average-channel-power?     org-openroadm-common-link-types:power-dBm
+        |  |  +--rw topo:supported-operational-modes*      string
+        |  |  +--rw topo:avail-freq-maps* [map-name]
+        |  |  |  +--rw topo:map-name                string
+        |  |  |  +--rw topo:start-edge-freq?        org-openroadm-common-optical-channel-types:frequency-THz
+        |  |  |  +--rw topo:freq-map-granularity?   org-openroadm-common-optical-channel-types:frequency-GHz
+        |  |  |  +--rw topo:effective-bits?         uint16
+        |  |  |  +--rw topo:freq-map?               binary
+        |  |  +--rw topo:type-variety?                     string
+        |  +--rw topo:xpdr-attributes
+        |  |  +--rw topo:xpdr-number?   uint16
+        |  |  +--rw topo:recolor?       boolean
         |  +--rw net:software-version?            string
         |  +--rw net:openroadm-version?           org-openroadm-common-types:openroadm-version-type
         |  +--rw net:vendor?                      string
@@ -227,37 +257,6 @@ module: ietf-network
         |  |     +--rw net:id            uint16
         |  |     +--rw net:start-date?   yang:date-and-time
         |  |     +--rw net:end-date?     yang:date-and-time
-        |  +--rw cn:clli?                         string
-        |  +--rw topo:srg-attributes
-        |  |  +--rw topo:srg-number?                    uint16
-        |  |  +--rw topo:max-pp?                        uint32
-        |  |  +--rw topo:current-provisioned-pp?        uint32
-        |  |  +--rw topo:wavelength-duplication?        org-openroadm-common-optical-channel-types:wavelength-duplication-type
-        |  |  +--rw topo:supported-operational-modes*   string
-        |  |  +--rw topo:avail-freq-maps* [map-name]
-        |  |  |  +--rw topo:map-name                string
-        |  |  |  +--rw topo:start-edge-freq?        org-openroadm-common-optical-channel-types:frequency-THz
-        |  |  |  +--rw topo:freq-map-granularity?   org-openroadm-common-optical-channel-types:frequency-GHz
-        |  |  |  +--rw topo:effective-bits?         uint16
-        |  |  |  +--rw topo:freq-map?               binary
-        |  |  +--rw topo:type-variety?                  string
-        |  +--rw topo:degree-attributes
-        |  |  +--rw topo:degree-number?                    uint16
-        |  |  +--rw topo:max-wavelengths?                  uint32
-        |  |  +--rw topo:ingress-span-loss-aging-margin?   org-openroadm-common-link-types:ratio-dB
-        |  |  +--rw topo:eol-max-load-pIn?                 org-openroadm-common-link-types:power-dBm
-        |  |  +--rw topo:egress-average-channel-power?     org-openroadm-common-link-types:power-dBm
-        |  |  +--rw topo:supported-operational-modes*      string
-        |  |  +--rw topo:avail-freq-maps* [map-name]
-        |  |  |  +--rw topo:map-name                string
-        |  |  |  +--rw topo:start-edge-freq?        org-openroadm-common-optical-channel-types:frequency-THz
-        |  |  |  +--rw topo:freq-map-granularity?   org-openroadm-common-optical-channel-types:frequency-GHz
-        |  |  |  +--rw topo:effective-bits?         uint16
-        |  |  |  +--rw topo:freq-map?               binary
-        |  |  +--rw topo:type-variety?                     string
-        |  +--rw topo:xpdr-attributes
-        |  |  +--rw topo:xpdr-number?   uint16
-        |  |  +--rw topo:recolor?       boolean
         |  +--rw otn-topo:tp-bandwidth-sharing
         |  |  +--rw otn-topo:tp-bandwidth-sharing* [tp-sharing-id]
         |  |     +--rw otn-topo:tp-sharing-id         uint16
@@ -373,4 +372,3 @@ module: ietf-network
            +--rw cnet:SRLG-name?     string
            +--rw cnet:SRLG-type?     org-openroadm-common-types:SRLG-type
            +--rw cnet:SRLG-length?   decimal64
-

--- a/model/Network/tree-view-network-full.txt
+++ b/model/Network/tree-view-network-full.txt
@@ -15,7 +15,6 @@ module: ietf-network
         |  +--rw supporting-node* [network-ref node-ref]
         |  |  +--rw network-ref    -> ../../../supporting-network/network-ref
         |  |  +--rw node-ref       -> /networks/network/node/node-id
-        |  +--rw cn:clli?                         string
         |  +--rw nt:termination-point* [tp-id]
         |  |  +--rw nt:tp-id                                       tp-id
         |  |  +--rw nt:supporting-termination-point* [network-ref node-ref tp-ref]
@@ -179,6 +178,7 @@ module: ietf-network
         |  |     +--rw otn-topo:service-format?                  org-openroadm-service-format:service-format
         |  |     +--rw otn-topo:service-rate?                    uint32
         |  |     +--rw otn-topo:other-service-format-and-rate?   string
+        |  +--rw cn:clli?                         string
         |  +--rw cnet:node-type?                  org-openroadm-network-types:openroadm-node-type
         |  +--rw cnet:node-subtype?               org-openroadm-common-node-types:node-subtypes
         |  +--rw cnet:lifecycle-state?            org-openroadm-common-state-types:lifecycle-state

--- a/model/Network/tree-view-network.txt
+++ b/model/Network/tree-view-network.txt
@@ -9,8 +9,8 @@ module: org-openroadm-common-network
 
   augment /nd:networks/nd:network/nd:network-types:
     +--rw openroadm-common-network!
-       +--rw net:openroadm-network!
        +--rw topo:openroadm-topology!
+       +--rw net:openroadm-network!
        +--rw otn-topo:otn-topology!
   augment /nd:networks/nd:network:
     +--rw SRLG-list* [SRLG-Id]

--- a/model/Network/tree-view-network.txt
+++ b/model/Network/tree-view-network.txt
@@ -9,8 +9,8 @@ module: org-openroadm-common-network
 
   augment /nd:networks/nd:network/nd:network-types:
     +--rw openroadm-common-network!
-       +--rw topo:openroadm-topology!
        +--rw net:openroadm-network!
+       +--rw topo:openroadm-topology!
        +--rw otn-topo:otn-topology!
   augment /nd:networks/nd:network:
     +--rw SRLG-list* [SRLG-Id]

--- a/model/Network/tree-view-network.txt
+++ b/model/Network/tree-view-network.txt
@@ -1,11 +1,12 @@
-
 module: org-openroadm-clli-network
+
   augment /nd:networks/nd:network/nd:network-types:
     +--rw clli-network!
   augment /nd:networks/nd:network/nd:node:
     +--rw clli?   string
 
 module: org-openroadm-common-network
+
   augment /nd:networks/nd:network/nd:network-types:
     +--rw openroadm-common-network!
        +--rw topo:openroadm-topology!
@@ -52,6 +53,7 @@ module: org-openroadm-common-network
     +--rw lifecycle-state?        org-openroadm-common-state-types:lifecycle-state
 
 module: org-openroadm-network-topology
+
   augment /nd:networks/nd:network/nd:node:
     +--rw srg-attributes
     |  +--rw srg-number?                    uint16
@@ -264,6 +266,7 @@ module: org-openroadm-network-topology
                          +--rw administrative-state?     org-openroadm-equipment-states-types:admin-states
 
 module: org-openroadm-network
+
   augment /nd:networks/nd:network/nd:node:
     +--rw software-version?            string
     +--rw openroadm-version?           org-openroadm-common-types:openroadm-version-type
@@ -310,6 +313,7 @@ module: org-openroadm-network
           +--rw end-date?     yang:date-and-time
 
 module: org-openroadm-otn-network-topology
+
   augment /nd:networks/nd:network/nd:node:
     +--rw tp-bandwidth-sharing
     |  +--rw tp-bandwidth-sharing* [tp-sharing-id]
@@ -367,3 +371,4 @@ module: org-openroadm-otn-network-topology
     +--rw available-bandwidth?   uint32
     +--rw used-bandwidth?        uint32
     +--rw ODU-protected?         boolean
+

--- a/model/Service/org-openroadm-ber-test.yang
+++ b/model/Service/org-openroadm-ber-test.yang
@@ -4,7 +4,7 @@ module org-openroadm-ber-test {
 
   import org-openroadm-common-service-types {
     prefix org-openroadm-common-service-types;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-common-ber-test {
     prefix org-openroadm-common-ber-test;
@@ -48,6 +48,10 @@ module org-openroadm-ber-test {
       ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
       POSSIBILITY OF SUCH DAMAGE";
 
+  revision 2025-01-10 {
+    description
+      "Version 13.1.1";
+  }
   revision 2023-05-26 {
     description
       "Version 13.1";

--- a/model/Service/org-openroadm-common-service-types.yang
+++ b/model/Service/org-openroadm-common-service-types.yang
@@ -40,7 +40,7 @@ module org-openroadm-common-service-types {
   }
   import org-openroadm-common-types {
     prefix org-openroadm-common-types;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-equipment-states-types {
     prefix org-openroadm-equipment-states-types;
@@ -105,6 +105,10 @@ module org-openroadm-common-service-types {
       ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
       POSSIBILITY OF SUCH DAMAGE";
 
+  revision 2025-01-10 {
+    description
+      "Version 13.1.1";
+  }
   revision 2023-05-26 {
     description
       "Version 13.1";

--- a/model/Service/org-openroadm-common-service-types.yang
+++ b/model/Service/org-openroadm-common-service-types.yang
@@ -32,7 +32,7 @@ module org-openroadm-common-service-types {
   }
   import org-openroadm-resource-types {
     prefix org-openroadm-resource-types;
-    revision-date 2022-03-25;
+    revision-date 2025-01-10;
   }
   import org-openroadm-otn-common-types {
     prefix org-openroadm-otn-common-types;

--- a/model/Service/org-openroadm-common-service-types.yang
+++ b/model/Service/org-openroadm-common-service-types.yang
@@ -56,7 +56,7 @@ module org-openroadm-common-service-types {
   }
   import org-openroadm-common-phy-codes {
     prefix org-openroadm-common-phy-codes;
-    revision-date 2022-05-27;
+    revision-date 2025-01-10;
   }
   import org-openroadm-common-optical-channel-types {
     prefix org-openroadm-common-optical-channel-types;

--- a/model/Service/org-openroadm-common-service-types.yang
+++ b/model/Service/org-openroadm-common-service-types.yang
@@ -16,7 +16,7 @@ module org-openroadm-common-service-types {
   }
   import org-openroadm-topology {
     prefix org-openroadm-topology;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-common-equipment-types {
     prefix org-openroadm-common-equipment-types;
@@ -36,7 +36,7 @@ module org-openroadm-common-service-types {
   }
   import org-openroadm-otn-common-types {
     prefix org-openroadm-otn-common-types;
-    revision-date 2021-09-24;
+    revision-date 2025-01-10;
   }
   import org-openroadm-common-types {
     prefix org-openroadm-common-types;
@@ -52,7 +52,7 @@ module org-openroadm-common-service-types {
   }
   import org-openroadm-common-attributes {
     prefix org-openroadm-common-attributes;
-    revision-date 2021-09-24;
+    revision-date 2025-01-10;
   }
   import org-openroadm-common-phy-codes {
     prefix org-openroadm-common-phy-codes;
@@ -60,7 +60,7 @@ module org-openroadm-common-service-types {
   }
   import org-openroadm-common-optical-channel-types {
     prefix org-openroadm-common-optical-channel-types;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-common-link-types {
     prefix org-openroadm-common-link-types;
@@ -68,7 +68,7 @@ module org-openroadm-common-service-types {
   }
   import org-openroadm-resource {
     prefix org-openroadm-resource;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
 
 

--- a/model/Service/org-openroadm-controller-customization.yang
+++ b/model/Service/org-openroadm-controller-customization.yang
@@ -17,7 +17,7 @@ module org-openroadm-controller-customization {
   }
   import org-openroadm-common-optical-channel-types {
     prefix org-openroadm-common-optical-channel-types;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
 
   organization

--- a/model/Service/org-openroadm-controller-customization.yang
+++ b/model/Service/org-openroadm-controller-customization.yang
@@ -13,7 +13,7 @@ module org-openroadm-controller-customization {
   }
   import org-openroadm-common-service-types {
     prefix org-openroadm-common-service-types;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-common-optical-channel-types {
     prefix org-openroadm-common-optical-channel-types;
@@ -53,6 +53,10 @@ module org-openroadm-controller-customization {
       ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
       POSSIBILITY OF SUCH DAMAGE";
 
+  revision 2025-01-10 {
+    description
+      "Version 13.1.1";
+  }
   revision 2023-05-26 {
     description
       "Version 13.1";

--- a/model/Service/org-openroadm-operational-mode-catalog.yang
+++ b/model/Service/org-openroadm-operational-mode-catalog.yang
@@ -12,7 +12,7 @@ module org-openroadm-operational-mode-catalog {
   }
   import org-openroadm-common-types {
     prefix org-openroadm-common-types;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
 
   organization
@@ -48,6 +48,10 @@ module org-openroadm-operational-mode-catalog {
       ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
       POSSIBILITY OF SUCH DAMAGE";
 
+  revision 2025-01-10 {
+    description
+      "Version 13.1.1";
+  }
   revision 2023-05-26 {
     description
       "Version 13.1";

--- a/model/Service/org-openroadm-operational-mode-catalog.yang
+++ b/model/Service/org-openroadm-operational-mode-catalog.yang
@@ -4,7 +4,7 @@ module org-openroadm-operational-mode-catalog {
 
   import org-openroadm-common-optical-channel-types {
     prefix org-openroadm-common-optical-channel-types;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-common-link-types {
     prefix org-openroadm-common-link-types;

--- a/model/Service/org-openroadm-service.yang
+++ b/model/Service/org-openroadm-service.yang
@@ -13,7 +13,7 @@ module org-openroadm-service {
   }
   import org-openroadm-common-types {
     prefix org-openroadm-common-types;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-resource-types {
     prefix org-openroadm-resource-types;
@@ -25,11 +25,11 @@ module org-openroadm-service {
   }
   import org-openroadm-common-service-types {
     prefix org-openroadm-common-service-types;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-controller-customization {
     prefix org-openroadm-controller-customization;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-topology {
     prefix org-openroadm-topology;
@@ -37,7 +37,7 @@ module org-openroadm-service {
   }
   import org-openroadm-operational-mode-catalog {
     prefix org-openroadm-operational-mode-catalog;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-common-optical-channel-types {
     prefix org-openroadm-common-optical-channel-types;
@@ -81,6 +81,10 @@ module org-openroadm-service {
       ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
       POSSIBILITY OF SUCH DAMAGE";
 
+  revision 2025-01-10 {
+    description
+      "Version 13.1.1";
+  }
   revision 2023-05-26 {
     description
       "Version 13.1";

--- a/model/Service/org-openroadm-service.yang
+++ b/model/Service/org-openroadm-service.yang
@@ -21,7 +21,7 @@ module org-openroadm-service {
   }
   import org-openroadm-resource {
     prefix org-openroadm-resource;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-common-service-types {
     prefix org-openroadm-common-service-types;
@@ -33,7 +33,7 @@ module org-openroadm-service {
   }
   import org-openroadm-topology {
     prefix org-openroadm-topology;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-operational-mode-catalog {
     prefix org-openroadm-operational-mode-catalog;
@@ -41,7 +41,7 @@ module org-openroadm-service {
   }
   import org-openroadm-common-optical-channel-types {
     prefix org-openroadm-common-optical-channel-types;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-common-link-types {
     prefix org-openroadm-common-link-types;

--- a/model/Service/org-openroadm-service.yang
+++ b/model/Service/org-openroadm-service.yang
@@ -17,7 +17,7 @@ module org-openroadm-service {
   }
   import org-openroadm-resource-types {
     prefix org-openroadm-resource-types;
-    revision-date 2022-03-25;
+    revision-date 2025-01-10;
   }
   import org-openroadm-resource {
     prefix org-openroadm-resource;

--- a/model/Service/org-openroadm-topology.yang
+++ b/model/Service/org-openroadm-topology.yang
@@ -4,7 +4,7 @@ module org-openroadm-topology {
 
   import org-openroadm-resource {
     prefix org-openroadm-resource;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
   import org-openroadm-network-resource {
     prefix org-openroadm-network-resource;
@@ -12,7 +12,7 @@ module org-openroadm-topology {
   }
   import org-openroadm-port-types {
     prefix org-openroadm-port-types;
-    revision-date 2023-05-26;
+    revision-date 2025-01-10;
   }
 
   organization
@@ -48,6 +48,10 @@ module org-openroadm-topology {
       ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
       POSSIBILITY OF SUCH DAMAGE";
 
+  revision 2025-01-10 {
+    description
+      "Version 13.1.1";
+  }
   revision 2023-05-26 {
     description
       "Version 13.1";

--- a/model/Service/tree-view-service.txt
+++ b/model/Service/tree-view-service.txt
@@ -277,6 +277,7 @@ module: org-openroadm-ber-test
                 +--ro ber-passed?            boolean
                 +--ro target-prefec-ber?     decimal64
                 +--ro measured-prefec-ber?   decimal64
+
 module: org-openroadm-controller-customization
 
   rpcs:
@@ -376,6 +377,7 @@ module: org-openroadm-controller-customization
           |  +--ro response-message?      string
           |  +--ro ack-final-indicator    string
           +--ro unsupported-customization-options*   string
+
 module: org-openroadm-service
   +--rw service-list
   |  +--rw services* [service-name]
@@ -12460,3 +12462,4 @@ module: org-openroadm-service
        +--ro impacted-resource-type?   string
        +--ro impacted-resource-id?     string
        +--ro topology-layer?           enumeration
+

--- a/model/Service/tree-view-service.txt
+++ b/model/Service/tree-view-service.txt
@@ -901,7 +901,15 @@ module: org-openroadm-service
   |     |  |  |     |  +--rw versioned-service-name       string
   |     |  |  |     |  +--rw version-number               uint64
   |     |  |  |     +--:(temp-service)
-  |     |  |  |        +--rw common-id                    string
+  |     |  |  |     |  +--rw common-id                    string
+  |     |  |  |     +--:(slot)
+  |     |  |  |     |  +--rw slot
+  |     |  |  |     |     +--rw shelf-name    string
+  |     |  |  |     |     +--rw slot-name     string
+  |     |  |  |     +--:(cp-slot)
+  |     |  |  |        +--rw cp-slot
+  |     |  |  |           +--rw circuit-pack-name    string
+  |     |  |  |           +--rw slot-name            string
   |     |  |  +--rw resourceType
   |     |  |     +--rw type         resource-type-enum
   |     |  |     +--rw extension?   string
@@ -1008,7 +1016,15 @@ module: org-openroadm-service
   |     |     |     |  +--rw versioned-service-name       string
   |     |     |     |  +--rw version-number               uint64
   |     |     |     +--:(temp-service)
-  |     |     |        +--rw common-id                    string
+  |     |     |     |  +--rw common-id                    string
+  |     |     |     +--:(slot)
+  |     |     |     |  +--rw slot
+  |     |     |     |     +--rw shelf-name    string
+  |     |     |     |     +--rw slot-name     string
+  |     |     |     +--:(cp-slot)
+  |     |     |        +--rw cp-slot
+  |     |     |           +--rw circuit-pack-name    string
+  |     |     |           +--rw slot-name            string
   |     |     +--rw resourceType
   |     |        +--rw type         resource-type-enum
   |     |        +--rw extension?   string
@@ -1119,7 +1135,15 @@ module: org-openroadm-service
   |     |     |  |     |  +--rw versioned-service-name       string
   |     |     |  |     |  +--rw version-number               uint64
   |     |     |  |     +--:(temp-service)
-  |     |     |  |        +--rw common-id                    string
+  |     |     |  |     |  +--rw common-id                    string
+  |     |     |  |     +--:(slot)
+  |     |     |  |     |  +--rw slot
+  |     |     |  |     |     +--rw shelf-name    string
+  |     |     |  |     |     +--rw slot-name     string
+  |     |     |  |     +--:(cp-slot)
+  |     |     |  |        +--rw cp-slot
+  |     |     |  |           +--rw circuit-pack-name    string
+  |     |     |  |           +--rw slot-name            string
   |     |     |  +--rw resourceType
   |     |     |     +--rw type         resource-type-enum
   |     |     |     +--rw extension?   string
@@ -1226,7 +1250,15 @@ module: org-openroadm-service
   |     |        |     |  +--rw versioned-service-name       string
   |     |        |     |  +--rw version-number               uint64
   |     |        |     +--:(temp-service)
-  |     |        |        +--rw common-id                    string
+  |     |        |     |  +--rw common-id                    string
+  |     |        |     +--:(slot)
+  |     |        |     |  +--rw slot
+  |     |        |     |     +--rw shelf-name    string
+  |     |        |     |     +--rw slot-name     string
+  |     |        |     +--:(cp-slot)
+  |     |        |        +--rw cp-slot
+  |     |        |           +--rw circuit-pack-name    string
+  |     |        |           +--rw slot-name            string
   |     |        +--rw resourceType
   |     |           +--rw type         resource-type-enum
   |     |           +--rw extension?   string
@@ -1815,7 +1847,15 @@ module: org-openroadm-service
   |     |  |  |     |  +--rw versioned-service-name       string
   |     |  |  |     |  +--rw version-number               uint64
   |     |  |  |     +--:(temp-service)
-  |     |  |  |        +--rw common-id                    string
+  |     |  |  |     |  +--rw common-id                    string
+  |     |  |  |     +--:(slot)
+  |     |  |  |     |  +--rw slot
+  |     |  |  |     |     +--rw shelf-name    string
+  |     |  |  |     |     +--rw slot-name     string
+  |     |  |  |     +--:(cp-slot)
+  |     |  |  |        +--rw cp-slot
+  |     |  |  |           +--rw circuit-pack-name    string
+  |     |  |  |           +--rw slot-name            string
   |     |  |  +--rw resourceType
   |     |  |     +--rw type         resource-type-enum
   |     |  |     +--rw extension?   string
@@ -1922,7 +1962,15 @@ module: org-openroadm-service
   |     |     |     |  +--rw versioned-service-name       string
   |     |     |     |  +--rw version-number               uint64
   |     |     |     +--:(temp-service)
-  |     |     |        +--rw common-id                    string
+  |     |     |     |  +--rw common-id                    string
+  |     |     |     +--:(slot)
+  |     |     |     |  +--rw slot
+  |     |     |     |     +--rw shelf-name    string
+  |     |     |     |     +--rw slot-name     string
+  |     |     |     +--:(cp-slot)
+  |     |     |        +--rw cp-slot
+  |     |     |           +--rw circuit-pack-name    string
+  |     |     |           +--rw slot-name            string
   |     |     +--rw resourceType
   |     |        +--rw type         resource-type-enum
   |     |        +--rw extension?   string
@@ -2033,7 +2081,15 @@ module: org-openroadm-service
   |     |     |  |     |  +--rw versioned-service-name       string
   |     |     |  |     |  +--rw version-number               uint64
   |     |     |  |     +--:(temp-service)
-  |     |     |  |        +--rw common-id                    string
+  |     |     |  |     |  +--rw common-id                    string
+  |     |     |  |     +--:(slot)
+  |     |     |  |     |  +--rw slot
+  |     |     |  |     |     +--rw shelf-name    string
+  |     |     |  |     |     +--rw slot-name     string
+  |     |     |  |     +--:(cp-slot)
+  |     |     |  |        +--rw cp-slot
+  |     |     |  |           +--rw circuit-pack-name    string
+  |     |     |  |           +--rw slot-name            string
   |     |     |  +--rw resourceType
   |     |     |     +--rw type         resource-type-enum
   |     |     |     +--rw extension?   string
@@ -2140,7 +2196,15 @@ module: org-openroadm-service
   |     |        |     |  +--rw versioned-service-name       string
   |     |        |     |  +--rw version-number               uint64
   |     |        |     +--:(temp-service)
-  |     |        |        +--rw common-id                    string
+  |     |        |     |  +--rw common-id                    string
+  |     |        |     +--:(slot)
+  |     |        |     |  +--rw slot
+  |     |        |     |     +--rw shelf-name    string
+  |     |        |     |     +--rw slot-name     string
+  |     |        |     +--:(cp-slot)
+  |     |        |        +--rw cp-slot
+  |     |        |           +--rw circuit-pack-name    string
+  |     |        |           +--rw slot-name            string
   |     |        +--rw resourceType
   |     |           +--rw type         resource-type-enum
   |     |           +--rw extension?   string
@@ -2754,7 +2818,15 @@ module: org-openroadm-service
   |     |  |  |     |  +--rw versioned-service-name       string
   |     |  |  |     |  +--rw version-number               uint64
   |     |  |  |     +--:(temp-service)
-  |     |  |  |        +--rw common-id                    string
+  |     |  |  |     |  +--rw common-id                    string
+  |     |  |  |     +--:(slot)
+  |     |  |  |     |  +--rw slot
+  |     |  |  |     |     +--rw shelf-name    string
+  |     |  |  |     |     +--rw slot-name     string
+  |     |  |  |     +--:(cp-slot)
+  |     |  |  |        +--rw cp-slot
+  |     |  |  |           +--rw circuit-pack-name    string
+  |     |  |  |           +--rw slot-name            string
   |     |  |  +--rw resourceType
   |     |  |     +--rw type         resource-type-enum
   |     |  |     +--rw extension?   string
@@ -2861,7 +2933,15 @@ module: org-openroadm-service
   |     |     |     |  +--rw versioned-service-name       string
   |     |     |     |  +--rw version-number               uint64
   |     |     |     +--:(temp-service)
-  |     |     |        +--rw common-id                    string
+  |     |     |     |  +--rw common-id                    string
+  |     |     |     +--:(slot)
+  |     |     |     |  +--rw slot
+  |     |     |     |     +--rw shelf-name    string
+  |     |     |     |     +--rw slot-name     string
+  |     |     |     +--:(cp-slot)
+  |     |     |        +--rw cp-slot
+  |     |     |           +--rw circuit-pack-name    string
+  |     |     |           +--rw slot-name            string
   |     |     +--rw resourceType
   |     |        +--rw type         resource-type-enum
   |     |        +--rw extension?   string
@@ -2972,7 +3052,15 @@ module: org-openroadm-service
   |     |     |  |     |  +--rw versioned-service-name       string
   |     |     |  |     |  +--rw version-number               uint64
   |     |     |  |     +--:(temp-service)
-  |     |     |  |        +--rw common-id                    string
+  |     |     |  |     |  +--rw common-id                    string
+  |     |     |  |     +--:(slot)
+  |     |     |  |     |  +--rw slot
+  |     |     |  |     |     +--rw shelf-name    string
+  |     |     |  |     |     +--rw slot-name     string
+  |     |     |  |     +--:(cp-slot)
+  |     |     |  |        +--rw cp-slot
+  |     |     |  |           +--rw circuit-pack-name    string
+  |     |     |  |           +--rw slot-name            string
   |     |     |  +--rw resourceType
   |     |     |     +--rw type         resource-type-enum
   |     |     |     +--rw extension?   string
@@ -3079,7 +3167,15 @@ module: org-openroadm-service
   |     |        |     |  +--rw versioned-service-name       string
   |     |        |     |  +--rw version-number               uint64
   |     |        |     +--:(temp-service)
-  |     |        |        +--rw common-id                    string
+  |     |        |     |  +--rw common-id                    string
+  |     |        |     +--:(slot)
+  |     |        |     |  +--rw slot
+  |     |        |     |     +--rw shelf-name    string
+  |     |        |     |     +--rw slot-name     string
+  |     |        |     +--:(cp-slot)
+  |     |        |        +--rw cp-slot
+  |     |        |           +--rw circuit-pack-name    string
+  |     |        |           +--rw slot-name            string
   |     |        +--rw resourceType
   |     |           +--rw type         resource-type-enum
   |     |           +--rw extension?   string
@@ -6190,7 +6286,15 @@ module: org-openroadm-service
     |     |  |  |  |     |  +--ro versioned-service-name       string
     |     |  |  |  |     |  +--ro version-number               uint64
     |     |  |  |  |     +--:(temp-service)
-    |     |  |  |  |        +--ro common-id                    string
+    |     |  |  |  |     |  +--ro common-id                    string
+    |     |  |  |  |     +--:(slot)
+    |     |  |  |  |     |  +--ro slot
+    |     |  |  |  |     |     +--ro shelf-name    string
+    |     |  |  |  |     |     +--ro slot-name     string
+    |     |  |  |  |     +--:(cp-slot)
+    |     |  |  |  |        +--ro cp-slot
+    |     |  |  |  |           +--ro circuit-pack-name    string
+    |     |  |  |  |           +--ro slot-name            string
     |     |  |  |  +--ro resourceType
     |     |  |  |     +--ro type         resource-type-enum
     |     |  |  |     +--ro extension?   string
@@ -6297,7 +6401,15 @@ module: org-openroadm-service
     |     |  |     |     |  +--ro versioned-service-name       string
     |     |  |     |     |  +--ro version-number               uint64
     |     |  |     |     +--:(temp-service)
-    |     |  |     |        +--ro common-id                    string
+    |     |  |     |     |  +--ro common-id                    string
+    |     |  |     |     +--:(slot)
+    |     |  |     |     |  +--ro slot
+    |     |  |     |     |     +--ro shelf-name    string
+    |     |  |     |     |     +--ro slot-name     string
+    |     |  |     |     +--:(cp-slot)
+    |     |  |     |        +--ro cp-slot
+    |     |  |     |           +--ro circuit-pack-name    string
+    |     |  |     |           +--ro slot-name            string
     |     |  |     +--ro resourceType
     |     |  |        +--ro type         resource-type-enum
     |     |  |        +--ro extension?   string
@@ -6408,7 +6520,15 @@ module: org-openroadm-service
     |     |  |     |  |     |  +--ro versioned-service-name       string
     |     |  |     |  |     |  +--ro version-number               uint64
     |     |  |     |  |     +--:(temp-service)
-    |     |  |     |  |        +--ro common-id                    string
+    |     |  |     |  |     |  +--ro common-id                    string
+    |     |  |     |  |     +--:(slot)
+    |     |  |     |  |     |  +--ro slot
+    |     |  |     |  |     |     +--ro shelf-name    string
+    |     |  |     |  |     |     +--ro slot-name     string
+    |     |  |     |  |     +--:(cp-slot)
+    |     |  |     |  |        +--ro cp-slot
+    |     |  |     |  |           +--ro circuit-pack-name    string
+    |     |  |     |  |           +--ro slot-name            string
     |     |  |     |  +--ro resourceType
     |     |  |     |     +--ro type         resource-type-enum
     |     |  |     |     +--ro extension?   string
@@ -6515,7 +6635,15 @@ module: org-openroadm-service
     |     |  |        |     |  +--ro versioned-service-name       string
     |     |  |        |     |  +--ro version-number               uint64
     |     |  |        |     +--:(temp-service)
-    |     |  |        |        +--ro common-id                    string
+    |     |  |        |     |  +--ro common-id                    string
+    |     |  |        |     +--:(slot)
+    |     |  |        |     |  +--ro slot
+    |     |  |        |     |     +--ro shelf-name    string
+    |     |  |        |     |     +--ro slot-name     string
+    |     |  |        |     +--:(cp-slot)
+    |     |  |        |        +--ro cp-slot
+    |     |  |        |           +--ro circuit-pack-name    string
+    |     |  |        |           +--ro slot-name            string
     |     |  |        +--ro resourceType
     |     |  |           +--ro type         resource-type-enum
     |     |  |           +--ro extension?   string
@@ -7627,7 +7755,15 @@ module: org-openroadm-service
     |        |  |  |  |     |  +--ro versioned-service-name       string
     |        |  |  |  |     |  +--ro version-number               uint64
     |        |  |  |  |     +--:(temp-service)
-    |        |  |  |  |        +--ro common-id                    string
+    |        |  |  |  |     |  +--ro common-id                    string
+    |        |  |  |  |     +--:(slot)
+    |        |  |  |  |     |  +--ro slot
+    |        |  |  |  |     |     +--ro shelf-name    string
+    |        |  |  |  |     |     +--ro slot-name     string
+    |        |  |  |  |     +--:(cp-slot)
+    |        |  |  |  |        +--ro cp-slot
+    |        |  |  |  |           +--ro circuit-pack-name    string
+    |        |  |  |  |           +--ro slot-name            string
     |        |  |  |  +--ro resourceType
     |        |  |  |     +--ro type         resource-type-enum
     |        |  |  |     +--ro extension?   string
@@ -7734,7 +7870,15 @@ module: org-openroadm-service
     |        |  |     |     |  +--ro versioned-service-name       string
     |        |  |     |     |  +--ro version-number               uint64
     |        |  |     |     +--:(temp-service)
-    |        |  |     |        +--ro common-id                    string
+    |        |  |     |     |  +--ro common-id                    string
+    |        |  |     |     +--:(slot)
+    |        |  |     |     |  +--ro slot
+    |        |  |     |     |     +--ro shelf-name    string
+    |        |  |     |     |     +--ro slot-name     string
+    |        |  |     |     +--:(cp-slot)
+    |        |  |     |        +--ro cp-slot
+    |        |  |     |           +--ro circuit-pack-name    string
+    |        |  |     |           +--ro slot-name            string
     |        |  |     +--ro resourceType
     |        |  |        +--ro type         resource-type-enum
     |        |  |        +--ro extension?   string
@@ -7845,7 +7989,15 @@ module: org-openroadm-service
     |        |  |     |  |     |  +--ro versioned-service-name       string
     |        |  |     |  |     |  +--ro version-number               uint64
     |        |  |     |  |     +--:(temp-service)
-    |        |  |     |  |        +--ro common-id                    string
+    |        |  |     |  |     |  +--ro common-id                    string
+    |        |  |     |  |     +--:(slot)
+    |        |  |     |  |     |  +--ro slot
+    |        |  |     |  |     |     +--ro shelf-name    string
+    |        |  |     |  |     |     +--ro slot-name     string
+    |        |  |     |  |     +--:(cp-slot)
+    |        |  |     |  |        +--ro cp-slot
+    |        |  |     |  |           +--ro circuit-pack-name    string
+    |        |  |     |  |           +--ro slot-name            string
     |        |  |     |  +--ro resourceType
     |        |  |     |     +--ro type         resource-type-enum
     |        |  |     |     +--ro extension?   string
@@ -7952,7 +8104,15 @@ module: org-openroadm-service
     |        |  |        |     |  +--ro versioned-service-name       string
     |        |  |        |     |  +--ro version-number               uint64
     |        |  |        |     +--:(temp-service)
-    |        |  |        |        +--ro common-id                    string
+    |        |  |        |     |  +--ro common-id                    string
+    |        |  |        |     +--:(slot)
+    |        |  |        |     |  +--ro slot
+    |        |  |        |     |     +--ro shelf-name    string
+    |        |  |        |     |     +--ro slot-name     string
+    |        |  |        |     +--:(cp-slot)
+    |        |  |        |        +--ro cp-slot
+    |        |  |        |           +--ro circuit-pack-name    string
+    |        |  |        |           +--ro slot-name            string
     |        |  |        +--ro resourceType
     |        |  |           +--ro type         resource-type-enum
     |        |  |           +--ro extension?   string
@@ -11138,7 +11298,15 @@ module: org-openroadm-service
     |  |  |  |     |  +--ro versioned-service-name       string
     |  |  |  |     |  +--ro version-number               uint64
     |  |  |  |     +--:(temp-service)
-    |  |  |  |        +--ro common-id                    string
+    |  |  |  |     |  +--ro common-id                    string
+    |  |  |  |     +--:(slot)
+    |  |  |  |     |  +--ro slot
+    |  |  |  |     |     +--ro shelf-name    string
+    |  |  |  |     |     +--ro slot-name     string
+    |  |  |  |     +--:(cp-slot)
+    |  |  |  |        +--ro cp-slot
+    |  |  |  |           +--ro circuit-pack-name    string
+    |  |  |  |           +--ro slot-name            string
     |  |  |  +--ro resourceType
     |  |  |     +--ro type         resource-type-enum
     |  |  |     +--ro extension?   string
@@ -11245,7 +11413,15 @@ module: org-openroadm-service
     |  |     |     |  +--ro versioned-service-name       string
     |  |     |     |  +--ro version-number               uint64
     |  |     |     +--:(temp-service)
-    |  |     |        +--ro common-id                    string
+    |  |     |     |  +--ro common-id                    string
+    |  |     |     +--:(slot)
+    |  |     |     |  +--ro slot
+    |  |     |     |     +--ro shelf-name    string
+    |  |     |     |     +--ro slot-name     string
+    |  |     |     +--:(cp-slot)
+    |  |     |        +--ro cp-slot
+    |  |     |           +--ro circuit-pack-name    string
+    |  |     |           +--ro slot-name            string
     |  |     +--ro resourceType
     |  |        +--ro type         resource-type-enum
     |  |        +--ro extension?   string
@@ -11356,7 +11532,15 @@ module: org-openroadm-service
     |  |     |  |     |  +--ro versioned-service-name       string
     |  |     |  |     |  +--ro version-number               uint64
     |  |     |  |     +--:(temp-service)
-    |  |     |  |        +--ro common-id                    string
+    |  |     |  |     |  +--ro common-id                    string
+    |  |     |  |     +--:(slot)
+    |  |     |  |     |  +--ro slot
+    |  |     |  |     |     +--ro shelf-name    string
+    |  |     |  |     |     +--ro slot-name     string
+    |  |     |  |     +--:(cp-slot)
+    |  |     |  |        +--ro cp-slot
+    |  |     |  |           +--ro circuit-pack-name    string
+    |  |     |  |           +--ro slot-name            string
     |  |     |  +--ro resourceType
     |  |     |     +--ro type         resource-type-enum
     |  |     |     +--ro extension?   string
@@ -11463,7 +11647,15 @@ module: org-openroadm-service
     |  |        |     |  +--ro versioned-service-name       string
     |  |        |     |  +--ro version-number               uint64
     |  |        |     +--:(temp-service)
-    |  |        |        +--ro common-id                    string
+    |  |        |     |  +--ro common-id                    string
+    |  |        |     +--:(slot)
+    |  |        |     |  +--ro slot
+    |  |        |     |     +--ro shelf-name    string
+    |  |        |     |     +--ro slot-name     string
+    |  |        |     +--:(cp-slot)
+    |  |        |        +--ro cp-slot
+    |  |        |           +--ro circuit-pack-name    string
+    |  |        |           +--ro slot-name            string
     |  |        +--ro resourceType
     |  |           +--ro type         resource-type-enum
     |  |           +--ro extension?   string
@@ -12053,7 +12245,15 @@ module: org-openroadm-service
     |  |  |  |     |  +--ro versioned-service-name       string
     |  |  |  |     |  +--ro version-number               uint64
     |  |  |  |     +--:(temp-service)
-    |  |  |  |        +--ro common-id                    string
+    |  |  |  |     |  +--ro common-id                    string
+    |  |  |  |     +--:(slot)
+    |  |  |  |     |  +--ro slot
+    |  |  |  |     |     +--ro shelf-name    string
+    |  |  |  |     |     +--ro slot-name     string
+    |  |  |  |     +--:(cp-slot)
+    |  |  |  |        +--ro cp-slot
+    |  |  |  |           +--ro circuit-pack-name    string
+    |  |  |  |           +--ro slot-name            string
     |  |  |  +--ro resourceType
     |  |  |     +--ro type         resource-type-enum
     |  |  |     +--ro extension?   string
@@ -12160,7 +12360,15 @@ module: org-openroadm-service
     |  |     |     |  +--ro versioned-service-name       string
     |  |     |     |  +--ro version-number               uint64
     |  |     |     +--:(temp-service)
-    |  |     |        +--ro common-id                    string
+    |  |     |     |  +--ro common-id                    string
+    |  |     |     +--:(slot)
+    |  |     |     |  +--ro slot
+    |  |     |     |     +--ro shelf-name    string
+    |  |     |     |     +--ro slot-name     string
+    |  |     |     +--:(cp-slot)
+    |  |     |        +--ro cp-slot
+    |  |     |           +--ro circuit-pack-name    string
+    |  |     |           +--ro slot-name            string
     |  |     +--ro resourceType
     |  |        +--ro type         resource-type-enum
     |  |        +--ro extension?   string
@@ -12271,7 +12479,15 @@ module: org-openroadm-service
     |  |     |  |     |  +--ro versioned-service-name       string
     |  |     |  |     |  +--ro version-number               uint64
     |  |     |  |     +--:(temp-service)
-    |  |     |  |        +--ro common-id                    string
+    |  |     |  |     |  +--ro common-id                    string
+    |  |     |  |     +--:(slot)
+    |  |     |  |     |  +--ro slot
+    |  |     |  |     |     +--ro shelf-name    string
+    |  |     |  |     |     +--ro slot-name     string
+    |  |     |  |     +--:(cp-slot)
+    |  |     |  |        +--ro cp-slot
+    |  |     |  |           +--ro circuit-pack-name    string
+    |  |     |  |           +--ro slot-name            string
     |  |     |  +--ro resourceType
     |  |     |     +--ro type         resource-type-enum
     |  |     |     +--ro extension?   string
@@ -12378,7 +12594,15 @@ module: org-openroadm-service
     |  |        |     |  +--ro versioned-service-name       string
     |  |        |     |  +--ro version-number               uint64
     |  |        |     +--:(temp-service)
-    |  |        |        +--ro common-id                    string
+    |  |        |     |  +--ro common-id                    string
+    |  |        |     +--:(slot)
+    |  |        |     |  +--ro slot
+    |  |        |     |     +--ro shelf-name    string
+    |  |        |     |     +--ro slot-name     string
+    |  |        |     +--:(cp-slot)
+    |  |        |        +--ro cp-slot
+    |  |        |           +--ro circuit-pack-name    string
+    |  |        |           +--ro slot-name            string
     |  |        +--ro resourceType
     |  |           +--ro type         resource-type-enum
     |  |           +--ro extension?   string

--- a/model/Specifications/apidoc-operational-modes-catalog-10_1-optical-spec-5_1.json
+++ b/model/Specifications/apidoc-operational-modes-catalog-10_1-optical-spec-5_1.json
@@ -2,9 +2,9 @@
     "operational-mode-catalog": {
         "openroadm-operational-modes": {
             "grid-parameters": {
-                "min-central-frequency": "191.32500000",
-                "max-central-frequency": "196.12500000",
-                "central-frequency-granularity": "12.50000",
+                "min-central-frequency": "191.35000000",
+                "max-central-frequency": "196.10000000",
+                "central-frequency-granularity": "6.250000",
                 "min-spacing": "37.50000"
             },
             "xponders-pluggables": {
@@ -15,16 +15,16 @@
                         "line-rate": "111.8",
                         "modulation-format": "dp-qpsk",
                         "min-TX-osnr": "33.000",
-                        "TX-OOB-osnr": {
+                        "TX-OOB-osnr": [{
                             "WR-openroadm-operational-mode-id": "MW-WR-core",
                             "min-OOB-osnr-multi-channel-value": "31.000",
                             "min-OOB-osnr-single-channel-value": "43.000"
-                        },
-                        "output-power-range": {
+                        }],
+                        "output-power-range": [{
                             "WR-openroadm-operational-mode-id": "MW-WR-core",
                             "min-output-power": "-5.000",
                             "max-output-power": "0.000"
-                        },
+                        }],
                         "min-RX-osnr-tolerance": "17.000",
                         "min-input-power-at-RX-osnr": "-22.000",
                         "max-input-power": "1.000",
@@ -69,15 +69,16 @@
                         "line-rate": "126.3",
                         "modulation-format": "dp-qpsk",
                         "min-TX-osnr": "37.000",
-                        "TX-OOB-osnr": {
+                        "TX-OOB-osnr": [{
                             "WR-openroadm-operational-mode-id": "MW-WR-core",
-                            "min-OOB-osnr-multi-channel-value": "36.000"
-                        },
-                        "output-power-range": {
+                            "min-OOB-osnr-multi-channel-value": "36.000",
+                            "min-OOB-osnr-single-channel-value": "43.000"
+                        }],
+                        "output-power-range": [{
                             "WR-openroadm-operational-mode-id": "MW-WR-core",
                             "min-output-power": "-5.000",
                             "max-output-power": "0.000"
-                        },
+                        }],
                         "min-RX-osnr-tolerance": "12.000",
                         "min-input-power-at-RX-osnr": "-18.000",
                         "max-input-power": "1.000",
@@ -154,15 +155,16 @@
                         "line-rate": "252.6",
                         "modulation-format": "dp-qam16",
                         "min-TX-osnr": "37.000",
-                        "TX-OOB-osnr": {
+                        "TX-OOB-osnr": [{
                             "WR-openroadm-operational-mode-id": "MW-WR-core",
-                            "min-OOB-osnr-multi-channel-value": "36.000"
-                        },
-                        "output-power-range": {
+                            "min-OOB-osnr-multi-channel-value": "36.000",
+                            "min-OOB-osnr-single-channel-value": "43.000"
+                        }],
+                        "output-power-range": [{
                             "WR-openroadm-operational-mode-id": "MW-WR-core",
                             "min-output-power": "-5.000",
                             "max-output-power": "0.000"
-                        },
+                        }],
                         "min-RX-osnr-tolerance": "20.500",
                         "min-input-power-at-RX-osnr": "-16.000",
                         "max-input-power": "1.000",
@@ -244,15 +246,16 @@
                         "line-rate": "252.6",
                         "modulation-format": "dp-qpsk",
                         "min-TX-osnr": "37.000",
-                        "TX-OOB-osnr": {
+                        "TX-OOB-osnr": [{
                             "WR-openroadm-operational-mode-id": "MW-WR-core",
-                            "min-OOB-osnr-multi-channel-value": "36.000"
-                        },
-                        "output-power-range": {
+                            "min-OOB-osnr-multi-channel-value": "36.000",
+                            "min-OOB-osnr-single-channel-value": "43.000"
+                        }],
+                        "output-power-range": [{
                             "WR-openroadm-operational-mode-id": "MW-WR-core",
                             "min-output-power": "-5.000",
                             "max-output-power": "0.000"
-                        },
+                        }],
                         "min-RX-osnr-tolerance": "17.000",
                         "min-input-power-at-RX-osnr": "-18.000",
                         "max-input-power": "1.000",
@@ -324,15 +327,16 @@
                         "line-rate": "378.8",
                         "modulation-format": "dp-qam8",
                         "min-TX-osnr": "37.000",
-                        "TX-OOB-osnr": {
+                        "TX-OOB-osnr": [{
                             "WR-openroadm-operational-mode-id": "MW-WR-core",
-                            "min-OOB-osnr-multi-channel-value": "36.000"
-                        },
-                        "output-power-range": {
+                            "min-OOB-osnr-multi-channel-value": "36.000",
+                            "min-OOB-osnr-single-channel-value": "43.000"
+                        }],
+                        "output-power-range": [{
                             "WR-openroadm-operational-mode-id": "MW-WR-core",
                             "min-output-power": "-5.000",
                             "max-output-power": "0.000"
-                        },
+                        }],
                         "min-RX-osnr-tolerance": "21.000",
                         "min-input-power-at-RX-osnr": "-16.000",
                         "max-input-power": "1.000",
@@ -409,15 +413,16 @@
                         "line-rate": "505.1",
                         "modulation-format": "dp-qam16",
                         "min-TX-osnr": "37.000",
-                        "TX-OOB-osnr": {
+                        "TX-OOB-osnr": [{
                             "WR-openroadm-operational-mode-id": "MW-WR-core",
-                            "min-OOB-osnr-multi-channel-value": "36.000"
-                        },
-                        "output-power-range": {
+                            "min-OOB-osnr-multi-channel-value": "36.000",
+                            "min-OOB-osnr-single-channel-value": "43.000"
+                        }],
+                        "output-power-range": [{
                             "WR-openroadm-operational-mode-id": "MW-WR-core",
                             "min-output-power": "-5.000",
                             "max-output-power": "0.000"
-                        },
+                        }],
                         "min-RX-osnr-tolerance": "24.000",
                         "min-input-power-at-RX-osnr": "-14.000",
                         "max-input-power": "1.000",

--- a/model/Specifications/apidoc-operational-modes-catalog-12_0-optical-spec-5_1.json
+++ b/model/Specifications/apidoc-operational-modes-catalog-12_0-optical-spec-5_1.json
@@ -2,9 +2,9 @@
     "operational-mode-catalog": {
         "openroadm-operational-modes": {
             "grid-parameters": {
-                "min-central-frequency": "191.32500000",
-                "max-central-frequency": "196.12500000",
-                "central-frequency-granularity": "12.50000",
+                "min-central-frequency": "191.35000000",
+                "max-central-frequency": "196.10000000",
+                "central-frequency-granularity": "6.250000",
                 "min-spacing": "37.50000"
             },
             "xponders-pluggables": {
@@ -15,16 +15,16 @@
                         "line-rate": "111.8",
                         "modulation-format": "dp-qpsk",
                         "min-TX-osnr": "33.000",
-                        "TX-OOB-osnr": {
+                        "TX-OOB-osnr": [{
                             "WR-openroadm-operational-mode-id": "MW-WR-core",
                             "min-OOB-osnr-multi-channel-value": "31.000",
                             "min-OOB-osnr-single-channel-value": "43.000"
-                        },
-                        "output-power-range": {
+                        }],
+                        "output-power-range": [{
                             "WR-openroadm-operational-mode-id": "MW-WR-core",
                             "min-output-power": "-5.000",
                             "max-output-power": "0.000"
-                        },
+                        }],
                         "min-RX-osnr-tolerance": "17.000",
                         "min-input-power-at-RX-osnr": "-22.000",
                         "max-input-power": "1.000",
@@ -69,15 +69,16 @@
                         "line-rate": "126.3",
                         "modulation-format": "dp-qpsk",
                         "min-TX-osnr": "37.000",
-                        "TX-OOB-osnr": {
+                        "TX-OOB-osnr": [{
                             "WR-openroadm-operational-mode-id": "MW-WR-core",
-                            "min-OOB-osnr-multi-channel-value": "36.000"
-                        },
-                        "output-power-range": {
+                            "min-OOB-osnr-multi-channel-value": "36.000",
+                            "min-OOB-osnr-single-channel-value": "43.000"
+                        }],
+                        "output-power-range": [{
                             "WR-openroadm-operational-mode-id": "MW-WR-core",
                             "min-output-power": "-5.000",
                             "max-output-power": "0.000"
-                        },
+                        }],
                         "min-RX-osnr-tolerance": "12.000",
                         "min-input-power-at-RX-osnr": "-18.000",
                         "max-input-power": "1.000",
@@ -154,15 +155,16 @@
                         "line-rate": "252.6",
                         "modulation-format": "dp-qam16",
                         "min-TX-osnr": "37.000",
-                        "TX-OOB-osnr": {
+                        "TX-OOB-osnr": [{
                             "WR-openroadm-operational-mode-id": "MW-WR-core",
-                            "min-OOB-osnr-multi-channel-value": "36.000"
-                        },
-                        "output-power-range": {
+                            "min-OOB-osnr-multi-channel-value": "36.000",
+                            "min-OOB-osnr-single-channel-value": "43.000"
+                        }],
+                        "output-power-range": [{
                             "WR-openroadm-operational-mode-id": "MW-WR-core",
                             "min-output-power": "-5.000",
                             "max-output-power": "0.000"
-                        },
+                        }],
                         "min-RX-osnr-tolerance": "20.500",
                         "min-input-power-at-RX-osnr": "-16.000",
                         "max-input-power": "1.000",
@@ -244,15 +246,16 @@
                         "line-rate": "252.6",
                         "modulation-format": "dp-qpsk",
                         "min-TX-osnr": "37.000",
-                        "TX-OOB-osnr": {
+                        "TX-OOB-osnr": [{
                             "WR-openroadm-operational-mode-id": "MW-WR-core",
-                            "min-OOB-osnr-multi-channel-value": "36.000"
-                        },
-                        "output-power-range": {
+                            "min-OOB-osnr-multi-channel-value": "36.000",
+                            "min-OOB-osnr-single-channel-value": "43.000"
+                        }],
+                        "output-power-range": [{
                             "WR-openroadm-operational-mode-id": "MW-WR-core",
                             "min-output-power": "-5.000",
                             "max-output-power": "0.000"
-                        },
+                        }],
                         "min-RX-osnr-tolerance": "17.000",
                         "min-input-power-at-RX-osnr": "-18.000",
                         "max-input-power": "1.000",
@@ -324,15 +327,16 @@
                         "line-rate": "378.8",
                         "modulation-format": "dp-qam8",
                         "min-TX-osnr": "37.000",
-                        "TX-OOB-osnr": {
+                        "TX-OOB-osnr": [{
                             "WR-openroadm-operational-mode-id": "MW-WR-core",
-                            "min-OOB-osnr-multi-channel-value": "36.000"
-                        },
-                        "output-power-range": {
+                            "min-OOB-osnr-multi-channel-value": "36.000",
+                            "min-OOB-osnr-single-channel-value": "43.000"
+                        }],
+                        "output-power-range": [{
                             "WR-openroadm-operational-mode-id": "MW-WR-core",
                             "min-output-power": "-5.000",
                             "max-output-power": "0.000"
-                        },
+                        }],
                         "min-RX-osnr-tolerance": "21.000",
                         "min-input-power-at-RX-osnr": "-16.000",
                         "max-input-power": "1.000",
@@ -409,15 +413,16 @@
                         "line-rate": "505.1",
                         "modulation-format": "dp-qam16",
                         "min-TX-osnr": "37.000",
-                        "TX-OOB-osnr": {
+                        "TX-OOB-osnr": [{
                             "WR-openroadm-operational-mode-id": "MW-WR-core",
-                            "min-OOB-osnr-multi-channel-value": "36.000"
-                        },
-                        "output-power-range": {
+                            "min-OOB-osnr-multi-channel-value": "36.000",
+                            "min-OOB-osnr-single-channel-value": "43.000"
+                        }],
+                        "output-power-range": [{
                             "WR-openroadm-operational-mode-id": "MW-WR-core",
                             "min-output-power": "-5.000",
                             "max-output-power": "0.000"
-                        },
+                        }],
                         "min-RX-osnr-tolerance": "24.000",
                         "min-input-power-at-RX-osnr": "-14.000",
                         "max-input-power": "1.000",

--- a/model/Specifications/apidoc-operational-modes-to-catalog-13_1-optical-spec-6_0.json
+++ b/model/Specifications/apidoc-operational-modes-to-catalog-13_1-optical-spec-6_0.json
@@ -1,0 +1,2076 @@
+{
+    "operational-mode-catalog": {
+        "openroadm-operational-modes": {
+            "grid-parameters": {
+                "min-central-frequency": "191.35000000",
+                "max-central-frequency": "196.10000000",
+                "central-frequency-granularity": "6.250000",
+                "min-spacing": "37.50000"
+            },
+            "xponders-pluggables": {
+                "xponder-pluggable-openroadm-operational-mode": [
+                    {
+                        "openroadm-operational-mode-id": "OR-W-100G-SC",
+                        "baud-rate": "28.0",
+                        "line-rate": "111.8",
+                        "modulation-format": "dp-qpsk",
+                        "min-TX-osnr": "33.000",
+                        "TX-OOB-osnr": [{
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-OOB-osnr-multi-channel-value": "31.000",
+                            "min-OOB-osnr-single-channel-value": "43.000"
+                        }],
+                        "output-power-range": [{
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-output-power": "-5.000",
+                            "max-output-power": "0.000"
+                        }],
+                        "min-RX-osnr-tolerance": "17.000",
+                        "min-input-power-at-RX-osnr": "-22.000",
+                        "max-input-power": "1.000",
+                        "channel-width": "40.00000",
+                        "fec-type": "org-openroadm-common-types:scfec",
+                        "penalties": [
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "18000",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "6",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "30",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-22",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "cross-talk-total-power-dB",
+                                "up-to-boundary": "15",
+                                "penalty-value": "0.200"
+                            },
+                            {
+                                "parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+                                "up-to-boundary": "4",
+                                "penalty-value": "0.200"
+                            }
+                        ]
+                    },
+                    {
+                        "openroadm-operational-mode-id": "OR-W-100G-oFEC-31.6Gbd",
+                        "baud-rate": "31.6",
+                        "line-rate": "126.3",
+                        "modulation-format": "dp-qpsk",
+                        "min-TX-osnr": "37.000",
+                        "TX-OOB-osnr": [{
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-OOB-osnr-multi-channel-value": "36.000",
+                            "min-OOB-osnr-single-channel-value": "43.000"
+                        }],
+                        "output-power-range": [{
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-output-power": "-5.000",
+                            "max-output-power": "0.000"
+                        }],
+                        "min-RX-osnr-tolerance": "12.000",
+                        "min-input-power-at-RX-osnr": "-18.000",
+                        "max-input-power": "1.000",
+                        "channel-width": "37.88400",
+                        "fec-type": "org-openroadm-common-types:ofec",
+                        "min-roll-off": "0.05",
+                        "max-roll-off": "0.20",
+                        "penalties": [
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "4000",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "48000",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "1",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "2",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "4",
+                                "penalty-value": "2.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "6",
+                                "penalty-value": "4.000"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "10",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "30",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-18",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-20",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "cross-talk-total-power-dB",
+                                "up-to-boundary": "15",
+                                "penalty-value": "0.200"
+                            },
+                            {
+                                "parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+                                "up-to-boundary": "4",
+                                "penalty-value": "0.200"
+                            }
+                        ]
+                    },
+                    {
+                        "openroadm-operational-mode-id": "OR-W-200G-oFEC-31.6Gbd",
+                        "baud-rate": "31.6",
+                        "line-rate": "252.6",
+                        "modulation-format": "dp-qam16",
+                        "min-TX-osnr": "37.000",
+                        "TX-OOB-osnr": [{
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-OOB-osnr-multi-channel-value": "36.000",
+                            "min-OOB-osnr-single-channel-value": "43.000"
+                        }],
+                        "output-power-range": [{
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-output-power": "-5.000",
+                            "max-output-power": "0.000"
+                        }],
+                        "min-RX-osnr-tolerance": "20.500",
+                        "min-input-power-at-RX-osnr": "-16.000",
+                        "max-input-power": "1.000",
+                        "channel-width": "37.88400",
+                        "fec-type": "org-openroadm-common-types:ofec",
+                        "min-roll-off": "0.05",
+                        "max-roll-off": "0.20",
+                        "penalties": [
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "4000",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "24000",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "1",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "2",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "4",
+                                "penalty-value": "2.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "6",
+                                "penalty-value": "4.000"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "10",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "30",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-16",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-18",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-20",
+                                "penalty-value": "2.000"
+                            },
+                            {
+                                "parameter-and-unit": "cross-talk-total-power-dB",
+                                "up-to-boundary": "15",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+                                "up-to-boundary": "4",
+                                "penalty-value": "0.500"
+                            }
+                        ]
+                    },
+                    {
+                        "openroadm-operational-mode-id": "OR-W-200G-oFEC-63.1Gbd",
+                        "baud-rate": "63.1",
+                        "line-rate": "252.6",
+                        "modulation-format": "dp-qpsk",
+                        "min-TX-osnr": "37.000",
+                        "TX-OOB-osnr": [{
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-OOB-osnr-multi-channel-value": "36.000",
+                            "min-OOB-osnr-single-channel-value": "43.000"
+                        }],
+                        "output-power-range": [{
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-output-power": "-5.000",
+                            "max-output-power": "0.000"
+                        }],
+                        "min-RX-osnr-tolerance": "16.000",
+                        "min-input-power-at-RX-osnr": "-18.000",
+                        "max-input-power": "1.000",
+                        "channel-width": "75.72000",
+                        "fec-type": "org-openroadm-common-types:ofec",
+                        "min-roll-off": "0.05",
+                        "max-roll-off": "0.20",
+                        "penalties": [
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "4000",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "24000",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "1",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "2",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "4",
+                                "penalty-value": "2.500"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "10",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "25",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-18",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-20",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "cross-talk-total-power-dB",
+                                "up-to-boundary": "15",
+                                "penalty-value": "0.300"
+                            },
+                            {
+                                "parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+                                "up-to-boundary": "4",
+                                "penalty-value": "0.500"
+                            }
+                        ]
+                    },
+                    {
+                        "openroadm-operational-mode-id": "OR-W-300G-oFEC-63.1Gbd",
+                        "baud-rate": "63.1",
+                        "line-rate": "378.8",
+                        "modulation-format": "dp-qam8",
+                        "min-TX-osnr": "37.000",
+                        "TX-OOB-osnr": [{
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-OOB-osnr-multi-channel-value": "36.000",
+                            "min-OOB-osnr-single-channel-value": "43.000"
+                        }],
+                        "output-power-range": [{
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-output-power": "-5.000",
+                            "max-output-power": "0.000"
+                        }],
+                        "min-RX-osnr-tolerance": "21.000",
+                        "min-input-power-at-RX-osnr": "-16.000",
+                        "max-input-power": "1.000",
+                        "channel-width": "75.72000",
+                        "fec-type": "org-openroadm-common-types:ofec",
+                        "min-roll-off": "0.05",
+                        "max-roll-off": "0.20",
+                        "penalties": [
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "4000",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "18000",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "1.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "2.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "4.00",
+                                "penalty-value": "2.500"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "10.00",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "25.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-16.00",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-18.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-20.00",
+                                "penalty-value": "2.000"
+                            },
+                            {
+                                "parameter-and-unit": "cross-talk-total-power-dB",
+                                "up-to-boundary": "15.00",
+                                "penalty-value": "0.300"
+                            },
+                            {
+                                "parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+                                "up-to-boundary": "4.0",
+                                "penalty-value": "0.500"
+                            }
+                        ]
+                    },
+                    {
+                        "openroadm-operational-mode-id": "OR-W-400G-oFEC-63.1Gbd",
+                        "baud-rate": "63.1",
+                        "line-rate": "505.1",
+                        "modulation-format": "dp-qam16",
+                        "min-TX-osnr": "37.000",
+                        "TX-OOB-osnr": [{
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-OOB-osnr-multi-channel-value": "36.000",
+                            "min-OOB-osnr-single-channel-value": "43.000"
+                        }],
+                        "output-power-range": [{
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-output-power": "-5.000",
+                            "max-output-power": "0.000"
+                        }],
+                        "min-RX-osnr-tolerance": "24.000",
+                        "min-input-power-at-RX-osnr": "-14.000",
+                        "max-input-power": "1.000",
+                        "channel-width": "75.72000",
+                        "fec-type": "org-openroadm-common-types:ofec",
+                        "min-roll-off": "0.05",
+                        "max-roll-off": "0.20",
+                        "penalties": [
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "4000",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "12000",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "1.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "2.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "4.00",
+                                "penalty-value": "2.500"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "10.00",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "20.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-14",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-16.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-18.00",
+                                "penalty-value": "2.000"
+                            },
+                            {
+                                "parameter-and-unit": "cross-talk-total-power-dB",
+                                "up-to-boundary": "13.00",
+                                "penalty-value": "0.300"
+                            },
+                            {
+                                "parameter-and-unit": "cross-talk-total-power-dB",
+                                "up-to-boundary": "15.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+                                "up-to-boundary": "4.10",
+                                "penalty-value": "0.500"
+                            }
+                        ]
+                    },
+					{
+                        "openroadm-operational-mode-id": "OR-W-400G-oFEC-124Gbd",
+                        "baud-rate": "124.1",
+                        "line-rate": "422.6",
+                        "modulation-format": "dp-qpsk",
+                        "min-TX-osnr": "37.000",
+                        "TX-OOB-osnr": [{
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-OOB-osnr-multi-channel-value": "36.000",
+                            "min-OOB-osnr-single-channel-value": "43.000"
+                        }],
+                        "output-power-range": [{
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-output-power": "-5.000",
+                            "max-output-power": "0.000"
+                        }],
+                        "min-RX-osnr-tolerance": "20.000",
+                        "min-input-power-at-RX-osnr": "-15.000",
+                        "max-input-power": "1.000",
+                        "channel-width": "148.92000",
+                        "fec-type": "org-openroadm-common-types:ofec",
+                        "min-roll-off": "0.05",
+                        "max-roll-off": "0.20",
+                        "penalties": [
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "4000",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "24000",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "1.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "2.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "4.00",
+                                "penalty-value": "2.500"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "10.00",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "25.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-15",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-18.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "cross-talk-total-power-dB",
+                                "up-to-boundary": "15.00",
+                                "penalty-value": "0.300"
+                            },
+                            {
+                                "parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+                                "up-to-boundary": "4.10",
+                                "penalty-value": "0.500"
+                            }
+                        ]
+                    },
+					{
+                        "openroadm-operational-mode-id": "OR-W-400G-oFEC-118Gbd",
+                        "baud-rate": "118.2",
+                        "line-rate": "422.6",
+                        "modulation-format": "dp-qpsk",
+                        "min-TX-osnr": "37.000",
+                        "TX-OOB-osnr": [{
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-OOB-osnr-multi-channel-value": "36.000",
+                            "min-OOB-osnr-single-channel-value": "43.000"
+                        }],
+                        "output-power-range": [{
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-output-power": "-5.000",
+                            "max-output-power": "0.000"
+                        }],
+                        "min-RX-osnr-tolerance": "20.000",
+                        "min-input-power-at-RX-osnr": "-15.000",
+                        "max-input-power": "1.000",
+                        "channel-width": "141.84000",
+                        "fec-type": "org-openroadm-common-types:ofec",
+                        "min-roll-off": "0.05",
+                        "max-roll-off": "0.20",
+                        "penalties": [
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "4000",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "24000",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "1.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "2.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "4.00",
+                                "penalty-value": "2.500"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "10.00",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "25.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-15",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-18.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "cross-talk-total-power-dB",
+                                "up-to-boundary": "15.00",
+                                "penalty-value": "0.300"
+                            },
+                            {
+                                "parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+                                "up-to-boundary": "4.10",
+                                "penalty-value": "0.500"
+                            }
+                        ]
+                    },
+					{
+                        "openroadm-operational-mode-id": "OR-W-400G-oFEC-124Gbd_type2",
+                        "baud-rate": "124.1",
+                        "line-rate": "422.6",
+                        "modulation-format": "dp-qpsk",
+                        "min-TX-osnr": "37.000",
+                        "TX-OOB-osnr": [{
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-OOB-osnr-multi-channel-value": "36.000",
+                            "min-OOB-osnr-single-channel-value": "43.000"
+                        }],
+                        "output-power-range": [{
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-output-power": "-5.000",
+                            "max-output-power": "0.000"
+                        }],
+                        "min-RX-osnr-tolerance": "20.000",
+                        "min-input-power-at-RX-osnr": "-15.000",
+                        "max-input-power": "1.000",
+                        "channel-width": "148.92000",
+                        "fec-type": "org-openroadm-common-types:ofec",
+                        "min-roll-off": "0.05",
+                        "max-roll-off": "0.20",
+                        "penalties": [
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "4000",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "24000",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "1.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "2.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "4.00",
+                                "penalty-value": "2.500"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "10.00",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "25.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-15",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-18.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "cross-talk-total-power-dB",
+                                "up-to-boundary": "15.00",
+                                "penalty-value": "0.300"
+                            },
+                            {
+                                "parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+                                "up-to-boundary": "4.10",
+                                "penalty-value": "0.500"
+                            }
+                        ]
+                    },
+					{
+                        "openroadm-operational-mode-id": "OR-W-400G-oFEC-118Gbd_type2",
+                        "baud-rate": "118.2",
+                        "line-rate": "422.6",
+                        "modulation-format": "dp-qpsk",
+                        "min-TX-osnr": "37.000",
+                        "TX-OOB-osnr": [{
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-OOB-osnr-multi-channel-value": "36.000",
+                            "min-OOB-osnr-single-channel-value": "43.000"
+                        }],
+                        "output-power-range": [{
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-output-power": "-5.000",
+                            "max-output-power": "0.000"
+                        }],
+                        "min-RX-osnr-tolerance": "20.000",
+                        "min-input-power-at-RX-osnr": "-15.000",
+                        "max-input-power": "1.000",
+                        "channel-width": "141.84000",
+                        "fec-type": "org-openroadm-common-types:ofec",
+                        "min-roll-off": "0.05",
+                        "max-roll-off": "0.20",
+                        "penalties": [
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "4000",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "24000",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "1.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "2.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "4.00",
+                                "penalty-value": "2.500"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "10.00",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "25.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-15",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-18.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "cross-talk-total-power-dB",
+                                "up-to-boundary": "15.00",
+                                "penalty-value": "0.300"
+                            },
+                            {
+                                "parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+                                "up-to-boundary": "4.10",
+                                "penalty-value": "0.500"
+                            }
+                        ]
+                    },
+					{
+                        "openroadm-operational-mode-id": "OR-W-800G-oFEC-124Gbd",
+                        "baud-rate": "124.1",
+                        "line-rate": "845.1",
+                        "modulation-format": "dp-qam16",
+                        "min-TX-osnr": "37.000",
+                        "TX-OOB-osnr": [{
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-OOB-osnr-multi-channel-value": "36.000",
+                            "min-OOB-osnr-single-channel-value": "43.000"
+                        }],
+                        "output-power-range": [{
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-output-power": "-5.000",
+                            "max-output-power": "0.000"
+                        }],
+                        "min-RX-osnr-tolerance": "27.200",
+                        "min-input-power-at-RX-osnr": "-11.000",
+                        "max-input-power": "1.000",
+                        "channel-width": "148.92000",
+                        "fec-type": "org-openroadm-common-types:ofec",
+                        "min-roll-off": "0.05",
+                        "max-roll-off": "0.20",
+                        "penalties": [
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "4000",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "12000",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "1.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "2.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "4.00",
+                                "penalty-value": "2.500"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "10.00",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "20.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-11.00",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-14.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "cross-talk-total-power-dB",
+                                "up-to-boundary": "13.00",
+                                "penalty-value": "0.300"
+                            },
+							{
+                                "parameter-and-unit": "cross-talk-total-power-dB",
+                                "up-to-boundary": "15.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+                                "up-to-boundary": "4.10",
+                                "penalty-value": "0.500"
+                            }
+                        ]
+                    },
+					{
+                        "openroadm-operational-mode-id": "OR-W-800G-oFEC-118Gbd",
+                        "baud-rate": "118.2",
+                        "line-rate": "845.1",
+                        "modulation-format": "dp-qam16",
+                        "min-TX-osnr": "37.000",
+                        "TX-OOB-osnr": [{
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-OOB-osnr-multi-channel-value": "36.000",
+                            "min-OOB-osnr-single-channel-value": "43.000"
+                        }],
+                        "output-power-range": [{
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-output-power": "-5.000",
+                            "max-output-power": "0.000"
+                        }],
+                        "min-RX-osnr-tolerance": "27.000",
+                        "min-input-power-at-RX-osnr": "-11.000",
+                        "max-input-power": "1.000",
+                        "channel-width": "141.84000",
+                        "fec-type": "org-openroadm-common-types:ofec",
+                        "min-roll-off": "0.05",
+                        "max-roll-off": "0.20",
+                        "penalties": [
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "4000",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "12000",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "1.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "2.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "4.00",
+                                "penalty-value": "2.500"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "10.00",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "20.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-11.00",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-14.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "cross-talk-total-power-dB",
+                                "up-to-boundary": "13.00",
+                                "penalty-value": "0.300"
+                            },
+							{
+                                "parameter-and-unit": "cross-talk-total-power-dB",
+                                "up-to-boundary": "15.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+                                "up-to-boundary": "4.10",
+                                "penalty-value": "0.500"
+                            }
+                        ]
+                    },
+					{
+                        "openroadm-operational-mode-id": "OR-W-800G-oFEC-124Gbd_type2",
+                        "baud-rate": "124.1",
+                        "line-rate": "845.1",
+                        "modulation-format": "dp-qam16",
+                        "min-TX-osnr": "37.000",
+                        "TX-OOB-osnr": [{
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-OOB-osnr-multi-channel-value": "36.000",
+                            "min-OOB-osnr-single-channel-value": "43.000"
+                        }],
+                        "output-power-range": [{
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-output-power": "-5.000",
+                            "max-output-power": "0.000"
+                        }],
+                        "min-RX-osnr-tolerance": "27.200",
+                        "min-input-power-at-RX-osnr": "-11.000",
+                        "max-input-power": "1.000",
+                        "channel-width": "148.92000",
+                        "fec-type": "org-openroadm-common-types:ofec",
+                        "min-roll-off": "0.05",
+                        "max-roll-off": "0.20",
+                        "penalties": [
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "4000",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "12000",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "1.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "2.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "4.00",
+                                "penalty-value": "2.500"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "10.00",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "20.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-11.00",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-14.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "cross-talk-total-power-dB",
+                                "up-to-boundary": "13.00",
+                                "penalty-value": "0.300"
+                            },
+							{
+                                "parameter-and-unit": "cross-talk-total-power-dB",
+                                "up-to-boundary": "15.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+                                "up-to-boundary": "4.10",
+                                "penalty-value": "0.500"
+                            }
+                        ]
+                    },
+					{
+                        "openroadm-operational-mode-id": "OR-W-800G-oFEC-118Gbd_type2",
+                        "baud-rate": "118.2",
+                        "line-rate": "845.1",
+                        "modulation-format": "dp-qam16",
+                        "min-TX-osnr": "37.000",
+                        "TX-OOB-osnr": [{
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-OOB-osnr-multi-channel-value": "36.000",
+                            "min-OOB-osnr-single-channel-value": "43.000"
+                        }],
+                        "output-power-range": [{
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-output-power": "-5.000",
+                            "max-output-power": "0.000"
+                        }],
+                        "min-RX-osnr-tolerance": "27.000",
+                        "min-input-power-at-RX-osnr": "-11.000",
+                        "max-input-power": "1.000",
+                        "channel-width": "141.84000",
+                        "fec-type": "org-openroadm-common-types:ofec",
+                        "min-roll-off": "0.05",
+                        "max-roll-off": "0.20",
+                        "penalties": [
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "4000",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "12000",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "1.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "2.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "4.00",
+                                "penalty-value": "2.500"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "10.00",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "20.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-11.00",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-14.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "cross-talk-total-power-dB",
+                                "up-to-boundary": "13.00",
+                                "penalty-value": "0.300"
+                            },
+							{
+                                "parameter-and-unit": "cross-talk-total-power-dB",
+                                "up-to-boundary": "15.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+                                "up-to-boundary": "4.10",
+                                "penalty-value": "0.500"
+                            }
+                        ]
+                    },
+					{
+                        "openroadm-operational-mode-id": "OR-W-600G-oFEC-124Gbd",
+                        "baud-rate": "124.7",
+                        "line-rate": "633.9",
+                        "modulation-format": "pcs-dp-qam16",
+                        "min-TX-osnr": "37.000",
+                        "TX-OOB-osnr": [{
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-OOB-osnr-multi-channel-value": "36.000",
+                            "min-OOB-osnr-single-channel-value": "43.000"
+                        }],
+                        "output-power-range": [{
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-output-power": "-5.000",
+                            "max-output-power": "0.000"
+                        }],
+                        "min-RX-osnr-tolerance": "99.999",
+                        "min-input-power-at-RX-osnr": "-11.000",
+                        "max-input-power": "1.000",
+                        "channel-width": "149.64000",
+                        "fec-type": "org-openroadm-common-types:ofec",
+                        "min-roll-off": "0.05",
+                        "max-roll-off": "0.20",
+                        "penalties": [
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "4000",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "22000",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "1.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "2.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "4.00",
+                                "penalty-value": "2.500"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "10.00",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "25.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-11.00",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-18.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "cross-talk-total-power-dB",
+                                "up-to-boundary": "15.00",
+                                "penalty-value": "0.300"
+                            },
+                            {
+                                "parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+                                "up-to-boundary": "4.10",
+                                "penalty-value": "0.500"
+                            }
+                        ]
+                    },
+					{
+                        "openroadm-operational-mode-id": "OR-W-600G-oFEC-118Gbd",
+                        "baud-rate": "118.8",
+                        "line-rate": "633.9",
+                        "modulation-format": "pcs-dp-qam16",
+                        "min-TX-osnr": "37.000",
+                        "TX-OOB-osnr": [{
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-OOB-osnr-multi-channel-value": "36.000",
+                            "min-OOB-osnr-single-channel-value": "43.000"
+                        }],
+                        "output-power-range": [{
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-output-power": "-5.000",
+                            "max-output-power": "0.000"
+                        }],
+                        "min-RX-osnr-tolerance": "99.999",
+                        "min-input-power-at-RX-osnr": "-11.000",
+                        "max-input-power": "1.000",
+                        "channel-width": "142.56000",
+                        "fec-type": "org-openroadm-common-types:ofec",
+                        "min-roll-off": "0.05",
+                        "max-roll-off": "0.20",
+                        "penalties": [
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "4000",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "22000",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "1.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "2.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "4.00",
+                                "penalty-value": "2.500"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "10.00",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "25.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-11.00",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-18.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "cross-talk-total-power-dB",
+                                "up-to-boundary": "15.00",
+                                "penalty-value": "0.300"
+                            },
+                            {
+                                "parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+                                "up-to-boundary": "4.10",
+                                "penalty-value": "0.500"
+                            }
+                        ]
+                    },
+					{
+                        "openroadm-operational-mode-id": "OR-W-800G-oFEC-131GbdE",
+                        "baud-rate": "131.3",
+                        "line-rate": "845.1",
+                        "modulation-format": "pcs-dp-qam16",
+                        "min-TX-osnr": "37.000",
+                        "TX-OOB-osnr": [{
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-OOB-osnr-multi-channel-value": "36.000",
+                            "min-OOB-osnr-single-channel-value": "43.000"
+                        }],
+                        "output-power-range": [{
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-output-power": "-5.000",
+                            "max-output-power": "0.000"
+                        }],
+                        "min-RX-osnr-tolerance": "25.000",
+                        "min-input-power-at-RX-osnr": "-11.000",
+                        "max-input-power": "1.000",
+                        "channel-width": "157.60800",
+                        "fec-type": "org-openroadm-common-types:ofec",
+                        "min-roll-off": "0.05",
+                        "max-roll-off": "0.20",
+                        "penalties": [
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "4000",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "20000",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "1.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "2.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "4.00",
+                                "penalty-value": "2.500"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "10.00",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "20.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-11.00",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-14.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "cross-talk-total-power-dB",
+                                "up-to-boundary": "13.00",
+                                "penalty-value": "0.300"
+                            },
+							{
+                                "parameter-and-unit": "cross-talk-total-power-dB",
+                                "up-to-boundary": "15.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+                                "up-to-boundary": "4.10",
+                                "penalty-value": "0.500"
+                            }
+                        ]
+                    },
+					{
+                        "openroadm-operational-mode-id": "OR-W-800G-oFEC-131GbdM",
+                        "baud-rate": "131.4",
+                        "line-rate": "845.1",
+                        "modulation-format": "pcs-dp-qam16",
+                        "min-TX-osnr": "37.000",
+                        "TX-OOB-osnr": [{
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-OOB-osnr-multi-channel-value": "36.000",
+                            "min-OOB-osnr-single-channel-value": "43.000"
+                        }],
+                        "output-power-range": [{
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-output-power": "-5.000",
+                            "max-output-power": "0.000"
+                        }],
+                        "min-RX-osnr-tolerance": "26.000",
+                        "min-input-power-at-RX-osnr": "-11.000",
+                        "max-input-power": "1.000",
+                        "channel-width": "157.62000",
+                        "fec-type": "org-openroadm-common-types:ofec",
+                        "min-roll-off": "0.05",
+                        "max-roll-off": "0.20",
+                        "penalties": [
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "4000",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "20000",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "1.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "2.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "4.00",
+                                "penalty-value": "2.500"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "10.00",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "20.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-11.00",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-14.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "cross-talk-total-power-dB",
+                                "up-to-boundary": "13.00",
+                                "penalty-value": "0.300"
+                            },
+							{
+                                "parameter-and-unit": "cross-talk-total-power-dB",
+                                "up-to-boundary": "15.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+                                "up-to-boundary": "4.10",
+                                "penalty-value": "0.500"
+                            }
+                        ]
+                    },
+					{
+                        "openroadm-operational-mode-id": "OR-W-600G-oFEC-124Gbd_type2",
+                        "baud-rate": "124.7",
+                        "line-rate": "633.9",
+                        "modulation-format": "pcs-dp-qam16",
+                        "min-TX-osnr": "37.000",
+                        "TX-OOB-osnr": [{
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-OOB-osnr-multi-channel-value": "36.000",
+                            "min-OOB-osnr-single-channel-value": "43.000"
+                        }],
+                        "output-power-range": [{
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-output-power": "-5.000",
+                            "max-output-power": "0.000"
+                        }],
+                        "min-RX-osnr-tolerance": "99.999",
+                        "min-input-power-at-RX-osnr": "-11.000",
+                        "max-input-power": "1.000",
+                        "channel-width": "149.64000",
+                        "fec-type": "org-openroadm-common-types:ofec",
+                        "min-roll-off": "0.05",
+                        "max-roll-off": "0.20",
+                        "penalties": [
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "4000",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "22000",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "1.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "2.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "4.00",
+                                "penalty-value": "2.500"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "10.00",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "25.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-11.00",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-18.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "cross-talk-total-power-dB",
+                                "up-to-boundary": "15.00",
+                                "penalty-value": "0.300"
+                            },
+                            {
+                                "parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+                                "up-to-boundary": "4.10",
+                                "penalty-value": "0.500"
+                            }
+                        ]
+                    },
+					{
+                        "openroadm-operational-mode-id": "OR-W-600G-oFEC-118Gbd_type2",
+                        "baud-rate": "118.8",
+                        "line-rate": "633.9",
+                        "modulation-format": "pcs-dp-qam16",
+                        "min-TX-osnr": "37.000",
+                        "TX-OOB-osnr": [{
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-OOB-osnr-multi-channel-value": "36.000",
+                            "min-OOB-osnr-single-channel-value": "43.000"
+                        }],
+                        "output-power-range": [{
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-output-power": "-5.000",
+                            "max-output-power": "0.000"
+                        }],
+                        "min-RX-osnr-tolerance": "99.999",
+                        "min-input-power-at-RX-osnr": "-11.000",
+                        "max-input-power": "1.000",
+                        "channel-width": "142.56000",
+                        "fec-type": "org-openroadm-common-types:ofec",
+                        "min-roll-off": "0.05",
+                        "max-roll-off": "0.20",
+                        "penalties": [
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "4000",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "22000",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "1.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "2.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "4.00",
+                                "penalty-value": "2.500"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "10.00",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "25.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-11.00",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-18.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "cross-talk-total-power-dB",
+                                "up-to-boundary": "15.00",
+                                "penalty-value": "0.300"
+                            },
+                            {
+                                "parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+                                "up-to-boundary": "4.10",
+                                "penalty-value": "0.500"
+                            }
+                        ]
+                    },
+					{
+                        "openroadm-operational-mode-id": "OR-W-800G-oFEC-131GbdE_type2",
+                        "baud-rate": "131.3",
+                        "line-rate": "845.1",
+                        "modulation-format": "pcs-dp-qam16",
+                        "min-TX-osnr": "37.000",
+                        "TX-OOB-osnr": [{
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-OOB-osnr-multi-channel-value": "36.000",
+                            "min-OOB-osnr-single-channel-value": "43.000"
+                        }],
+                        "output-power-range": [{
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-output-power": "-5.000",
+                            "max-output-power": "0.000"
+                        }],
+                        "min-RX-osnr-tolerance": "25.000",
+                        "min-input-power-at-RX-osnr": "-11.000",
+                        "max-input-power": "1.000",
+                        "channel-width": "157.60800",
+                        "fec-type": "org-openroadm-common-types:ofec",
+                        "min-roll-off": "0.05",
+                        "max-roll-off": "0.20",
+                        "penalties": [
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "4000",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "20000",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "1.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "2.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "4.00",
+                                "penalty-value": "2.500"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "10.00",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "20.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-11.00",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-14.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "cross-talk-total-power-dB",
+                                "up-to-boundary": "13.00",
+                                "penalty-value": "0.300"
+                            },
+							{
+                                "parameter-and-unit": "cross-talk-total-power-dB",
+                                "up-to-boundary": "15.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+                                "up-to-boundary": "4.10",
+                                "penalty-value": "0.500"
+                            }
+                        ]
+                    },
+					{
+                        "openroadm-operational-mode-id": "OR-W-800G-oFEC-131GbdM_type2",
+                        "baud-rate": "131.4",
+                        "line-rate": "845.1",
+                        "modulation-format": "pcs-dp-qam16",
+                        "min-TX-osnr": "37.000",
+                        "TX-OOB-osnr": [{
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-OOB-osnr-multi-channel-value": "36.000",
+                            "min-OOB-osnr-single-channel-value": "43.000"
+                        }],
+                        "output-power-range": [{
+                            "WR-openroadm-operational-mode-id": "MW-WR-core",
+                            "min-output-power": "-5.000",
+                            "max-output-power": "0.000"
+                        }],
+                        "min-RX-osnr-tolerance": "26.000",
+                        "min-input-power-at-RX-osnr": "-11.000",
+                        "max-input-power": "1.000",
+                        "channel-width": "157.62000",
+                        "fec-type": "org-openroadm-common-types:ofec",
+                        "min-roll-off": "0.05",
+                        "max-roll-off": "0.20",
+                        "penalties": [
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "4000",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "CD-ps/nm",
+                                "up-to-boundary": "20000",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "1.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "2.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "PDL-dB",
+                                "up-to-boundary": "4.00",
+                                "penalty-value": "2.500"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "10.00",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "PMD-ps",
+                                "up-to-boundary": "20.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-11.00",
+                                "penalty-value": "0.000"
+                            },
+                            {
+                                "parameter-and-unit": "power-dBm",
+                                "up-to-boundary": "-14.00",
+                                "penalty-value": "1.000"
+                            },
+                            {
+                                "parameter-and-unit": "cross-talk-total-power-dB",
+                                "up-to-boundary": "13.00",
+                                "penalty-value": "0.300"
+                            },
+							{
+                                "parameter-and-unit": "cross-talk-total-power-dB",
+                                "up-to-boundary": "15.00",
+                                "penalty-value": "0.500"
+                            },
+                            {
+                                "parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+                                "up-to-boundary": "4.10",
+                                "penalty-value": "0.500"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "roadms": {
+                "Express": {
+                    "openroadm-operational-mode": {
+                        "openroadm-operational-mode-id": "MW-MW-core",
+                        "per-channel-Pin-min": "-21.000",
+                        "per-channel-Pin-max": "-9.000",
+                        "max-introduced-pdl": "1.500",
+                        "max-introduced-dgd": "3.00",
+                        "max-introduced-cd": "25.00",
+                        "osnr-polynomial-fit": {
+                            "A": "-0.00059520",
+                            "B": "-0.06250000",
+                            "C": "-1.07100000",
+                            "D": "27.99000000"
+                        },
+                        "mask-power-vs-pin": [
+                            {
+                                "lower-boundary": "0",
+                                "upper-boundary": "6",
+                                "C": "1.00000000",
+                                "D": "-9.00000000",
+                                "fiber-type": "smf"
+                            },
+                            {
+                                "lower-boundary": "6",
+                                "upper-boundary": "8",
+                                "C": "-0.00000000",
+                                "D": "-3.00000000",
+                                "fiber-type": "smf"
+                            },
+                            {
+                                "lower-boundary": "8",
+                                "upper-boundary": "23",
+                                "C": "0.33333334",
+                                "D": "-5.66666667",
+                                "fiber-type": "smf"
+                            },
+                            {
+                                "lower-boundary": "23",
+                                "upper-boundary": "27",
+                                "C": "0.00000000",
+                                "D": "2.00000000",
+                                "fiber-type": "smf"
+                            }
+                        ]
+                    }
+                },
+                "Add": {
+                    "add-openroadm-operational-mode": {
+                        "openroadm-operational-mode-id": "MW-WR-core",
+                        "incremental-osnr": "33.000",
+                        "per-channel-Pin-min": "-6.000",
+                        "per-channel-Pin-max": "3.000",
+                        "max-introduced-pdl": "1.500",
+                        "max-introduced-dgd": "3.00",
+                        "max-introduced-cd": "25.00",
+                        "mask-power-vs-pin": [
+                            {
+                                "lower-boundary": "0",
+                                "upper-boundary": "6",
+                                "C": "1.00000000",
+                                "D": "-9.00000000",
+                                "fiber-type": "smf"
+                            },
+                            {
+                                "lower-boundary": "6",
+                                "upper-boundary": "8",
+                                "C": "-0.00000000",
+                                "D": "-3.00000000",
+                                "fiber-type": "smf"
+                            },
+                            {
+                                "lower-boundary": "8",
+                                "upper-boundary": "23",
+                                "C": "0.33333334",
+                                "D": "-5.66666667",
+                                "fiber-type": "smf"
+                            },
+                            {
+                                "lower-boundary": "23",
+                                "upper-boundary": "27",
+                                "C": "0.00000000",
+                                "D": "2.00000000",
+                                "fiber-type": "smf"
+                            }
+                        ]
+                    }
+                },
+                "Drop": {
+                    "openroadm-operational-mode": {
+                        "openroadm-operational-mode-id": "MW-WR-core",
+                        "per-channel-Pin-min": "-25.000",
+                        "per-channel-Pin-max": "-9.000",
+                        "max-introduced-pdl": "1.500",
+                        "max-introduced-dgd": "3.00",
+                        "max-introduced-cd": "25.00",
+                        "osnr-polynomial-fit": {
+                            "A": "-0.00059520",
+                            "B": "-0.06250000",
+                            "C": "-1.07100000",
+                            "D": "27.99000000"
+                        },
+                        "per-channel-Pout-min": "-22.000",
+                        "per-channel-Pout-max": "1.000"
+                    }
+                }
+            },
+            "amplifiers": {
+				"Amplifier": {
+					"openroadm-operational-mode": [
+						{
+							"openroadm-operational-mode-id": "MWi-standard",
+							"per-channel-Pin-min": "-31.000",
+							"per-channel-Pin-max": "-9.000",
+							"max-introduced-pdl": "0.70",
+							"max-introduced-dgd": "3.00",
+							"max-introduced-cd": "0.00",
+							"osnr-polynomial-fit": {
+								"A": "-0.00059520",
+								"B": "-0.06250000",
+								"C": "-1.07100000",
+								"D": "28.99000000"
+							},
+							"mask-power-vs-pin": [
+								{
+									"lower-boundary": "0",
+									"upper-boundary": "6",
+									"C": "1.00000000",
+									"D": "-9.00000000",
+									"fiber-type": "smf"
+								},
+								{
+									"lower-boundary": "6",
+									"upper-boundary": "8",
+									"C": "-0.00000000",
+									"D": "-3.00000000",
+									"fiber-type": "smf"
+								},
+								{
+									"lower-boundary": "8",
+									"upper-boundary": "23",
+									"C": "0.33333334",
+									"D": "-5.66666667",
+									"fiber-type": "smf"
+								},
+								{
+									"lower-boundary": "23",
+									"upper-boundary": "31",
+									"C": "0.00000000",
+									"D": "2.00000000",
+									"fiber-type": "smf"
+								}
+							],
+							"min-gain": "0.000",
+							"max-gain": "27.000",
+							"max-extended-gain": "31.000",
+							"mask-gain-ripple-vs-tilt": [
+								{
+									"lower-boundary": "-4",
+									"upper-boundary": "-1",
+									"C": "-0.50",
+									"D": "1.00"
+								},
+								{
+									"lower-boundary": "-1",
+									"upper-boundary": "0",
+									"C": "0.50",
+									"D": "2.00"
+								}
+							]
+						},
+						{
+							"openroadm-operational-mode-id": "MWi-low-noise",
+							"per-channel-Pin-min": "-31.000",
+							"per-channel-Pin-max": "-9.000",
+							"max-introduced-pdl": "0.700",
+							"max-introduced-dgd": "3.00",
+							"max-introduced-cd": "0.00",
+							"osnr-polynomial-fit": {
+								"A": "-0.00081040",
+								"B": "-0.06221000",
+								"C": "-0.58890000",
+								"D": "37.62000000"
+							},
+							"mask-power-vs-pin": [
+								{
+									"lower-boundary": "0",
+									"upper-boundary": "6",
+									"C": "1.00000000",
+									"D": "-9.00000000",
+									"fiber-type": "smf"
+								},
+								{
+									"lower-boundary": "6",
+									"upper-boundary": "8",
+									"C": "-0.00000000",
+									"D": "-3.00000000",
+									"fiber-type": "smf"
+								},
+								{
+									"lower-boundary": "8",
+									"upper-boundary": "23",
+									"C": "0.33333334",
+									"D": "-5.66666667",
+									"fiber-type": "smf"
+								},
+								{
+									"lower-boundary": "23",
+									"upper-boundary": "31",
+									"C": "0.00000000",
+									"D": "2.00000000",
+									"fiber-type": "smf"
+								}
+							],
+							"min-gain": "0.000",
+							"max-gain": "27.000",
+							"max-extended-gain": "31.000",
+							 "mask-gain-ripple-vs-tilt": [
+								{
+									"lower-boundary": "-4",
+									"upper-boundary": "-1",
+									"C": "-0.50",
+									"D": "1.00"
+								},
+								{
+									"lower-boundary": "-1",
+									"upper-boundary": "0",
+									"C": "0.50",
+									"D": "2.00"
+								}
+							]
+						}
+					]
+				}
+			}
+        }
+    }
+}

--- a/model/Specifications/body-rpc-add-operational-modes-to-catalog-10_1-optical-spec-5_1.json
+++ b/model/Specifications/body-rpc-add-operational-modes-to-catalog-10_1-optical-spec-5_1.json
@@ -7,9 +7,9 @@
 		    },		
             "operational-mode-info": {
                 "grid-parameters": {
-                    "min-central-frequency": "191.32500000",
-                    "max-central-frequency": "196.12500000",
-                    "central-frequency-granularity": "12.50000",
+                    "min-central-frequency": "191.35000000",
+                    "max-central-frequency": "196.10000000",
+                    "central-frequency-granularity": "6.250000",
                     "min-spacing": "37.50000"
                 },
                 "xponders-pluggables": {
@@ -20,16 +20,16 @@
                             "line-rate": "111.8",
                             "modulation-format": "dp-qpsk",
                             "min-TX-osnr": "33.000",
-                            "TX-OOB-osnr": {
+                            "TX-OOB-osnr": [{
                                 "WR-openroadm-operational-mode-id": "MW-WR-core",
                                 "min-OOB-osnr-multi-channel-value": "31.000",
                                 "min-OOB-osnr-single-channel-value": "43.000"
-                            },
-                            "output-power-range": {
+                            }],
+                            "output-power-range": [{
                                 "WR-openroadm-operational-mode-id": "MW-WR-core",
                                 "min-output-power": "-5.000",
                                 "max-output-power": "0.000"
-                            },
+                            }],
                             "min-RX-osnr-tolerance": "17.000",
                             "min-input-power-at-RX-osnr": "-22.000",
                             "max-input-power": "1.000",
@@ -74,20 +74,21 @@
                             "line-rate": "126.3",
                             "modulation-format": "dp-qpsk",
                             "min-TX-osnr": "37.000",
-                            "TX-OOB-osnr": {
+                            "TX-OOB-osnr": [{
                                 "WR-openroadm-operational-mode-id": "MW-WR-core",
-                                "min-OOB-osnr-multi-channel-value": "36.000"
-                            },
-                            "output-power-range": {
+                                "min-OOB-osnr-multi-channel-value": "36.000",
+                                "min-OOB-osnr-single-channel-value": "43.000"
+                           }],
+                            "output-power-range": [{
                                 "WR-openroadm-operational-mode-id": "MW-WR-core",
                                 "min-output-power": "-5.000",
                                 "max-output-power": "0.000"
-                            },
+                            }],
                             "min-RX-osnr-tolerance": "12.000",
                             "min-input-power-at-RX-osnr": "-18.000",
                             "max-input-power": "1.000",
                             "channel-width": "37.88400",
-                            "fec-type": "ofec",
+                            "fec-type": "org-openroadm-common-types:ofec",
                             "min-roll-off": "0.05",
                             "max-roll-off": "0.20",
                             "penalties": [
@@ -159,20 +160,21 @@
                             "line-rate": "252.6",
                             "modulation-format": "dp-qam16",
                             "min-TX-osnr": "37.000",
-                            "TX-OOB-osnr": {
+                            "TX-OOB-osnr": [{
                                 "WR-openroadm-operational-mode-id": "MW-WR-core",
-                                "min-OOB-osnr-multi-channel-value": "36.000"
-                            },
-                            "output-power-range": {
+                                "min-OOB-osnr-multi-channel-value": "36.000",
+                                "min-OOB-osnr-single-channel-value": "43.000"
+                            }],
+                            "output-power-range": [{
                                 "WR-openroadm-operational-mode-id": "MW-WR-core",
                                 "min-output-power": "-5.000",
                                 "max-output-power": "0.000"
-                            },
+                            }],
                             "min-RX-osnr-tolerance": "20.500",
                             "min-input-power-at-RX-osnr": "-16.000",
                             "max-input-power": "1.000",
                             "channel-width": "37.88400",
-                            "fec-type": "ofec",
+                            "fec-type": "org-openroadm-common-types:ofec",
                             "min-roll-off": "0.05",
                             "max-roll-off": "0.20",
                             "penalties": [
@@ -249,20 +251,21 @@
                             "line-rate": "252.6",
                             "modulation-format": "dp-qpsk",
                             "min-TX-osnr": "37.000",
-                            "TX-OOB-osnr": {
+                            "TX-OOB-osnr": [{
                                 "WR-openroadm-operational-mode-id": "MW-WR-core",
-                                "min-OOB-osnr-multi-channel-value": "36.000"
-                            },
-                            "output-power-range": {
+                                "min-OOB-osnr-multi-channel-value": "36.000",
+                                "min-OOB-osnr-single-channel-value": "43.000"
+                            }],
+                            "output-power-range": [{
                                 "WR-openroadm-operational-mode-id": "MW-WR-core",
                                 "min-output-power": "-5.000",
                                 "max-output-power": "0.000"
-                            },
+                            }],
                             "min-RX-osnr-tolerance": "17.000",
                             "min-input-power-at-RX-osnr": "-18.000",
                             "max-input-power": "1.000",
                             "channel-width": "75.72000",
-                            "fec-type": "ofec",
+                            "fec-type": "org-openroadm-common-types:ofec",
                             "min-roll-off": "0.05",
                             "max-roll-off": "0.20",
                             "penalties": [
@@ -329,20 +332,21 @@
                             "line-rate": "378.8",
                             "modulation-format": "dp-qam8",
                             "min-TX-osnr": "37.000",
-                            "TX-OOB-osnr": {
+                            "TX-OOB-osnr": [{
                                 "WR-openroadm-operational-mode-id": "MW-WR-core",
-                                "min-OOB-osnr-multi-channel-value": "36.000"
-                            },
-                            "output-power-range": {
+                                "min-OOB-osnr-multi-channel-value": "36.000",
+                                "min-OOB-osnr-single-channel-value": "43.000"
+                            }],
+                            "output-power-range": [{
                                 "WR-openroadm-operational-mode-id": "MW-WR-core",
                                 "min-output-power": "-5.000",
                                 "max-output-power": "0.000"
-                            },
+                            }],
                             "min-RX-osnr-tolerance": "21.000",
                             "min-input-power-at-RX-osnr": "-16.000",
                             "max-input-power": "1.000",
                             "channel-width": "75.72000",
-                            "fec-type": "ofec",
+                            "fec-type": "org-openroadm-common-types:ofec",
                             "min-roll-off": "0.05",
                             "max-roll-off": "0.20",
                             "penalties": [
@@ -414,20 +418,21 @@
                             "line-rate": "505.1",
                             "modulation-format": "dp-qam16",
                             "min-TX-osnr": "37.000",
-                            "TX-OOB-osnr": {
+                            "TX-OOB-osnr": [{
                                 "WR-openroadm-operational-mode-id": "MW-WR-core",
-                                "min-OOB-osnr-multi-channel-value": "36.000"
-                            },
-                            "output-power-range": {
+                                "min-OOB-osnr-multi-channel-value": "36.000",
+                                "min-OOB-osnr-single-channel-value": "43.000"
+                            }],
+                            "output-power-range": [{
                                 "WR-openroadm-operational-mode-id": "MW-WR-core",
                                 "min-output-power": "-5.000",
                                 "max-output-power": "0.000"
-                            },
+                            }],
                             "min-RX-osnr-tolerance": "24.000",
                             "min-input-power-at-RX-osnr": "-14.000",
                             "max-input-power": "1.000",
                             "channel-width": "75.72000",
-                            "fec-type": "ofec",
+                            "fec-type": "org-openroadm-common-types:ofec",
                             "min-roll-off": "0.05",
                             "max-roll-off": "0.20",
                             "penalties": [

--- a/model/Specifications/body-rpc-add-operational-modes-to-catalog-12_0-optical-spec-5_1.json
+++ b/model/Specifications/body-rpc-add-operational-modes-to-catalog-12_0-optical-spec-5_1.json
@@ -7,9 +7,9 @@
 		    },		
             "operational-mode-info": {
                 "grid-parameters": {
-                    "min-central-frequency": "191.32500000",
-                    "max-central-frequency": "196.12500000",
-                    "central-frequency-granularity": "12.50000",
+                    "min-central-frequency": "191.35000000",
+                    "max-central-frequency": "196.10000000",
+                    "central-frequency-granularity": "6.250000",
                     "min-spacing": "37.50000"
                 },
                 "xponders-pluggables": {
@@ -20,16 +20,16 @@
                             "line-rate": "111.8",
                             "modulation-format": "dp-qpsk",
                             "min-TX-osnr": "33.000",
-                            "TX-OOB-osnr": {
+                            "TX-OOB-osnr": [{
                                 "WR-openroadm-operational-mode-id": "MW-WR-core",
                                 "min-OOB-osnr-multi-channel-value": "31.000",
                                 "min-OOB-osnr-single-channel-value": "43.000"
-                            },
-                            "output-power-range": {
+                            }],
+                            "output-power-range": [{
                                 "WR-openroadm-operational-mode-id": "MW-WR-core",
                                 "min-output-power": "-5.000",
                                 "max-output-power": "0.000"
-                            },
+                            }],
                             "min-RX-osnr-tolerance": "17.000",
                             "min-input-power-at-RX-osnr": "-22.000",
                             "max-input-power": "1.000",
@@ -74,20 +74,21 @@
                             "line-rate": "126.3",
                             "modulation-format": "dp-qpsk",
                             "min-TX-osnr": "37.000",
-                            "TX-OOB-osnr": {
+                            "TX-OOB-osnr": [{
                                 "WR-openroadm-operational-mode-id": "MW-WR-core",
-                                "min-OOB-osnr-multi-channel-value": "36.000"
-                            },
-                            "output-power-range": {
+                                "min-OOB-osnr-multi-channel-value": "36.000",
+                                "min-OOB-osnr-single-channel-value": "43.000"
+                            }],
+                            "output-power-range": [{
                                 "WR-openroadm-operational-mode-id": "MW-WR-core",
                                 "min-output-power": "-5.000",
                                 "max-output-power": "0.000"
-                            },
+                            }],
                             "min-RX-osnr-tolerance": "12.000",
                             "min-input-power-at-RX-osnr": "-18.000",
                             "max-input-power": "1.000",
                             "channel-width": "37.88400",
-                            "fec-type": "ofec",
+                            "fec-type": "org-openroadm-common-types:ofec",
                             "min-roll-off": "0.05",
                             "max-roll-off": "0.20",
                             "penalties": [
@@ -159,20 +160,21 @@
                             "line-rate": "252.6",
                             "modulation-format": "dp-qam16",
                             "min-TX-osnr": "37.000",
-                            "TX-OOB-osnr": {
+                            "TX-OOB-osnr": [{
                                 "WR-openroadm-operational-mode-id": "MW-WR-core",
-                                "min-OOB-osnr-multi-channel-value": "36.000"
-                            },
-                            "output-power-range": {
+                                "min-OOB-osnr-multi-channel-value": "36.000",
+                                "min-OOB-osnr-single-channel-value": "43.000"
+                            }],
+                            "output-power-range": [{
                                 "WR-openroadm-operational-mode-id": "MW-WR-core",
                                 "min-output-power": "-5.000",
                                 "max-output-power": "0.000"
-                            },
+                            }],
                             "min-RX-osnr-tolerance": "20.500",
                             "min-input-power-at-RX-osnr": "-16.000",
                             "max-input-power": "1.000",
                             "channel-width": "37.88400",
-                            "fec-type": "ofec",
+                            "fec-type": "org-openroadm-common-types:ofec",
                             "min-roll-off": "0.05",
                             "max-roll-off": "0.20",
                             "penalties": [
@@ -249,20 +251,21 @@
                             "line-rate": "252.6",
                             "modulation-format": "dp-qpsk",
                             "min-TX-osnr": "37.000",
-                            "TX-OOB-osnr": {
+                            "TX-OOB-osnr": [{
                                 "WR-openroadm-operational-mode-id": "MW-WR-core",
-                                "min-OOB-osnr-multi-channel-value": "36.000"
-                            },
-                            "output-power-range": {
+                                "min-OOB-osnr-multi-channel-value": "36.000",
+                                "min-OOB-osnr-single-channel-value": "43.000"
+                            }],
+                            "output-power-range": [{
                                 "WR-openroadm-operational-mode-id": "MW-WR-core",
                                 "min-output-power": "-5.000",
                                 "max-output-power": "0.000"
-                            },
+                            }],
                             "min-RX-osnr-tolerance": "17.000",
                             "min-input-power-at-RX-osnr": "-18.000",
                             "max-input-power": "1.000",
                             "channel-width": "75.72000",
-                            "fec-type": "ofec",
+                            "fec-type": "org-openroadm-common-types:ofec",
                             "min-roll-off": "0.05",
                             "max-roll-off": "0.20",
                             "penalties": [
@@ -329,20 +332,21 @@
                             "line-rate": "378.8",
                             "modulation-format": "dp-qam8",
                             "min-TX-osnr": "37.000",
-                            "TX-OOB-osnr": {
+                            "TX-OOB-osnr": [{
                                 "WR-openroadm-operational-mode-id": "MW-WR-core",
-                                "min-OOB-osnr-multi-channel-value": "36.000"
-                            },
-                            "output-power-range": {
+                                "min-OOB-osnr-multi-channel-value": "36.000",
+                                "min-OOB-osnr-single-channel-value": "43.000"
+                            }],
+                            "output-power-range": [{
                                 "WR-openroadm-operational-mode-id": "MW-WR-core",
                                 "min-output-power": "-5.000",
                                 "max-output-power": "0.000"
-                            },
+                            }],
                             "min-RX-osnr-tolerance": "21.000",
                             "min-input-power-at-RX-osnr": "-16.000",
                             "max-input-power": "1.000",
                             "channel-width": "75.72000",
-                            "fec-type": "ofec",
+                            "fec-type": "org-openroadm-common-types:ofec",
                             "min-roll-off": "0.05",
                             "max-roll-off": "0.20",
                             "penalties": [
@@ -414,20 +418,21 @@
                             "line-rate": "505.1",
                             "modulation-format": "dp-qam16",
                             "min-TX-osnr": "37.000",
-                            "TX-OOB-osnr": {
+                            "TX-OOB-osnr": [{
                                 "WR-openroadm-operational-mode-id": "MW-WR-core",
-                                "min-OOB-osnr-multi-channel-value": "36.000"
-                            },
-                            "output-power-range": {
+                                "min-OOB-osnr-multi-channel-value": "36.000",
+                                "min-OOB-osnr-single-channel-value": "43.000"
+                            }],
+                            "output-power-range": [{
                                 "WR-openroadm-operational-mode-id": "MW-WR-core",
                                 "min-output-power": "-5.000",
                                 "max-output-power": "0.000"
-                            },
+                            }],
                             "min-RX-osnr-tolerance": "24.000",
                             "min-input-power-at-RX-osnr": "-14.000",
                             "max-input-power": "1.000",
                             "channel-width": "75.72000",
-                            "fec-type": "ofec",
+                            "fec-type": "org-openroadm-common-types:ofec",
                             "min-roll-off": "0.05",
                             "max-roll-off": "0.20",
                             "penalties": [

--- a/model/Specifications/body-rpc-add-operational-modes-to-catalog-13_1-optical-spec-6_0.json
+++ b/model/Specifications/body-rpc-add-operational-modes-to-catalog-13_1-optical-spec-6_0.json
@@ -1,0 +1,2081 @@
+{
+	"input": {
+		    "sdnc-request-header": {
+			    "request-id": "load-OM-Catalog",
+			    "rpc-action": "fill-catalog-with-or-operational-modes",
+			    "request-system-id": "appname"
+		    },		
+            "operational-mode-info": {
+                "grid-parameters": {
+                    "min-central-frequency": "191.35000000",
+                    "max-central-frequency": "196.10000000",
+                    "central-frequency-granularity": "6.250000",
+                    "min-spacing": "37.50000"
+                },
+                "xponders-pluggables": {
+                    "xponder-pluggable-openroadm-operational-mode": [
+                        {
+                            "openroadm-operational-mode-id": "OR-W-100G-SC",
+                            "baud-rate": "28.0",
+                            "line-rate": "111.8",
+                            "modulation-format": "dp-qpsk",
+                            "min-TX-osnr": "33.000",
+                            "TX-OOB-osnr": [{
+                                "WR-openroadm-operational-mode-id": "MW-WR-core",
+                                "min-OOB-osnr-multi-channel-value": "31.000",
+                                "min-OOB-osnr-single-channel-value": "43.000"
+                            }],
+                            "output-power-range": [{
+                                "WR-openroadm-operational-mode-id": "MW-WR-core",
+                                "min-output-power": "-5.000",
+                                "max-output-power": "0.000"
+                            }],
+                            "min-RX-osnr-tolerance": "17.000",
+                            "min-input-power-at-RX-osnr": "-22.000",
+                            "max-input-power": "1.000",
+                            "channel-width": "40.00000",
+                            "fec-type": "org-openroadm-common-types:scfec",
+                            "penalties": [
+                                {
+                                    "parameter-and-unit": "CD-ps/nm",
+                                    "up-to-boundary": "18000.00",
+                                    "penalty-value": "0.000"
+                                },
+                                {
+                                    "parameter-and-unit": "PDL-dB",
+                                    "up-to-boundary": "6.00",
+                                    "penalty-value": "0.000"
+                                },
+                                {
+                                    "parameter-and-unit": "PMD-ps",
+                                    "up-to-boundary": "30.00",
+                                    "penalty-value": "0.000"
+                                },
+                                {
+                                    "parameter-and-unit": "power-dBm",
+                                    "up-to-boundary": "-22.00",
+                                    "penalty-value": "0.000"
+                                },
+                                {
+                                    "parameter-and-unit": "cross-talk-total-power-dB",
+                                    "up-to-boundary": "15.00",
+                                    "penalty-value": "0.200"
+                                },
+                                {
+                                    "parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+                                    "up-to-boundary": "4.00",
+                                    "penalty-value": "0.200"
+                                }
+                            ]
+                        },
+                        {
+                            "openroadm-operational-mode-id": "OR-W-100G-oFEC-31.6Gbd",
+                            "baud-rate": "31.6",
+                            "line-rate": "126.3",
+                            "modulation-format": "dp-qpsk",
+                            "min-TX-osnr": "37.000",
+                            "TX-OOB-osnr": [{
+                                "WR-openroadm-operational-mode-id": "MW-WR-core",
+                                "min-OOB-osnr-multi-channel-value": "36.000",
+                                "min-OOB-osnr-single-channel-value": "43.000"
+                            }],
+                            "output-power-range": [{
+                                "WR-openroadm-operational-mode-id": "MW-WR-core",
+                                "min-output-power": "-5.000",
+                                "max-output-power": "0.000"
+                            }],
+                            "min-RX-osnr-tolerance": "12.000",
+                            "min-input-power-at-RX-osnr": "-18.000",
+                            "max-input-power": "1.000",
+                            "channel-width": "37.88400",
+                            "fec-type": "org-openroadm-common-types:ofec",
+                            "min-roll-off": "0.05",
+                            "max-roll-off": "0.20",
+                            "penalties": [
+                                {
+                                    "parameter-and-unit": "CD-ps/nm",
+                                    "up-to-boundary": "4000.00",
+                                    "penalty-value": "0.000"
+                                },
+                                {
+                                    "parameter-and-unit": "CD-ps/nm",
+                                    "up-to-boundary": "48000.00",
+                                    "penalty-value": "0.500"
+                                },
+                                {
+                                    "parameter-and-unit": "PDL-dB",
+                                    "up-to-boundary": "1.00",
+                                    "penalty-value": "0.500"
+                                },
+                                {
+                                    "parameter-and-unit": "PDL-dB",
+                                    "up-to-boundary": "2.00",
+                                    "penalty-value": "1.000"
+                                },
+                                {
+                                    "parameter-and-unit": "PDL-dB",
+                                    "up-to-boundary": "4.00",
+                                    "penalty-value": "2.500"
+                                },
+                                {
+                                    "parameter-and-unit": "PDL-dB",
+                                    "up-to-boundary": "6.00",
+                                    "penalty-value": "4.000"
+                                },
+                                {
+                                    "parameter-and-unit": "PMD-ps",
+                                    "up-to-boundary": "10.00",
+                                    "penalty-value": "0.000"
+                                },
+                                {
+                                    "parameter-and-unit": "PMD-ps",
+                                    "up-to-boundary": "30.00",
+                                    "penalty-value": "0.500"
+                                },
+                                {
+                                    "parameter-and-unit": "power-dBm",
+                                    "up-to-boundary": "-18.00",
+                                    "penalty-value": "0.000"
+                                },
+                                {
+                                    "parameter-and-unit": "power-dBm",
+                                    "up-to-boundary": "-20.00",
+                                    "penalty-value": "1.000"
+                                },
+                                {
+                                    "parameter-and-unit": "cross-talk-total-power-dB",
+                                    "up-to-boundary": "15.00",
+                                    "penalty-value": "0.200"
+                                },
+                                {
+                                    "parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+                                    "up-to-boundary": "4.0",
+                                    "penalty-value": "0.200"
+                                }
+                            ]
+                        },
+                        {
+                            "openroadm-operational-mode-id": "OR-W-200G-oFEC-31.6Gbd",
+                            "baud-rate": "31.6",
+                            "line-rate": "252.6",
+                            "modulation-format": "dp-qam16",
+                            "min-TX-osnr": "37.000",
+                            "TX-OOB-osnr": [{
+                                "WR-openroadm-operational-mode-id": "MW-WR-core",
+                                "min-OOB-osnr-multi-channel-value": "36.000",
+                                "min-OOB-osnr-single-channel-value": "43.000"
+                            }],
+                            "output-power-range": [{
+                                "WR-openroadm-operational-mode-id": "MW-WR-core",
+                                "min-output-power": "-5.000",
+                                "max-output-power": "0.000"
+                            }],
+                            "min-RX-osnr-tolerance": "20.500",
+                            "min-input-power-at-RX-osnr": "-16.000",
+                            "max-input-power": "1.000",
+                            "channel-width": "37.88400",
+                            "fec-type": "org-openroadm-common-types:ofec",
+                            "min-roll-off": "0.05",
+                            "max-roll-off": "0.20",
+                            "penalties": [
+                                {
+                                    "parameter-and-unit": "CD-ps/nm",
+                                    "up-to-boundary": "4000.00",
+                                    "penalty-value": "0.000"
+                                },
+                                {
+                                    "parameter-and-unit": "CD-ps/nm",
+                                    "up-to-boundary": "24000.00",
+                                    "penalty-value": "0.500"
+                                },
+                                {
+                                    "parameter-and-unit": "PDL-dB",
+                                    "up-to-boundary": "1.00",
+                                    "penalty-value": "0.500"
+                                },
+                                {
+                                    "parameter-and-unit": "PDL-dB",
+                                    "up-to-boundary": "2.00",
+                                    "penalty-value": "1.000"
+                                },
+                                {
+                                    "parameter-and-unit": "PDL-dB",
+                                    "up-to-boundary": "4.00",
+                                    "penalty-value": "2.500"
+                                },
+                                {
+                                    "parameter-and-unit": "PDL-dB",
+                                    "up-to-boundary": "6.00",
+                                    "penalty-value": "4.000"
+                                },
+                                {
+                                    "parameter-and-unit": "PMD-ps",
+                                    "up-to-boundary": "10.00",
+                                    "penalty-value": "0.000"
+                                },
+                                {
+                                    "parameter-and-unit": "PMD-ps",
+                                    "up-to-boundary": "30.00",
+                                    "penalty-value": "0.500"
+                                },
+                                {
+                                    "parameter-and-unit": "power-dBm",
+                                    "up-to-boundary": "-16.00",
+                                    "penalty-value": "0.000"
+                                },
+                                {
+                                    "parameter-and-unit": "power-dBm",
+                                    "up-to-boundary": "-18.00",
+                                    "penalty-value": "1.000"
+                                },
+                                {
+                                    "parameter-and-unit": "power-dBm",
+                                    "up-to-boundary": "-20.00",
+                                    "penalty-value": "2.000"
+                                },
+                                {
+                                    "parameter-and-unit": "cross-talk-total-power-dB",
+                                    "up-to-boundary": "15.00",
+                                    "penalty-value": "0.500"
+                                },
+                                {
+                                    "parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+                                    "up-to-boundary": "4.00",
+                                    "penalty-value": "0.500"
+                                }
+                            ]
+                        },
+                        {
+                            "openroadm-operational-mode-id": "OR-W-200G-oFEC-63.1Gbd",
+                            "baud-rate": "63.1",
+                            "line-rate": "252.6",
+                            "modulation-format": "dp-qpsk",
+                            "min-TX-osnr": "37.000",
+                            "TX-OOB-osnr": [{
+                                "WR-openroadm-operational-mode-id": "MW-WR-core",
+                                "min-OOB-osnr-multi-channel-value": "36.000",
+                                "min-OOB-osnr-single-channel-value": "43.000"
+                            }],
+                            "output-power-range": [{
+                                "WR-openroadm-operational-mode-id": "MW-WR-core",
+                                "min-output-power": "-5.000",
+                                "max-output-power": "0.000"
+                            }],
+                            "min-RX-osnr-tolerance": "16.000",
+                            "min-input-power-at-RX-osnr": "-18.000",
+                            "max-input-power": "1.000",
+                            "channel-width": "75.72000",
+                            "fec-type": "org-openroadm-common-types:ofec",
+                            "min-roll-off": "0.05",
+                            "max-roll-off": "0.20",
+                            "penalties": [
+                                {
+                                    "parameter-and-unit": "CD-ps/nm",
+                                    "up-to-boundary": "4000.00",
+                                    "penalty-value": "0.000"
+                                },
+                                {
+                                    "parameter-and-unit": "CD-ps/nm",
+                                    "up-to-boundary": "24000.00",
+                                    "penalty-value": "0.500"
+                                },
+                                {
+                                    "parameter-and-unit": "PDL-dB",
+                                    "up-to-boundary": "1.00",
+                                    "penalty-value": "0.500"
+                                },
+                                {
+                                    "parameter-and-unit": "PDL-dB",
+                                    "up-to-boundary": "2.00",
+                                    "penalty-value": "1.000"
+                                },
+                                {
+                                    "parameter-and-unit": "PDL-dB",
+                                    "up-to-boundary": "4.00",
+                                    "penalty-value": "2.500"
+                                },
+                                {
+                                    "parameter-and-unit": "PMD-ps",
+                                    "up-to-boundary": "10.00",
+                                    "penalty-value": "0.000"
+                                },
+                                {
+                                    "parameter-and-unit": "PMD-ps",
+                                    "up-to-boundary": "25.00",
+                                    "penalty-value": "0.500"
+                                },
+                                {
+                                    "parameter-and-unit": "power-dBm",
+                                    "up-to-boundary": "-18.00",
+                                    "penalty-value": "0.000"
+                                },
+                                {
+                                    "parameter-and-unit": "power-dBm",
+                                    "up-to-boundary": "-20.00",
+                                    "penalty-value": "1.000"
+                                },
+                                {
+                                    "parameter-and-unit": "cross-talk-total-power-dB",
+                                    "up-to-boundary": "15.00",
+                                    "penalty-value": "0.300"
+                                },
+                                {
+                                    "parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+                                    "up-to-boundary": "4.00",
+                                    "penalty-value": "0.500"
+                                }
+                            ]
+                        },
+                        {
+                            "openroadm-operational-mode-id": "OR-W-300G-oFEC-63.1Gbd",
+                            "baud-rate": "63.1",
+                            "line-rate": "378.8",
+                            "modulation-format": "dp-qam8",
+                            "min-TX-osnr": "37.000",
+                            "TX-OOB-osnr": [{
+                                "WR-openroadm-operational-mode-id": "MW-WR-core",
+                                "min-OOB-osnr-multi-channel-value": "36.000",
+                                "min-OOB-osnr-single-channel-value": "43.000"
+                            }],
+                            "output-power-range": [{
+                                "WR-openroadm-operational-mode-id": "MW-WR-core",
+                                "min-output-power": "-5.000",
+                                "max-output-power": "0.000"
+                            }],
+                            "min-RX-osnr-tolerance": "21.000",
+                            "min-input-power-at-RX-osnr": "-16.000",
+                            "max-input-power": "1.000",
+                            "channel-width": "75.72000",
+                            "fec-type": "org-openroadm-common-types:ofec",
+                            "min-roll-off": "0.05",
+                            "max-roll-off": "0.20",
+                            "penalties": [
+                                {
+                                    "parameter-and-unit": "CD-ps/nm",
+                                    "up-to-boundary": "4000.00",
+                                    "penalty-value": "0.000"
+                                },
+                                {
+                                    "parameter-and-unit": "CD-ps/nm",
+                                    "up-to-boundary": "18000.00",
+                                    "penalty-value": "0.500"
+                                },
+                                {
+                                    "parameter-and-unit": "PDL-dB",
+                                    "up-to-boundary": "1.00",
+                                    "penalty-value": "0.500"
+                                },
+                                {
+                                    "parameter-and-unit": "PDL-dB",
+                                    "up-to-boundary": "2.00",
+                                    "penalty-value": "1.000"
+                                },
+                                {
+                                    "parameter-and-unit": "PDL-dB",
+                                    "up-to-boundary": "4.00",
+                                    "penalty-value": "2.500"
+                                },
+                                {
+                                    "parameter-and-unit": "PMD-ps",
+                                    "up-to-boundary": "10.00",
+                                    "penalty-value": "0.000"
+                                },
+                                {
+                                    "parameter-and-unit": "PMD-ps",
+                                    "up-to-boundary": "25.00",
+                                    "penalty-value": "0.500"
+                                },
+                                {
+                                    "parameter-and-unit": "power-dBm",
+                                    "up-to-boundary": "-16.00",
+                                    "penalty-value": "0.000"
+                                },
+                                {
+                                    "parameter-and-unit": "power-dBm",
+                                    "up-to-boundary": "-18.00",
+                                    "penalty-value": "1.000"
+                                },
+                                {
+                                    "parameter-and-unit": "power-dBm",
+                                    "up-to-boundary": "-20.00",
+                                    "penalty-value": "2.000"
+                                },
+                                {
+                                    "parameter-and-unit": "cross-talk-total-power-dB",
+                                    "up-to-boundary": "15.00",
+                                    "penalty-value": "0.300"
+                                },
+                                {
+                                    "parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+                                    "up-to-boundary": "4.00",
+                                    "penalty-value": "0.500"
+                                }
+                            ]
+                        },
+                        {
+                            "openroadm-operational-mode-id": "OR-W-400G-oFEC-63.1Gbd",
+                            "baud-rate": "63.1",
+                            "line-rate": "505.1",
+                            "modulation-format": "dp-qam16",
+                            "min-TX-osnr": "37.000",
+                            "TX-OOB-osnr": [{
+                                "WR-openroadm-operational-mode-id": "MW-WR-core",
+                                "min-OOB-osnr-multi-channel-value": "36.000",
+                                "min-OOB-osnr-single-channel-value": "43.000"
+                            }],
+                            "output-power-range": [{
+                                "WR-openroadm-operational-mode-id": "MW-WR-core",
+                                "min-output-power": "-5.000",
+                                "max-output-power": "0.000"
+                            }],
+                            "min-RX-osnr-tolerance": "24.000",
+                            "min-input-power-at-RX-osnr": "-14.000",
+                            "max-input-power": "1.000",
+                            "channel-width": "75.72000",
+                            "fec-type": "org-openroadm-common-types:ofec",
+                            "min-roll-off": "0.05",
+                            "max-roll-off": "0.20",
+                            "penalties": [
+                                {
+                                    "parameter-and-unit": "CD-ps/nm",
+                                    "up-to-boundary": "4000.00",
+                                    "penalty-value": "0.000"
+                                },
+                                {
+                                    "parameter-and-unit": "CD-ps/nm",
+                                    "up-to-boundary": "12000.00",
+                                    "penalty-value": "0.500"
+                                },
+                                {
+                                    "parameter-and-unit": "PDL-dB",
+                                    "up-to-boundary": "1.00",
+                                    "penalty-value": "0.500"
+                                },
+                                {
+                                    "parameter-and-unit": "PDL-dB",
+                                    "up-to-boundary": "2.00",
+                                    "penalty-value": "1.000"
+                                },
+                                {
+                                    "parameter-and-unit": "PDL-dB",
+                                    "up-to-boundary": "4.00",
+                                    "penalty-value": "2.500"
+                                },
+                                {
+                                    "parameter-and-unit": "PMD-ps",
+                                    "up-to-boundary": "10.00",
+                                    "penalty-value": "0.000"
+                                },
+                                {
+                                    "parameter-and-unit": "PMD-ps",
+                                    "up-to-boundary": "20.00",
+                                    "penalty-value": "0.500"
+                                },
+                                {
+                                    "parameter-and-unit": "power-dBm",
+                                    "up-to-boundary": "-14.00",
+                                    "penalty-value": "0.000"
+                                },
+                                {
+                                    "parameter-and-unit": "power-dBm",
+                                    "up-to-boundary": "-16.00",
+                                    "penalty-value": "1.000"
+                                },
+                                {
+                                    "parameter-and-unit": "power-dBm",
+                                    "up-to-boundary": "-18.00",
+                                    "penalty-value": "2.000"
+                                },
+                                {
+                                    "parameter-and-unit": "cross-talk-total-power-dB",
+                                    "up-to-boundary": "13.00",
+                                    "penalty-value": "0.300"
+                                },
+                                {
+                                    "parameter-and-unit": "cross-talk-total-power-dB",
+                                    "up-to-boundary": "15.00",
+                                    "penalty-value": "0.500"
+                                },
+                                {
+                                    "parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+                                    "up-to-boundary": "4.00",
+                                    "penalty-value": "0.500"
+                                }
+                            ]
+                        },
+						{
+							"openroadm-operational-mode-id": "OR-W-400G-oFEC-124Gbd",
+							"baud-rate": "124.1",
+							"line-rate": "422.6",
+							"modulation-format": "dp-qpsk",
+							"min-TX-osnr": "37.000",
+							"TX-OOB-osnr": [{
+								"WR-openroadm-operational-mode-id": "MW-WR-core",
+								"min-OOB-osnr-multi-channel-value": "36.000",
+								"min-OOB-osnr-single-channel-value": "43.000"
+							}],
+							"output-power-range": [{
+								"WR-openroadm-operational-mode-id": "MW-WR-core",
+								"min-output-power": "-5.000",
+								"max-output-power": "0.000"
+							}],
+							"min-RX-osnr-tolerance": "20.000",
+							"min-input-power-at-RX-osnr": "-15.000",
+							"max-input-power": "1.000",
+							"channel-width": "148.92000",
+							"fec-type": "org-openroadm-common-types:ofec",
+							"min-roll-off": "0.05",
+							"max-roll-off": "0.20",
+							"penalties": [
+								{
+									"parameter-and-unit": "CD-ps/nm",
+									"up-to-boundary": "4000",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "CD-ps/nm",
+									"up-to-boundary": "24000",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "1.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "2.00",
+									"penalty-value": "1.000"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "4.00",
+									"penalty-value": "2.500"
+								},
+								{
+									"parameter-and-unit": "PMD-ps",
+									"up-to-boundary": "10.00",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "PMD-ps",
+									"up-to-boundary": "25.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "power-dBm",
+									"up-to-boundary": "-15",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "power-dBm",
+									"up-to-boundary": "-18.00",
+									"penalty-value": "1.000"
+								},
+								{
+									"parameter-and-unit": "cross-talk-total-power-dB",
+									"up-to-boundary": "15.00",
+									"penalty-value": "0.300"
+								},
+								{
+									"parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+									"up-to-boundary": "4.10",
+									"penalty-value": "0.500"
+								}
+							]
+						},
+						{
+							"openroadm-operational-mode-id": "OR-W-400G-oFEC-118Gbd",
+							"baud-rate": "118.2",
+							"line-rate": "422.6",
+							"modulation-format": "dp-qpsk",
+							"min-TX-osnr": "37.000",
+							"TX-OOB-osnr": [{
+								"WR-openroadm-operational-mode-id": "MW-WR-core",
+								"min-OOB-osnr-multi-channel-value": "36.000",
+								"min-OOB-osnr-single-channel-value": "43.000"
+						    }],
+							"output-power-range": [{
+								"WR-openroadm-operational-mode-id": "MW-WR-core",
+								"min-output-power": "-5.000",
+								"max-output-power": "0.000"
+							}],
+							"min-RX-osnr-tolerance": "20.000",
+							"min-input-power-at-RX-osnr": "-15.000",
+							"max-input-power": "1.000",
+							"channel-width": "141.84000",
+							"fec-type": "org-openroadm-common-types:ofec",
+							"min-roll-off": "0.05",
+							"max-roll-off": "0.20",
+							"penalties": [
+								{
+									"parameter-and-unit": "CD-ps/nm",
+									"up-to-boundary": "4000",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "CD-ps/nm",
+									"up-to-boundary": "24000",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "1.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "2.00",
+									"penalty-value": "1.000"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "4.00",
+									"penalty-value": "2.500"
+								},
+								{
+									"parameter-and-unit": "PMD-ps",
+									"up-to-boundary": "10.00",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "PMD-ps",
+									"up-to-boundary": "25.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "power-dBm",
+									"up-to-boundary": "-15",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "power-dBm",
+									"up-to-boundary": "-18.00",
+									"penalty-value": "1.000"
+								},
+								{
+									"parameter-and-unit": "cross-talk-total-power-dB",
+									"up-to-boundary": "15.00",
+									"penalty-value": "0.300"
+								},
+								{
+									"parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+									"up-to-boundary": "4.10",
+									"penalty-value": "0.500"
+								}
+							]
+						},
+						{
+							"openroadm-operational-mode-id": "OR-W-400G-oFEC-124Gbd_type2",
+							"baud-rate": "124.1",
+							"line-rate": "422.6",
+							"modulation-format": "dp-qpsk",
+							"min-TX-osnr": "37.000",
+							"TX-OOB-osnr": [{
+								"WR-openroadm-operational-mode-id": "MW-WR-core",
+								"min-OOB-osnr-multi-channel-value": "36.000",
+								"min-OOB-osnr-single-channel-value": "43.000"
+							}],
+							"output-power-range": [{
+								"WR-openroadm-operational-mode-id": "MW-WR-core",
+								"min-output-power": "-5.000",
+								"max-output-power": "0.000"
+							}],
+							"min-RX-osnr-tolerance": "20.000",
+							"min-input-power-at-RX-osnr": "-15.000",
+							"max-input-power": "1.000",
+							"channel-width": "148.92000",
+							"fec-type": "org-openroadm-common-types:ofec",
+							"min-roll-off": "0.05",
+							"max-roll-off": "0.20",
+							"penalties": [
+								{
+									"parameter-and-unit": "CD-ps/nm",
+									"up-to-boundary": "4000",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "CD-ps/nm",
+									"up-to-boundary": "24000",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "1.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "2.00",
+									"penalty-value": "1.000"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "4.00",
+									"penalty-value": "2.500"
+								},
+								{
+									"parameter-and-unit": "PMD-ps",
+									"up-to-boundary": "10.00",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "PMD-ps",
+									"up-to-boundary": "25.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "power-dBm",
+									"up-to-boundary": "-15",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "power-dBm",
+									"up-to-boundary": "-18.00",
+									"penalty-value": "1.000"
+								},
+								{
+									"parameter-and-unit": "cross-talk-total-power-dB",
+									"up-to-boundary": "15.00",
+									"penalty-value": "0.300"
+								},
+								{
+									"parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+									"up-to-boundary": "4.10",
+									"penalty-value": "0.500"
+								}
+							]
+						},
+						{
+							"openroadm-operational-mode-id": "OR-W-400G-oFEC-118Gbd_type2",
+							"baud-rate": "118.2",
+							"line-rate": "422.6",
+							"modulation-format": "dp-qpsk",
+							"min-TX-osnr": "37.000",
+							"TX-OOB-osnr": [{
+								"WR-openroadm-operational-mode-id": "MW-WR-core",
+								"min-OOB-osnr-multi-channel-value": "36.000",
+								"min-OOB-osnr-single-channel-value": "43.000"
+							}],
+							"output-power-range": [{
+								"WR-openroadm-operational-mode-id": "MW-WR-core",
+								"min-output-power": "-5.000",
+								"max-output-power": "0.000"
+							}],
+							"min-RX-osnr-tolerance": "20.000",
+							"min-input-power-at-RX-osnr": "-15.000",
+							"max-input-power": "1.000",
+							"channel-width": "141.84000",
+							"fec-type": "org-openroadm-common-types:ofec",
+							"min-roll-off": "0.05",
+							"max-roll-off": "0.20",
+							"penalties": [
+								{
+									"parameter-and-unit": "CD-ps/nm",
+									"up-to-boundary": "4000",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "CD-ps/nm",
+									"up-to-boundary": "24000",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "1.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "2.00",
+									"penalty-value": "1.000"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "4.00",
+									"penalty-value": "2.500"
+								},
+								{
+									"parameter-and-unit": "PMD-ps",
+									"up-to-boundary": "10.00",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "PMD-ps",
+									"up-to-boundary": "25.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "power-dBm",
+									"up-to-boundary": "-15",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "power-dBm",
+									"up-to-boundary": "-18.00",
+									"penalty-value": "1.000"
+								},
+								{
+									"parameter-and-unit": "cross-talk-total-power-dB",
+									"up-to-boundary": "15.00",
+									"penalty-value": "0.300"
+								},
+								{
+									"parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+									"up-to-boundary": "4.10",
+									"penalty-value": "0.500"
+								}
+							]
+						},
+						{
+							"openroadm-operational-mode-id": "OR-W-800G-oFEC-124Gbd",
+							"baud-rate": "124.1",
+							"line-rate": "845.1",
+							"modulation-format": "dp-qam16",
+							"min-TX-osnr": "37.000",
+							"TX-OOB-osnr": [{
+								"WR-openroadm-operational-mode-id": "MW-WR-core",
+								"min-OOB-osnr-multi-channel-value": "36.000",
+								"min-OOB-osnr-single-channel-value": "43.000"
+						    }],
+							"output-power-range": [{
+								"WR-openroadm-operational-mode-id": "MW-WR-core",
+								"min-output-power": "-5.000",
+								"max-output-power": "0.000"
+							}],
+							"min-RX-osnr-tolerance": "27.200",
+							"min-input-power-at-RX-osnr": "-11.000",
+							"max-input-power": "1.000",
+							"channel-width": "148.92000",
+							"fec-type": "org-openroadm-common-types:ofec",
+							"min-roll-off": "0.05",
+							"max-roll-off": "0.20",
+							"penalties": [
+								{
+									"parameter-and-unit": "CD-ps/nm",
+									"up-to-boundary": "4000",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "CD-ps/nm",
+									"up-to-boundary": "12000",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "1.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "2.00",
+									"penalty-value": "1.000"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "4.00",
+									"penalty-value": "2.500"
+								},
+								{
+									"parameter-and-unit": "PMD-ps",
+									"up-to-boundary": "10.00",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "PMD-ps",
+									"up-to-boundary": "20.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "power-dBm",
+									"up-to-boundary": "-11.00",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "power-dBm",
+									"up-to-boundary": "-14.00",
+									"penalty-value": "1.000"
+								},
+								{
+									"parameter-and-unit": "cross-talk-total-power-dB",
+									"up-to-boundary": "13.00",
+									"penalty-value": "0.300"
+								},
+								{
+									"parameter-and-unit": "cross-talk-total-power-dB",
+									"up-to-boundary": "15.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+									"up-to-boundary": "4.10",
+									"penalty-value": "0.500"
+								}
+							]
+						},
+						{
+							"openroadm-operational-mode-id": "OR-W-800G-oFEC-118Gbd",
+							"baud-rate": "118.2",
+							"line-rate": "845.1",
+							"modulation-format": "dp-qam16",
+							"min-TX-osnr": "37.000",
+							"TX-OOB-osnr": [{
+								"WR-openroadm-operational-mode-id": "MW-WR-core",
+								"min-OOB-osnr-multi-channel-value": "36.000",
+								"min-OOB-osnr-single-channel-value": "43.000"
+						    }],
+							"output-power-range": [{
+								"WR-openroadm-operational-mode-id": "MW-WR-core",
+								"min-output-power": "-5.000",
+								"max-output-power": "0.000"
+							}],
+							"min-RX-osnr-tolerance": "27.000",
+							"min-input-power-at-RX-osnr": "-11.000",
+							"max-input-power": "1.000",
+							"channel-width": "141.84000",
+							"fec-type": "org-openroadm-common-types:ofec",
+							"min-roll-off": "0.05",
+							"max-roll-off": "0.20",
+							"penalties": [
+								{
+									"parameter-and-unit": "CD-ps/nm",
+									"up-to-boundary": "4000",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "CD-ps/nm",
+									"up-to-boundary": "12000",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "1.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "2.00",
+									"penalty-value": "1.000"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "4.00",
+									"penalty-value": "2.500"
+								},
+								{
+									"parameter-and-unit": "PMD-ps",
+									"up-to-boundary": "10.00",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "PMD-ps",
+									"up-to-boundary": "20.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "power-dBm",
+									"up-to-boundary": "-11.00",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "power-dBm",
+									"up-to-boundary": "-14.00",
+									"penalty-value": "1.000"
+								},
+								{
+									"parameter-and-unit": "cross-talk-total-power-dB",
+									"up-to-boundary": "13.00",
+									"penalty-value": "0.300"
+								},
+								{
+									"parameter-and-unit": "cross-talk-total-power-dB",
+									"up-to-boundary": "15.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+									"up-to-boundary": "4.10",
+									"penalty-value": "0.500"
+								}
+							]
+						},
+						{
+							"openroadm-operational-mode-id": "OR-W-800G-oFEC-124Gbd_type2",
+							"baud-rate": "124.1",
+							"line-rate": "845.1",
+							"modulation-format": "dp-qam16",
+							"min-TX-osnr": "37.000",
+							"TX-OOB-osnr": [{
+								"WR-openroadm-operational-mode-id": "MW-WR-core",
+								"min-OOB-osnr-multi-channel-value": "36.000",
+								"min-OOB-osnr-single-channel-value": "43.000"
+						    }],
+							"output-power-range": [{
+								"WR-openroadm-operational-mode-id": "MW-WR-core",
+								"min-output-power": "-5.000",
+								"max-output-power": "0.000"
+							}],
+							"min-RX-osnr-tolerance": "27.200",
+							"min-input-power-at-RX-osnr": "-11.000",
+							"max-input-power": "1.000",
+							"channel-width": "148.92000",
+							"fec-type": "org-openroadm-common-types:ofec",
+							"min-roll-off": "0.05",
+							"max-roll-off": "0.20",
+							"penalties": [
+								{
+									"parameter-and-unit": "CD-ps/nm",
+									"up-to-boundary": "4000",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "CD-ps/nm",
+									"up-to-boundary": "12000",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "1.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "2.00",
+									"penalty-value": "1.000"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "4.00",
+									"penalty-value": "2.500"
+								},
+								{
+									"parameter-and-unit": "PMD-ps",
+									"up-to-boundary": "10.00",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "PMD-ps",
+									"up-to-boundary": "20.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "power-dBm",
+									"up-to-boundary": "-11.00",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "power-dBm",
+									"up-to-boundary": "-14.00",
+									"penalty-value": "1.000"
+								},
+								{
+									"parameter-and-unit": "cross-talk-total-power-dB",
+									"up-to-boundary": "13.00",
+									"penalty-value": "0.300"
+								},
+								{
+									"parameter-and-unit": "cross-talk-total-power-dB",
+									"up-to-boundary": "15.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+									"up-to-boundary": "4.10",
+									"penalty-value": "0.500"
+								}
+							]
+						},
+						{
+							"openroadm-operational-mode-id": "OR-W-800G-oFEC-118Gbd_type2",
+							"baud-rate": "118.2",
+							"line-rate": "845.1",
+							"modulation-format": "dp-qam16",
+							"min-TX-osnr": "37.000",
+							"TX-OOB-osnr": [{
+								"WR-openroadm-operational-mode-id": "MW-WR-core",
+								"min-OOB-osnr-multi-channel-value": "36.000",
+								"min-OOB-osnr-single-channel-value": "43.000"
+						    }],
+							"output-power-range": [{
+								"WR-openroadm-operational-mode-id": "MW-WR-core",
+								"min-output-power": "-5.000",
+								"max-output-power": "0.000"
+							}],
+							"min-RX-osnr-tolerance": "27.000",
+							"min-input-power-at-RX-osnr": "-11.000",
+							"max-input-power": "1.000",
+							"channel-width": "141.84000",
+							"fec-type": "org-openroadm-common-types:ofec",
+							"min-roll-off": "0.05",
+							"max-roll-off": "0.20",
+							"penalties": [
+								{
+									"parameter-and-unit": "CD-ps/nm",
+									"up-to-boundary": "4000",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "CD-ps/nm",
+									"up-to-boundary": "12000",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "1.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "2.00",
+									"penalty-value": "1.000"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "4.00",
+									"penalty-value": "2.500"
+								},
+								{
+									"parameter-and-unit": "PMD-ps",
+									"up-to-boundary": "10.00",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "PMD-ps",
+									"up-to-boundary": "20.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "power-dBm",
+									"up-to-boundary": "-11.00",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "power-dBm",
+									"up-to-boundary": "-14.00",
+									"penalty-value": "1.000"
+								},
+								{
+									"parameter-and-unit": "cross-talk-total-power-dB",
+									"up-to-boundary": "13.00",
+									"penalty-value": "0.300"
+								},
+								{
+									"parameter-and-unit": "cross-talk-total-power-dB",
+									"up-to-boundary": "15.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+									"up-to-boundary": "4.10",
+									"penalty-value": "0.500"
+								}
+							]
+						},
+						{
+							"openroadm-operational-mode-id": "OR-W-600G-oFEC-124Gbd",
+							"baud-rate": "124.7",
+							"line-rate": "633.9",
+							"modulation-format": "pcs-dp-qam16",
+							"min-TX-osnr": "37.000",
+							"TX-OOB-osnr": [{
+								"WR-openroadm-operational-mode-id": "MW-WR-core",
+								"min-OOB-osnr-multi-channel-value": "36.000",
+								"min-OOB-osnr-single-channel-value": "43.000"
+						    }],
+							"output-power-range": [{
+								"WR-openroadm-operational-mode-id": "MW-WR-core",
+								"min-output-power": "-5.000",
+								"max-output-power": "0.000"
+							}],
+							"min-RX-osnr-tolerance": "99.999",
+							"min-input-power-at-RX-osnr": "-11.000",
+							"max-input-power": "1.000",
+							"channel-width": "149.64000",
+							"fec-type": "org-openroadm-common-types:ofec",
+							"min-roll-off": "0.05",
+							"max-roll-off": "0.20",
+							"penalties": [
+								{
+									"parameter-and-unit": "CD-ps/nm",
+									"up-to-boundary": "4000",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "CD-ps/nm",
+									"up-to-boundary": "22000",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "1.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "2.00",
+									"penalty-value": "1.000"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "4.00",
+									"penalty-value": "2.500"
+								},
+								{
+									"parameter-and-unit": "PMD-ps",
+									"up-to-boundary": "10.00",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "PMD-ps",
+									"up-to-boundary": "25.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "power-dBm",
+									"up-to-boundary": "-11.00",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "power-dBm",
+									"up-to-boundary": "-18.00",
+									"penalty-value": "1.000"
+								},
+								{
+									"parameter-and-unit": "cross-talk-total-power-dB",
+									"up-to-boundary": "15.00",
+									"penalty-value": "0.300"
+								},
+								{
+									"parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+									"up-to-boundary": "4.10",
+									"penalty-value": "0.500"
+								}
+							]
+						},
+						{
+							"openroadm-operational-mode-id": "OR-W-600G-oFEC-118Gbd",
+							"baud-rate": "118.8",
+							"line-rate": "633.9",
+							"modulation-format": "pcs-dp-qam16",
+							"min-TX-osnr": "37.000",
+							"TX-OOB-osnr": [{
+								"WR-openroadm-operational-mode-id": "MW-WR-core",
+								"min-OOB-osnr-multi-channel-value": "36.000",
+								"min-OOB-osnr-single-channel-value": "43.000"
+							}],
+							"output-power-range": [{
+								"WR-openroadm-operational-mode-id": "MW-WR-core",
+								"min-output-power": "-5.000",
+								"max-output-power": "0.000"
+							}],
+							"min-RX-osnr-tolerance": "99.999",
+							"min-input-power-at-RX-osnr": "-11.000",
+							"max-input-power": "1.000",
+							"channel-width": "142.56000",
+							"fec-type": "org-openroadm-common-types:ofec",
+							"min-roll-off": "0.05",
+							"max-roll-off": "0.20",
+							"penalties": [
+								{
+									"parameter-and-unit": "CD-ps/nm",
+									"up-to-boundary": "4000",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "CD-ps/nm",
+									"up-to-boundary": "22000",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "1.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "2.00",
+									"penalty-value": "1.000"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "4.00",
+									"penalty-value": "2.500"
+								},
+								{
+									"parameter-and-unit": "PMD-ps",
+									"up-to-boundary": "10.00",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "PMD-ps",
+									"up-to-boundary": "25.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "power-dBm",
+									"up-to-boundary": "-11.00",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "power-dBm",
+									"up-to-boundary": "-18.00",
+									"penalty-value": "1.000"
+								},
+								{
+									"parameter-and-unit": "cross-talk-total-power-dB",
+									"up-to-boundary": "15.00",
+									"penalty-value": "0.300"
+								},
+								{
+									"parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+									"up-to-boundary": "4.10",
+									"penalty-value": "0.500"
+								}
+							]
+						},
+						{
+							"openroadm-operational-mode-id": "OR-W-800G-oFEC-131GbdE",
+							"baud-rate": "131.3",
+							"line-rate": "845.1",
+							"modulation-format": "pcs-dp-qam16",
+							"min-TX-osnr": "37.000",
+							"TX-OOB-osnr": [{
+								"WR-openroadm-operational-mode-id": "MW-WR-core",
+								"min-OOB-osnr-multi-channel-value": "36.000",
+								"min-OOB-osnr-single-channel-value": "43.000"
+						    }],
+							"output-power-range": [{
+								"WR-openroadm-operational-mode-id": "MW-WR-core",
+								"min-output-power": "-5.000",
+								"max-output-power": "0.000"
+							}],
+							"min-RX-osnr-tolerance": "25.000",
+							"min-input-power-at-RX-osnr": "-11.000",
+							"max-input-power": "1.000",
+							"channel-width": "157.60800",
+							"fec-type": "org-openroadm-common-types:ofec",
+							"min-roll-off": "0.05",
+							"max-roll-off": "0.20",
+							"penalties": [
+								{
+									"parameter-and-unit": "CD-ps/nm",
+									"up-to-boundary": "4000",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "CD-ps/nm",
+									"up-to-boundary": "20000",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "1.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "2.00",
+									"penalty-value": "1.000"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "4.00",
+									"penalty-value": "2.500"
+								},
+								{
+									"parameter-and-unit": "PMD-ps",
+									"up-to-boundary": "10.00",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "PMD-ps",
+									"up-to-boundary": "20.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "power-dBm",
+									"up-to-boundary": "-11.00",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "power-dBm",
+									"up-to-boundary": "-14.00",
+									"penalty-value": "1.000"
+								},
+								{
+									"parameter-and-unit": "cross-talk-total-power-dB",
+									"up-to-boundary": "13.00",
+									"penalty-value": "0.300"
+								},
+								{
+									"parameter-and-unit": "cross-talk-total-power-dB",
+									"up-to-boundary": "15.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+									"up-to-boundary": "4.10",
+									"penalty-value": "0.500"
+								}
+							]
+						},
+						{
+							"openroadm-operational-mode-id": "OR-W-800G-oFEC-131GbdM",
+							"baud-rate": "131.4",
+							"line-rate": "845.1",
+							"modulation-format": "pcs-dp-qam16",
+							"min-TX-osnr": "37.000",
+							"TX-OOB-osnr": [{
+								"WR-openroadm-operational-mode-id": "MW-WR-core",
+								"min-OOB-osnr-multi-channel-value": "36.000",
+								"min-OOB-osnr-single-channel-value": "43.000"
+					        }],
+							"output-power-range": [{
+								"WR-openroadm-operational-mode-id": "MW-WR-core",
+								"min-output-power": "-5.000",
+								"max-output-power": "0.000"
+							}],
+							"min-RX-osnr-tolerance": "26.000",
+							"min-input-power-at-RX-osnr": "-11.000",
+							"max-input-power": "1.000",
+							"channel-width": "157.62000",
+							"fec-type": "org-openroadm-common-types:ofec",
+							"min-roll-off": "0.05",
+							"max-roll-off": "0.20",
+							"penalties": [
+								{
+									"parameter-and-unit": "CD-ps/nm",
+									"up-to-boundary": "4000",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "CD-ps/nm",
+									"up-to-boundary": "20000",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "1.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "2.00",
+									"penalty-value": "1.000"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "4.00",
+									"penalty-value": "2.500"
+								},
+								{
+									"parameter-and-unit": "PMD-ps",
+									"up-to-boundary": "10.00",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "PMD-ps",
+									"up-to-boundary": "20.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "power-dBm",
+									"up-to-boundary": "-11.00",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "power-dBm",
+									"up-to-boundary": "-14.00",
+									"penalty-value": "1.000"
+								},
+								{
+									"parameter-and-unit": "cross-talk-total-power-dB",
+									"up-to-boundary": "13.00",
+									"penalty-value": "0.300"
+								},
+								{
+									"parameter-and-unit": "cross-talk-total-power-dB",
+									"up-to-boundary": "15.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+									"up-to-boundary": "4.10",
+									"penalty-value": "0.500"
+								}
+							]
+						},
+						{
+							"openroadm-operational-mode-id": "OR-W-600G-oFEC-124Gbd_type2",
+							"baud-rate": "124.7",
+							"line-rate": "633.9",
+							"modulation-format": "pcs-dp-qam16",
+							"min-TX-osnr": "37.000",
+							"TX-OOB-osnr": [{
+								"WR-openroadm-operational-mode-id": "MW-WR-core",
+								"min-OOB-osnr-multi-channel-value": "36.000",
+								"min-OOB-osnr-single-channel-value": "43.000"
+						    }],
+							"output-power-range": [{
+								"WR-openroadm-operational-mode-id": "MW-WR-core",
+								"min-output-power": "-5.000",
+								"max-output-power": "0.000"
+							}],
+							"min-RX-osnr-tolerance": "99.999",
+							"min-input-power-at-RX-osnr": "-11.000",
+							"max-input-power": "1.000",
+							"channel-width": "149.64000",
+							"fec-type": "org-openroadm-common-types:ofec",
+							"min-roll-off": "0.05",
+							"max-roll-off": "0.20",
+							"penalties": [
+								{
+									"parameter-and-unit": "CD-ps/nm",
+									"up-to-boundary": "4000",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "CD-ps/nm",
+									"up-to-boundary": "22000",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "1.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "2.00",
+									"penalty-value": "1.000"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "4.00",
+									"penalty-value": "2.500"
+								},
+								{
+									"parameter-and-unit": "PMD-ps",
+									"up-to-boundary": "10.00",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "PMD-ps",
+									"up-to-boundary": "25.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "power-dBm",
+									"up-to-boundary": "-11.00",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "power-dBm",
+									"up-to-boundary": "-18.00",
+									"penalty-value": "1.000"
+								},
+								{
+									"parameter-and-unit": "cross-talk-total-power-dB",
+									"up-to-boundary": "15.00",
+									"penalty-value": "0.300"
+								},
+								{
+									"parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+									"up-to-boundary": "4.10",
+									"penalty-value": "0.500"
+								}
+							]
+						},
+						{
+							"openroadm-operational-mode-id": "OR-W-600G-oFEC-118Gbd_type2",
+							"baud-rate": "118.8",
+							"line-rate": "633.9",
+							"modulation-format": "pcs-dp-qam16",
+							"min-TX-osnr": "37.000",
+							"TX-OOB-osnr": [{
+								"WR-openroadm-operational-mode-id": "MW-WR-core",
+								"min-OOB-osnr-multi-channel-value": "36.000",
+								"min-OOB-osnr-single-channel-value": "43.000"
+						    }],
+							"output-power-range": [{
+								"WR-openroadm-operational-mode-id": "MW-WR-core",
+								"min-output-power": "-5.000",
+								"max-output-power": "0.000"
+							}],
+							"min-RX-osnr-tolerance": "99.999",
+							"min-input-power-at-RX-osnr": "-11.000",
+							"max-input-power": "1.000",
+							"channel-width": "142.56000",
+							"fec-type": "org-openroadm-common-types:ofec",
+							"min-roll-off": "0.05",
+							"max-roll-off": "0.20",
+							"penalties": [
+								{
+									"parameter-and-unit": "CD-ps/nm",
+									"up-to-boundary": "4000",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "CD-ps/nm",
+									"up-to-boundary": "22000",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "1.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "2.00",
+									"penalty-value": "1.000"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "4.00",
+									"penalty-value": "2.500"
+								},
+								{
+									"parameter-and-unit": "PMD-ps",
+									"up-to-boundary": "10.00",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "PMD-ps",
+									"up-to-boundary": "25.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "power-dBm",
+									"up-to-boundary": "-11.00",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "power-dBm",
+									"up-to-boundary": "-18.00",
+									"penalty-value": "1.000"
+								},
+								{
+									"parameter-and-unit": "cross-talk-total-power-dB",
+									"up-to-boundary": "15.00",
+									"penalty-value": "0.300"
+								},
+								{
+									"parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+									"up-to-boundary": "4.10",
+									"penalty-value": "0.500"
+								}
+							]
+						},
+						{
+							"openroadm-operational-mode-id": "OR-W-800G-oFEC-131GbdE_type2",
+							"baud-rate": "131.3",
+							"line-rate": "845.1",
+							"modulation-format": "pcs-dp-qam16",
+							"min-TX-osnr": "37.000",
+							"TX-OOB-osnr": [{
+								"WR-openroadm-operational-mode-id": "MW-WR-core",
+								"min-OOB-osnr-multi-channel-value": "36.000",
+								"min-OOB-osnr-single-channel-value": "43.000"
+						    }],
+							"output-power-range": [{
+								"WR-openroadm-operational-mode-id": "MW-WR-core",
+								"min-output-power": "-5.000",
+								"max-output-power": "0.000"
+							}],
+							"min-RX-osnr-tolerance": "25.000",
+							"min-input-power-at-RX-osnr": "-11.000",
+							"max-input-power": "1.000",
+							"channel-width": "157.60800",
+							"fec-type": "org-openroadm-common-types:ofec",
+							"min-roll-off": "0.05",
+							"max-roll-off": "0.20",
+							"penalties": [
+								{
+									"parameter-and-unit": "CD-ps/nm",
+									"up-to-boundary": "4000",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "CD-ps/nm",
+									"up-to-boundary": "20000",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "1.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "2.00",
+									"penalty-value": "1.000"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "4.00",
+									"penalty-value": "2.500"
+								},
+								{
+									"parameter-and-unit": "PMD-ps",
+									"up-to-boundary": "10.00",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "PMD-ps",
+									"up-to-boundary": "20.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "power-dBm",
+									"up-to-boundary": "-11.00",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "power-dBm",
+									"up-to-boundary": "-14.00",
+									"penalty-value": "1.000"
+								},
+								{
+									"parameter-and-unit": "cross-talk-total-power-dB",
+									"up-to-boundary": "13.00",
+									"penalty-value": "0.300"
+								},
+								{
+									"parameter-and-unit": "cross-talk-total-power-dB",
+									"up-to-boundary": "15.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+									"up-to-boundary": "4.10",
+									"penalty-value": "0.500"
+								}
+							]
+						},
+						{
+							"openroadm-operational-mode-id": "OR-W-800G-oFEC-131GbdM_type2",
+							"baud-rate": "131.4",
+							"line-rate": "845.1",
+							"modulation-format": "pcs-dp-qam16",
+							"min-TX-osnr": "37.000",
+							"TX-OOB-osnr": [{
+								"WR-openroadm-operational-mode-id": "MW-WR-core",
+								"min-OOB-osnr-multi-channel-value": "36.000",
+							    "min-OOB-osnr-single-channel-value": "43.000"
+							}],
+							"output-power-range": [{
+								"WR-openroadm-operational-mode-id": "MW-WR-core",
+								"min-output-power": "-5.000",
+								"max-output-power": "0.000"
+							}],
+							"min-RX-osnr-tolerance": "26.000",
+							"min-input-power-at-RX-osnr": "-11.000",
+							"max-input-power": "1.000",
+							"channel-width": "157.62000",
+							"fec-type": "org-openroadm-common-types:ofec",
+							"min-roll-off": "0.05",
+							"max-roll-off": "0.20",
+							"penalties": [
+								{
+									"parameter-and-unit": "CD-ps/nm",
+									"up-to-boundary": "4000",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "CD-ps/nm",
+									"up-to-boundary": "20000",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "1.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "2.00",
+									"penalty-value": "1.000"
+								},
+								{
+									"parameter-and-unit": "PDL-dB",
+									"up-to-boundary": "4.00",
+									"penalty-value": "2.500"
+								},
+								{
+									"parameter-and-unit": "PMD-ps",
+									"up-to-boundary": "10.00",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "PMD-ps",
+									"up-to-boundary": "20.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "power-dBm",
+									"up-to-boundary": "-11.00",
+									"penalty-value": "0.000"
+								},
+								{
+									"parameter-and-unit": "power-dBm",
+									"up-to-boundary": "-14.00",
+									"penalty-value": "1.000"
+								},
+								{
+									"parameter-and-unit": "cross-talk-total-power-dB",
+									"up-to-boundary": "13.00",
+									"penalty-value": "0.300"
+								},
+								{
+									"parameter-and-unit": "cross-talk-total-power-dB",
+									"up-to-boundary": "15.00",
+									"penalty-value": "0.500"
+								},
+								{
+									"parameter-and-unit": "colorless-drop-adjacent-channel-crosstalk-GHz",
+									"up-to-boundary": "4.10",
+									"penalty-value": "0.500"
+								}
+							]
+						}
+                    ]
+                },
+                "roadms": {
+                    "Express": {
+                        "openroadm-operational-mode": {
+                            "openroadm-operational-mode-id": "MW-MW-core",
+                            "per-channel-Pin-min": "-21.000",
+                            "per-channel-Pin-max": "-9.000",
+                            "max-introduced-pdl": "1.500",
+                            "max-introduced-dgd": "3.00",
+                            "max-introduced-cd": "25.00",
+                            "osnr-polynomial-fit": {
+                                "A": "-0.00059520",
+                                "B": "-0.06250000",
+                                "C": "-1.07100000",
+                                "D": "27.99000000"
+                            },
+                            "mask-power-vs-pin": [
+                                {
+                                    "lower-boundary": "0",
+                                    "upper-boundary": "6",
+                                    "C": "1.00000000",
+                                    "D": "-9.00000000",
+                                    "fiber-type": "smf"
+                                },
+                                {
+                                    "lower-boundary": "6",
+                                    "upper-boundary": "8",
+                                    "C": "-0.00000000",
+                                    "D": "-3.00000000",
+                                    "fiber-type": "smf"
+                                },
+                                {
+                                    "lower-boundary": "8",
+                                    "upper-boundary": "23",
+                                    "C": "0.33333334",
+                                    "D": "-5.66666667",
+                                    "fiber-type": "smf"
+                                },
+                                {
+                                    "lower-boundary": "23",
+                                    "upper-boundary": "27",
+                                    "C": "0.00000000",
+                                    "D": "2.00000000",
+                                    "fiber-type": "smf"
+                                }
+                            ]
+                        }
+                    },
+                    "Add": {
+                        "add-openroadm-operational-mode": {
+                            "openroadm-operational-mode-id": "MW-WR-core",
+                            "incremental-osnr": "33.000",
+                            "per-channel-Pin-min": "-6.000",
+                            "per-channel-Pin-max": "3.000",
+                            "max-introduced-pdl": "1.500",
+                            "max-introduced-dgd": "3.00",
+                            "max-introduced-cd": "25.00",
+                            "mask-power-vs-pin": [
+                                {
+                                    "lower-boundary": "0",
+                                    "upper-boundary": "6",
+                                    "C": "1.00000000",
+                                    "D": "-9.00000000",
+                                    "fiber-type": "smf"
+                                },
+                                {
+                                    "lower-boundary": "6",
+                                    "upper-boundary": "8",
+                                    "C": "-0.00000000",
+                                    "D": "-3.00000000",
+                                    "fiber-type": "smf"
+                                },
+                                {
+                                    "lower-boundary": "8",
+                                    "upper-boundary": "23",
+                                    "C": "0.33333334",
+                                    "D": "-5.66666667",
+                                    "fiber-type": "smf"
+                                },
+                                {
+                                    "lower-boundary": "23",
+                                    "upper-boundary": "27",
+                                    "C": "0.00000000",
+                                    "D": "2.00000000",
+                                    "fiber-type": "smf"
+                                }
+                            ]
+                        }
+                    },
+                    "Drop": {
+                        "openroadm-operational-mode": {
+                            "openroadm-operational-mode-id": "MW-WR-core",
+                            "per-channel-Pin-min": "-25.000",
+                            "per-channel-Pin-max": "-9.000",
+                            "max-introduced-pdl": "1.500",
+                            "max-introduced-dgd": "3.00",
+                            "max-introduced-cd": "25.00",
+                            "osnr-polynomial-fit": {
+                                "A": "-0.00059520",
+                                "B": "-0.06250000",
+                                "C": "-1.07100000",
+                                "D": "27.99000000"
+                            },
+                            "per-channel-Pout-min": "-22.000",
+                            "per-channel-Pout-max": "1.000"
+                        }
+                    }
+                },
+                "amplifiers": {
+                    "Amplifier": {
+                        "openroadm-operational-mode": [
+                            {
+                                "openroadm-operational-mode-id": "MWi-standard",
+                                "per-channel-Pin-min": "-31.000",
+                                "per-channel-Pin-max": "-9.000",
+                                "max-introduced-pdl": "0.70",
+                                "max-introduced-dgd": "3.00",
+                                "max-introduced-cd": "0.00",
+                                "osnr-polynomial-fit": {
+                                    "A": "-0.00059520",
+                                    "B": "-0.06250000",
+                                    "C": "-1.07100000",
+                                    "D": "28.99000000"
+                                },
+								 "mask-power-vs-pin": [
+									{
+										"lower-boundary": "0",
+										"upper-boundary": "6",
+										"C": "1.00000000",
+										"D": "-9.00000000",
+										"fiber-type": "smf"
+									},
+									{
+										"lower-boundary": "6",
+										"upper-boundary": "8",
+										"C": "-0.00000000",
+										"D": "-3.00000000",
+										"fiber-type": "smf"
+									},
+									{
+										"lower-boundary": "8",
+										"upper-boundary": "23",
+										"C": "0.33333334",
+										"D": "-5.66666667",
+										"fiber-type": "smf"
+									},
+									{
+										"lower-boundary": "23",
+										"upper-boundary": "31",
+										"C": "0.00000000",
+										"D": "2.00000000",
+										"fiber-type": "smf"
+									}
+								],
+								"min-gain": "0.000",
+								"max-gain": "27.000",
+								"max-extended-gain": "31.000",
+								 "mask-gain-ripple-vs-tilt": [
+                                    {
+                                        "lower-boundary": "-4",
+                                        "upper-boundary": "-1",
+                                        "C": "-0.50",
+                                        "D": "1.00"
+                                    },
+                                    {
+                                        "lower-boundary": "-1",
+                                        "upper-boundary": "0",
+                                        "C": "0.50",
+                                        "D": "2.00"
+                                    }
+                                ]
+                            },
+                            {
+                                "openroadm-operational-mode-id": "MWi-low-noise",
+                                "per-channel-Pin-min": "-31.000",
+                                "per-channel-Pin-max": "-9.000",
+                                "max-introduced-pdl": "0.700",
+                                "max-introduced-dgd": "3.00",
+                                "max-introduced-cd": "0.00",
+                                "osnr-polynomial-fit": {
+                                    "A": "-0.00081040",
+                                    "B": "-0.06221000",
+                                    "C": "-0.58890000",
+                                    "D": "37.62000000"
+                                },
+								 "mask-power-vs-pin": [
+									{
+										"lower-boundary": "0",
+										"upper-boundary": "6",
+										"C": "1.00000000",
+										"D": "-9.00000000",
+										"fiber-type": "smf"
+									},
+									{
+										"lower-boundary": "6",
+										"upper-boundary": "8",
+										"C": "-0.00000000",
+										"D": "-3.00000000",
+										"fiber-type": "smf"
+									},
+									{
+										"lower-boundary": "8",
+										"upper-boundary": "23",
+										"C": "0.33333334",
+										"D": "-5.66666667",
+										"fiber-type": "smf"
+									},
+									{
+										"lower-boundary": "23",
+										"upper-boundary": "31",
+										"C": "0.00000000",
+										"D": "2.00000000",
+										"fiber-type": "smf"
+									}
+								],
+								"min-gain": "0.000",
+								"max-gain": "27.000",
+								"max-extended-gain": "31.000",
+								 "mask-gain-ripple-vs-tilt": [
+                                    {
+                                        "lower-boundary": "-4",
+                                        "upper-boundary": "-1",
+                                        "C": "-0.50",
+                                        "D": "1.00"
+                                    },
+                                    {
+                                        "lower-boundary": "-1",
+                                        "upper-boundary": "0",
+                                        "C": "0.50",
+                                        "D": "2.00"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+}


### PR DESCRIPTION
This is dot release for 13.1 OpenROADM models, with new branch 13.1.1

- Routing Instance Update 
- Fix issue of IPv6 model for origin and status
- B400 Support
- 400GE PHY code
- Add pointer to OAMP interface in info container
- Remove IANA-AFN-SAFI (deprecated)
- Add support for shelf and/or circuit-pack cp-slots
- Add lifecycle-states for device resources
- Add support for Flexo-regen
- Model Changes for Flexo-xe
- Correction to spec files